### PR TITLE
Clean up the rustup add docs, enable copy/paste command

### DIFF
--- a/content/spin/quickstart.md
+++ b/content/spin/quickstart.md
@@ -152,7 +152,16 @@ fn spin_hello_world(req: Request) -> Result<Response> {
 > See the document on writing [Rust](./rust-components.md) and [Go](./go-components.md)
 > components for Spin, to ensure you have all dependencies installed.
 
-For Rust templates you need the `wasm32-wasi` target. You can add it using `rustup`:`rustup target add wasm32-wasi`.
+For Rust templates you need to install the `wasm32-wasi` target using `rustup`:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ rustup target add wasm32-wasi
+info: downloading component 'rust-std' for 'wasm32-wasi'
+info: installing component 'rust-std' for 'wasm32-wasi'
+ 19.8 MiB /  19.8 MiB (100 %)  11.5 MiB/s in  1s ETA:  0s
+```
 
 For TinyGo templates you need the [TinyGo toolchain installed](https://tinygo.org/getting-started/install/).
 


### PR DESCRIPTION
Just a small PR to clean up the docs. When I was reading through this wasn't as clean as I thought it could be -- also enabled copy/pasting of the rustup comamnd (I think, just following the examples I'm seeing in the markdown here).

Thanks!

Signed-off-by: goproslowyo <68455785+goproslowyo@users.noreply.github.com>

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title, `template`, and `date` are all set
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [x] Has passed [`bart check`](https://bartholomew.fermyon.dev/quickstart)
- [x] Has run `npm run build-index`
- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors
