### PR TITLE
standardize all the code blocks/ replace just outputs as text instead…

### DIFF
--- a/content/cloud/data-postgres.md
+++ b/content/cloud/data-postgres.md
@@ -17,13 +17,17 @@ First, you need to have Spin installed on your computer. Please use the official
 
 The Spin CLI facilitates the creation of new Spin applications through the use of application templates. You can install Spin application templates using the [official Spin CLI documentation](https://developer.fermyon.com/cloud/cli-reference/#templates). The template we are interested in, for this tutorial, is the experimental `http-csharp` template. We can go ahead and install it using the following command:
 
+<!-- @selectiveCpy -->
+
 ```bash
-spin templates install --git https://github.com/fermyon/spin-dotnet-sdk --branch main --update
+$ spin templates install --git https://github.com/fermyon/spin-dotnet-sdk --branch main --update
 ```
 
 The output from the command above will be similar to the following:
 
-```bash
+<!-- @nocpy -->
+
+```text
 Copying remote template source
 Installing template http-csharp...
 Installed 1 template(s)
@@ -96,27 +100,35 @@ public static class Handler {
 
 Wizer is required to successfully build this application. Please go ahead and install Wizer using the following command:
 
+<!-- @selectiveCpy -->
+
 ```bash
-cargo install wizer --all-features
+$ cargo install wizer --all-features
 ```
 
 ## Spin Build
 
 To build the application, use the following command:
 
+<!-- @selectiveCpy -->
+
 ```bash
-spin build
+$ spin build
 ```
 
 ## Spin Deploy
 
 To deploy the application, use the deploy command:
 
+<!-- @selectiveCpy -->
+
 ```bash
-spin deploy
+$ spin deploy
 ```
 
 The above deploy command will produce similar output to the following:
+
+<!-- @nocpy -->
 
 ```bash
 Deployed httpCSharpApplication version 1.0.0+XXXXXXXX

--- a/content/cloud/data-redis.md
+++ b/content/cloud/data-redis.md
@@ -27,7 +27,7 @@ The output from the command above will be similar to the following:
 
 <!-- @nocpy -->
 
-```console
+```text
 Copying remote template source
 // --snip--
 Installing template http-rust...
@@ -69,7 +69,7 @@ You can fill out these values, when prompted, for example:
 
 <!-- @nocpy -->
 
-```console
+```bash
 Project description: A new redis-rust Spin Application.
 Redis base: /
 Redis channel: /data
@@ -138,7 +138,7 @@ We need to log into Fermyon Cloud, so that we can build/deploy our application. 
 
 <!-- @selectiveCpy -->
 
-```console
+```bash
 $ spin login
 ```
 
@@ -147,7 +147,7 @@ $ spin login
 We build this application by typing the following command:
 <!-- @selectiveCpy -->
 
-```console
+```bash
 $ spin build
 ```
 
@@ -165,13 +165,13 @@ Successfully ran the build command for the Spin components.
 To deploy the application, use the deploy command:
 <!-- @selectiveCpy -->
 
-```console
+```bash
 $ spin deploy
 ```
 
 The above deploy command will produce similar output to the following:
 
-```bash
+```text
 Deployed redisRustApplication version 0.1.0+XXXXXXXX
 Application is running at redisRustApplication-XXXXXXXX.fermyon.app
 ```

--- a/content/cloud/faq.md
+++ b/content/cloud/faq.md
@@ -37,7 +37,9 @@ The following are known limitations of the Fermyon Cloud
 - **Why do I see mixed replies from my service during an upgrade?**
   - When doing an upgrade of an application, there is a gradual roll-out happening. This means that requests will hit both the existing and new modules, as the upgrade completes. You will see a pattern like the one below, showing the body reply from an HTTP request:
 
-```console
+<!-- @nocpy -->
+
+```text
 11:08:13 : Hello from Rust
 11:08:18 : Hello from Rust - updated
 11:08:19 : Hello from Rust

--- a/content/cloud/upgrade.md
+++ b/content/cloud/upgrade.md
@@ -30,8 +30,10 @@ version = "0.1.1"
 
 You can now deploy the upgraded version of your application by running this command:
 
-```console
-spin deploy
+<!-- @selectiveCpy -->
+
+```bash
+$ spin deploy
 ```
 
 That’s how to upgrade a Spin Application, just as simple as that!

--- a/content/spin/configuration.md
+++ b/content/spin/configuration.md
@@ -163,7 +163,7 @@ to environment variables by upper-casing and prepending with `SPIN_APP_`:
 
 <!-- @selectiveCpy -->
 
-```sh
+```bash
 $ export SPIN_APP_API_KEY = "1234"  # Sets the `api_key` value.
 $ spin up
 ```

--- a/content/spin/contributing.md
+++ b/content/spin/contributing.md
@@ -46,7 +46,7 @@ to make to Spin, make sure you can correctly build the project:
 
 <!-- @selectiveCpy -->
 
-```
+```bash
 # clone the repository
 $ git clone https://github.com/fermyon/spin && cd spin
 # add a new remote pointing to your fork of the project

--- a/content/spin/developing.md
+++ b/content/spin/developing.md
@@ -27,7 +27,7 @@ Then, running `spin build` will execute, sequentially, each build command:
 
 <!-- @selectiveCpy -->
 
-```
+```bash
 $ RUST_LOG=spin=trace spin build
 2022-04-25T03:01:56.721630Z  INFO spin_build: Executing the build command for component rust-hello.
     Finished release [optimized] target(s) in 0.05s

--- a/content/spin/http-trigger.md
+++ b/content/spin/http-trigger.md
@@ -209,7 +209,9 @@ printing its value to standard output
 - an empty line between the headers and the body
 - the response body printed to standard output
 
-```
+<!-- @nocpy -->
+
+```text
 print("content-type: text/html; charset=UTF-8\n\n");
 print("hello world\n");
 ```

--- a/content/spin/index.md
+++ b/content/spin/index.md
@@ -62,7 +62,7 @@ a web server:
 
 <!-- @selectiveCpy -->
 
-```console
+```bash
 $ spin up
 Serving HTTP on address http://127.0.0.1:3000
 Available Routes:

--- a/content/spin/install.md
+++ b/content/spin/install.md
@@ -14,14 +14,18 @@ There are multiple ways to install Spin. The easiest is to use the installer scr
 
 This command will install the latest version of Spin in you current directory.
 
-```console
-curl https://spin.fermyon.dev/downloads/install.sh | bash
+<!-- @selectiveCpy -->
+
+```bash
+$ curl https://spin.fermyon.dev/downloads/install.sh | bash
 ```
 
 It's highly recommended to add Spin to a folder, which is on your path, e.g.:
 
-```console
-sudo mv spin /usr/local/bin/
+<!-- @selectiveCpy -->
+
+```bash
+$ sudo mv spin /usr/local/bin/
 ```
 
 ## Linux: Additional Libraries
@@ -31,44 +35,54 @@ On a fresh Linux installation, you will also need the standard build toolchain
 
 On Debian-like distributions, including Ubuntu, you can install these with a command like this:
 
-```console
-sudo apt-get install build-essential libssl-dev pkg-config
+<!-- @selectiveCpy -->
+
+```bash
+$ sudo apt-get install build-essential libssl-dev pkg-config
 ```
 
 ## Installing a specific version of Spin
 
 To install a specific version, you can pass arguments to the install script this way:
 
-```console
-curl https://spin.fermyon.dev/downloads/install.sh | bash -s -- -v v0.6.0
+<!-- @selectiveCpy -->
+
+```bash
+$ curl https://spin.fermyon.dev/downloads/install.sh | bash -s -- -v v0.6.0
 ```
 
 To install canary version of spin, you should pass the argument `-v canary`. The canary version is always the latest commit to the main branch of Spin.
 
-```console
-curl https://spin.fermyon.dev/downloads/install.sh | bash -s -- -v canary
+<!-- @selectiveCpy -->
+
+```bash
+$ curl https://spin.fermyon.dev/downloads/install.sh | bash -s -- -v canary
 ```
 
 ## Building Spin from source
 
 [Follow the contribution document](./contributing.md) for a detailed guide on building Spin from source:
 
-```console
-git clone https://github.com/fermyon/spin
-cd spin && make build
-./target/release/spin --help
+<!-- @selectiveCpy -->
+
+```bash
+$ git clone https://github.com/fermyon/spin
+$ cd spin && make build
+$ ./target/release/spin --help
 ```
 
 ## Using Cargo to install Spin
 
 If you have [`cargo`](https://doc.rust-lang.org/cargo/getting-started/installation.html), you can clone the repo and install it to your path:
 
-```console
-git clone https://github.com/fermyon/spin -b v0.6.0
-cd spin
-rustup target add wasm32-wasi
-cargo install --locked --path .
-spin --help
+<!-- @selectiveCpy -->
+
+```bash
+$ git clone https://github.com/fermyon/spin -b v0.6.0
+$ cd spin
+$ rustup target add wasm32-wasi
+$ cargo install --locked --path .
+$ spin --help
 ```
 
 ## Next Steps

--- a/content/spin/quickstart.md
+++ b/content/spin/quickstart.md
@@ -16,7 +16,8 @@ keywords = "quickstart"
 You can install the `spin` binary using the `install.sh` script hosted on this site.
 
 <!-- @selectiveCpy -->
-```console
+
+```bash
 $ curl https://spin.fermyon.dev/downloads/install.sh | bash
 ```
 
@@ -24,7 +25,8 @@ At this point, move the `spin` binary somewhere in your path, so it can be
 accessed from any directory. For example:
 
 <!-- @selectiveCpy -->
-```console
+
+```bash
 $ sudo mv ./spin /usr/local/bin/spin
 ```
 
@@ -36,7 +38,7 @@ Spin helps you create a new application based on templates:
 
 <!-- @selectiveCpy -->
 
-```console
+```bash
 $ spin templates list
 You have no templates installed. Run
 spin templates install --git https://github.com/fermyon/spin
@@ -47,7 +49,7 @@ We first need to configure the [templates from the Spin repository](https://gith
 
 <!-- @selectiveCpy -->
 
-```console
+```bash
 $ spin templates install --git https://github.com/fermyon/spin
 Copying remote template source
 Installing template redis-rust...
@@ -71,6 +73,7 @@ Installing template http-go...
 Let's create a new Spin application based on the Rust HTTP template:
 
 <!-- @selectiveCpy -->
+
 ```bash
 $ spin new
 Pick a template to start your project with:
@@ -161,7 +164,7 @@ execute the command defined above in `spin.toml` and call the Rust toolchain:
 
 <!-- @selectiveCpy -->
 
-```console
+```bash
 $ spin build
 Executing the build command for component spin-hello-world: cargo build --target wasm32-wasi --release
    Compiling spin_hello_world v0.1.0
@@ -206,7 +209,7 @@ component can now be invoked by making requests to `http://localhost:3000/hello`
 
 <!-- @selectiveCpy -->
 
-```
+```bash
 $ curl -i localhost:3000/hello
 HTTP/1.1 200 OK
 foo: bar

--- a/content/spin/rust-components.md
+++ b/content/spin/rust-components.md
@@ -17,7 +17,9 @@ official resources for learning Rust](https://www.rust-lang.org/learn).
 In order to compile Rust programs to Spin components, you also need the
 `wasm32-wasi` target. You can add it using `rustup`:
 
-```console
+<!-- @selectiveCpy -->
+
+```bash
 $ rustup target add wasm32-wasi
 ```
 
@@ -313,7 +315,7 @@ When creating a new Spin projects with Cargo, you should use the `--lib` flag.
 
 <!-- @selectiveCpy -->
 
-```console
+```bash
 $ cargo init --lib
 ```
 


### PR DESCRIPTION
… of bash

Signed-off-by: karthik Ganeshram <karthik.ganeshram@fermyon.com>

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ x] The `title, `template`, and `date` are all set
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [x] Has passed `bart check`
- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors
