### PR TITLE
Update Rust Redis examples with complete code

### DIFF
--- a/content/spin/rust-components.md
+++ b/content/spin/rust-components.md
@@ -153,10 +153,14 @@ new messages on the configured channels.
 Writing a Redis component in Rust also takes advantage of the SDK:
 
 ```rust
+use anyhow::Result;
+use bytes::Bytes;
+use spin_sdk::redis_component;
+
 /// A simple Spin Redis component.
 #[redis_component]
-fn on_message(msg: Bytes) -> Result<()> {
-    println!("{}", from_utf8(&msg)?);
+fn on_message(message: Bytes) -> Result<()> {
+    println!("{}", std::str::from_utf8(&message)?);
     Ok(())
 }
 ```
@@ -243,20 +247,47 @@ components.
 Let's see how we can use the Rust SDK to connect to Redis:
 
 ```rust
-#[spin_sdk::http_component]
+use anyhow::{anyhow, Result};
+use spin_sdk::{
+    http::{internal_server_error, Request, Response},
+    http_component, redis,
+};
+
+// The environment variable set in `spin.toml` that points to the
+// address of the Redis server that the component will publish
+// a message to.
+const REDIS_ADDRESS_ENV: &str = "REDIS_ADDRESS";
+
+// The environment variable set in `spin.toml` that specifies
+// the Redis channel that the component will publish to.
+const REDIS_CHANNEL_ENV: &str = "REDIS_CHANNEL";
+
+/// This HTTP component demonstrates fetching a value from Redis
+/// by key, setting a key with a value, and publishing a message
+/// to a Redis channel. The component is triggered by an HTTP
+/// request served on the route configured in the `spin.toml`.
+#[http_component]
+
 fn publish(_req: Request) -> Result<Response> {
     let address = std::env::var(REDIS_ADDRESS_ENV)?;
     let channel = std::env::var(REDIS_CHANNEL_ENV)?;
 
     // Get the message to publish from the Redis key "mykey"
-    let payload = spin_sdk::redis::get(&address, &"mykey").map_err(|_| anyhow!("Error querying Redis"))?;
+    let payload = redis::get(&address, "mykey").map_err(|_| anyhow!("Error querying Redis"))?;
 
     // Set the Redis key "spin-example" to value "Eureka!"
-    spin_sdk::redis::set(&address, &"spin-example", &b"Eureka!"[..])
-        .map_err(|_| anyhow!("Error executing Redis command"))?;
+    redis::set(&address, "spin-example", &b"Eureka!"[..])
+        .map_err(|_| anyhow!("Error executing Redis set command"))?;
+
+    // Set the Redis key "int-key" to value 0
+    redis::set(&address, "int-key", format!("{:x}", 0).as_bytes())
+        .map_err(|_| anyhow!("Error executing Redis set command"))?;
+    let int_value = redis::incr(&address, "int-key")
+        .map_err(|_| anyhow!("Error executing Redis incr command",))?;
+    assert_eq!(int_value, 1);
 
     // Publish to Redis
-    match spin_sdk::redis::publish(&address, &channel, &payload) {
+    match redis::publish(&address, &channel, &payload) {
         Ok(()) => Ok(http::Response::builder().status(200).body(None)?),
         Err(_e) => internal_server_error(),
     }


### PR DESCRIPTION
close #177 

This commit updates the Rust Redis examples from the Spin documentation to contain complete code samples, including imports.

Signed-off-by: Radu Matei <radu.matei@fermyon.com>
