### PR TITLE
Fix `applicatin` typo in quickstart.md

### DIFF
--- a/content/spin/quickstart.md
+++ b/content/spin/quickstart.md
@@ -233,4 +233,4 @@ in multiple programming languages](https://github.com/fermyon/spin-kitchensink/)
 ## Next Steps
 
 - Learn about how to [develop a Spin application](developing)
-- Try deploying a Spin applicatin to the [Fermyon Cloud](/cloud/quickstart)
+- Try deploying a Spin application to the [Fermyon Cloud](/cloud/quickstart)


### PR DESCRIPTION
Fix a typo `applicatin` -> `application`

Signed-off-by: goproslowyo <68455785+goproslowyo@users.noreply.github.com>

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed `bart check`
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
