### PR TITLE
Remove canary note from Vault config docs

### DIFF
--- a/content/spin/configuration.md
+++ b/content/spin/configuration.md
@@ -174,12 +174,9 @@ $ spin up
 
 #### Vault Config Provider
 
-Note: This will be included after spin v0.6.0.
-You can use [canary](https://github.com/fermyon/spin/releases/tag/canary) to try it.
-
-The vault config provider gets secret values from [HashiCorp Vault](https://www.vaultproject.io/).
+The Vault config provider gets secret values from [HashiCorp Vault](https://www.vaultproject.io/).
 Currently, only [KV Secrets Engine - Version 2](https://developer.hashicorp.com/vault/docs/secrets/kv/kv-v2) is supported.
-You can set up v2 kv secret engine at any mount point and give vault information in the [runtime configuration](#runtime-configuration):
+You can set up v2 kv secret engine at any mount point and give Vault information in the [runtime configuration](#runtime-configuration) file:
 
 ```toml
 [[config_provider]]
@@ -192,7 +189,7 @@ mount = "secret"
 ##### Vault Config Provider Example
 
 1. [Install Vault](https://developer.hashicorp.com/vault/tutorials/getting-started/getting-started-install).
-2. Start vault.
+2. Start Vault.
 
 ```bash
 $ vault server -dev -dev-root-token-id root


### PR DESCRIPTION
Since Spin 0.6.0 is now released.

(I also fixed some capitalisation.)

Signed-off-by: itowlson <ivan.towlson@fermyon.com>

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://bartholomew.fermyon.dev/quickstart)
- [ ] Has run `npm run build-index`
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
