### PR TITLE
remove misleading line when doing local spin dev

### DIFF
--- a/content/cloud/develop.md
+++ b/content/cloud/develop.md
@@ -168,8 +168,6 @@ fn hello_rust(req: Request) -> Result<Response> {
 
 This Spin application will now take the query string of the URL `http://localhost:3000?Doc` and return the text `Hello Doc!` as a greeting.
 
-Head over to the [Fermyon Cloud Web](https://cloud.fermyon.com) to see your applications logs.
-
 ## Next steps
 
 - Learn how to [deploy an application](deploy)


### PR DESCRIPTION
in https://canary.developer.fermyon.com/cloud/develop, we walk through user to develop a spin app locally, but then ask him to go to cloud.fermyon.com to check application logs, that sounds misleading.

refer to attached screenshot

<img width="856" alt="Screen Shot 2022-10-24 at 2 40 02 PM" src="https://user-images.githubusercontent.com/612092/197491712-b775718d-406d-46dd-a52b-38066b4da40a.png">

this PR removes that misleading text and link.