### PR TITLE
Corrected the route to match example code

### DIFF
--- a/content/spin/rust-components.md
+++ b/content/spin/rust-components.md
@@ -106,12 +106,12 @@ id = "hello"
 source = "target/wasm32-wasi/release/spinhelloworld.wasm"
 allowed_http_hosts = [ "some-random-api.ml" ]
 [component.trigger]
-route = "/hello"
+route = "/wilcard"
 ```
 
 Running the application using `spin up --file spin.toml` will start the HTTP
 listener locally (by default on `localhost:3000`), and our component can
-now receive requests in route `/hello`:
+now receive requests in route `/wildcard`:
 
 <!-- @selectiveCpy -->
 

--- a/content/spin/rust-components.md
+++ b/content/spin/rust-components.md
@@ -111,7 +111,7 @@ route = "/outbound"
 
 Running the application using `spin up --file spin.toml` will start the HTTP
 listener locally (by default on `localhost:3000`), and our component can
-now receive requests in route `/wildcard`:
+now receive requests in route `/outbound`:
 
 <!-- @selectiveCpy -->
 

--- a/content/spin/rust-components.md
+++ b/content/spin/rust-components.md
@@ -106,7 +106,7 @@ id = "hello"
 source = "target/wasm32-wasi/release/spinhelloworld.wasm"
 allowed_http_hosts = [ "some-random-api.ml" ]
 [component.trigger]
-route = "/wilcard"
+route = "/outbound"
 ```
 
 Running the application using `spin up --file spin.toml` will start the HTTP

--- a/content/spin/rust-components.md
+++ b/content/spin/rust-components.md
@@ -116,7 +116,7 @@ now receive requests in route `/wildcard`:
 <!-- @selectiveCpy -->
 
 ```bash
-$ curl -i localhost:3000/hello
+$ curl -i localhost:3000/outbound
 HTTP/1.1 200 OK
 date: Fri, 18 Mar 2022 03:54:36 GMT
 content-type: application/json; charset=utf-8


### PR DESCRIPTION
The Rust Example code uses the /wildcard route instead of /hello. Updating the docs to match the code.

https://github.com/fermyon/spin/blob/013059cb7eda1189190fdec9fced86c9fc88867f/examples/http-rust-outbound-http/spin.toml#L22

Signed-off-by: Luke Berndt <lukekb@gmail.com>

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://bartholomew.fermyon.dev/quickstart)
- [ ] Has run `npm run build-index`
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
