### PR TITLE
fix 2 typos in product name

### DIFF
--- a/content/spin/index.md
+++ b/content/spin/index.md
@@ -75,7 +75,7 @@ stanza to the `spin.toml` file.
 
 ## Deploying a Spin application
 
-Spin applications can be deployed to the fully managed [Fermyon Cloud](/cloud/index), or using the self-hosted [Fremoyn Platform](https://www.fermyon.dev)
+Spin applications can be deployed to the fully managed [Fermyon Cloud](/cloud/index), or using the self-hosted [Fermyon Platform](https://www.fermyon.dev)
 
 ## Next Steps
 


### PR DESCRIPTION
Fremoyn -> Fermyon

Signed-off-by: Aymeric Planche <aymeric.planche@gmail.com>

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed `bart check`
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
