### PR TITLE
misc fix links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Prerequisites to run the website locally:
 
 - [npm and node](https://docs.npmjs.com/cli/v8/configuring-npm/install)
-- [Spin](https://spin.fermyon.dev/quickstart/)
+- [Spin](https://developer.fermyon.com/spin/quickstart)
 
 Build and run the website locally:
 

--- a/content/cloud/develop.md
+++ b/content/cloud/develop.md
@@ -18,7 +18,7 @@ This article briefly describes how to create a new Spin application. For a more 
 Before developing a Spin application, you need to have the Spin CLI installed locally. Here’s a way to install the Spin CLI:
 
 ```bash
-curl https://spin.fermyon.dev/downloads/install.sh | bash
+curl https://developer.fermyon.com/downloads/install.sh | bash
 ```
 
 {{ details "Additional info" "It's easier if you move the spin binary somewhere in your path, so it can be accessed from any directory. E.g., `sudo mv ./spin /usr/local/bin/spin`. \n\nYou can verify the version of Spin installed by running `spin --version`" }}

--- a/content/spin/extending-and-embedding.md
+++ b/content/spin/extending-and-embedding.md
@@ -25,7 +25,7 @@ timer, executing Spin components at configured time interval.
 
 The current application types that can be implemented with Spin have entry points
 defined using
-[WebAssembly Interface (WIT)](https://github.com/bytecodealliance/wit-bindgen/blob/main/WIT.md):
+[WebAssembly Interface (WIT)](https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md):
 
 ```fsharp
 // The entry point for an HTTP handler.

--- a/content/spin/install.md
+++ b/content/spin/install.md
@@ -17,7 +17,7 @@ This command will install the latest version of Spin in you current directory.
 <!-- @selectiveCpy -->
 
 ```bash
-$ curl https://spin.fermyon.dev/downloads/install.sh | bash
+$ curl https://developer.fermyon.com/downloads/install.sh | bash
 ```
 
 It's highly recommended to add Spin to a folder, which is on your path, e.g.:
@@ -48,7 +48,7 @@ To install a specific version, you can pass arguments to the install script this
 <!-- @selectiveCpy -->
 
 ```bash
-$ curl https://spin.fermyon.dev/downloads/install.sh | bash -s -- -v v0.6.0
+$ curl https://developer.fermyon.com/downloads/install.sh | bash -s -- -v v0.6.0
 ```
 
 To install canary version of spin, you should pass the argument `-v canary`. The canary version is always the latest commit to the main branch of Spin.
@@ -56,7 +56,7 @@ To install canary version of spin, you should pass the argument `-v canary`. The
 <!-- @selectiveCpy -->
 
 ```bash
-$ curl https://spin.fermyon.dev/downloads/install.sh | bash -s -- -v canary
+$ curl https://developer.fermyon.com/downloads/install.sh | bash -s -- -v canary
 ```
 
 ## Building Spin from source

--- a/content/spin/quickstart.md
+++ b/content/spin/quickstart.md
@@ -18,7 +18,7 @@ You can install the `spin` binary using the `install.sh` script hosted on this s
 <!-- @selectiveCpy -->
 
 ```bash
-$ curl https://spin.fermyon.dev/downloads/install.sh | bash
+$ curl https://developer.fermyon.com/downloads/install.sh | bash
 ```
 
 At this point, move the `spin` binary somewhere in your path, so it can be

--- a/content/spin/redis-trigger.md
+++ b/content/spin/redis-trigger.md
@@ -38,7 +38,7 @@ channel = "messages"
 The Redis trigger is built on top of the
 [WebAssembly component model](https://github.com/WebAssembly/component-model).
 The current interface is defined using the
-[WebAssembly Interface (WIT)](https://github.com/bytecodealliance/wit-bindgen/blob/main/WIT.md)
+[WebAssembly Interface (WIT)](https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md)
 format, and is a function that takes the message payload as its only parameter:
 
 ```fsharp

--- a/downloads/install.sh
+++ b/downloads/install.sh
@@ -99,7 +99,7 @@ case $OSTYPE in
     ;;
 *)
     fancy_print 1 "The OSTYPE: ${OSTYPE} is not supported by this script."
-    fancy_print 2 "Please refer to this article to install Spin: https://spin.fermyon.dev/quickstart/"
+    fancy_print 2 "Please refer to this article to install Spin: https://developer.fermyon.com/spin/quickstart"
     exit 1
     ;;
 esac
@@ -130,5 +130,5 @@ rm $FILE
 fancy_print 0 "Done...\n"
 
 # Direct to quicks-start doc
-fancy_print 0 "You're good to go. Check here for the next steps: https://spin.fermyon.dev/quickstart/"
+fancy_print 0 "You're good to go. Check here for the next steps: https://developer.fermyon.com/spin/quickstart"
 fancy_print 0 "Run './spin' to get started"


### PR DESCRIPTION
- point to developer docs instead of spin.fermyon.dev for download scripts and other places
- fix WIT link (it will still be broken due to a bug https://github.com/fermyon/bartholomew/issues/139) 

