### PR TITLE
fix:anchor tags to change URL

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -102,7 +102,7 @@ const addAnchorLinks = () => {
     heading.append(anchor);
     anchor.addEventListener("click", (e) => {
       e.preventDefault()
-
+      window.location = anchor.href
       document.querySelector(anchor.getAttribute('href')).scrollIntoView({
         behavior: 'smooth',
         block: 'start' //scroll to top of the target element


### PR DESCRIPTION
in reference to #118  for anchor links. Just updates the URL but does not copy the anchor link as this seems to be the general behavior (GitHub).

Signed-off-by: karthik Ganeshram <karthik.ganeshram@fermyon.com>

Noncontent Change