### PR TITLE
optional/partial copy using comment annotations

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -61,16 +61,42 @@ const svgCheck =
 
 const addCopyButtons = (clipboard) => {
   document.querySelectorAll("pre > code").forEach((codeBlock) => {
+    let content = codeBlock.innerText
+    let isComment = codeBlock.parentNode.previousSibling.previousSibling
+    if (isComment.nodeName == "#comment") {
+      switch (isComment.textContent.trim()) {
+        case "@nocpy": return
+        case "@selectiveCpy": {
+          let previousSlashEnding = false
+          content = content.split("\n").map(k => {
+            console.log(k)
+            k = k.trim()
+            let isCommand = k.startsWith("$")
+            if (isCommand || previousSlashEnding == true) {
+              if (!k.endsWith("\\")) {
+                console.log("here")
+                previousSlashEnding = false
+              } else {
+                previousSlashEnding = true
+              }
+              return isCommand ? k.substring(1).trim() : k
+            } else {
+              return undefined
+            }
+          }).filter(k => k != undefined).join("\n")
+        }
+      }
+    }
     let button = document.createElement("button");
     button.className = "copy-code-button";
     button.type = "button";
     button.ariaLabel = "Copy code"
     button.innerHTML = svgCopy;
     button.addEventListener("click", () => {
-      clipboard.writeText(codeBlock.innerText).then(
+      clipboard.writeText(content).then(
         () => {
-            button.classList.add("is-success")
-            button.innerHTML = svgCheck;
+          button.classList.add("is-success")
+          button.innerHTML = svgCheck;
           setTimeout(() => {
             button.innerHTML = svgCopy
             button.classList.remove("is-success")


### PR DESCRIPTION
Copy button on code blocks can now be turned off using a comment to annotate the code block as follow

```
<!-- @nocpy -->
```

Any code block prefixed by this comment will not have a copy code button.

For a code block that contains terminal commands interleaved with `stdout`, only the commands can be forced to be copied using the comment. Works for multiline commands (separated by `\`) as well  

```
<!-- @selectiveCpy -->
```

(eg)
```
<!-- @selectiveCpy -->
'''
$ spin build
Successfully built...
$ spin up 
Serving HTTP on address http://127.0.0.1:3000
Available Routes:
  hello: http://127.0.0.1:3000/hello
'''
```

When code is copied form this the following will be copied to the clipboard
```
spin build
spin up
```

Signed-off-by: karthik Ganeshram <karthik.ganeshram@fermyon.com>