### PR TITLE
remove trailing slash to fix sub links

### DIFF
--- a/templates/content_navbar.hbs
+++ b/templates/content_navbar.hbs
@@ -42,9 +42,9 @@
     <div class="navbar-menu">
         <div class="navbar-start">
             
-            <a href="/spin/index/" class="{{#if (active_project request.spin-path-info "/spin/" )}} is-active {{/if}} navbar-item"><span>Spin</span></a>
+            <a href="/spin/index" class="{{#if (active_project request.spin-path-info "/spin/" )}} is-active {{/if}} navbar-item"><span>Spin</span></a>
 
-            <a href="/cloud/index/" class="{{#if (active_project request.spin-path-info "/cloud/" )}} is-active {{/if}} navbar-item"><span>Cloud</span></a>
+            <a href="/cloud/index" class="{{#if (active_project request.spin-path-info "/cloud/" )}} is-active {{/if}} navbar-item"><span>Cloud</span></a>
         </div>
 
         <div class="navbar-end">


### PR DESCRIPTION
fixes sublinks in content if we navigate to `spin` or `cloud` doc from the burger menu