### PR TITLE
Spin cli symlink

### DIFF
--- a/content/spin/cli-reference.md
+++ b/content/spin/cli-reference.md
@@ -1,0 +1,1 @@
+../cloud/cli-reference.md

--- a/templates/spin_sidebar.hbs
+++ b/templates/spin_sidebar.hbs
@@ -29,6 +29,13 @@
         </ul>
 
         <p class="menu-label">
+            References
+        </p>
+        <ul class="menu-list">
+            <li><a {{#if (active_content request.spin-path-info "/spin/cli-reference" )}} class="active" {{/if}} href="{{site.info.base_url}}/spin/cli-reference">CLI Reference</a></li>
+        </ul>
+
+        <p class="menu-label">
             Advanced
         </p>
         <ul class="menu-list">


### PR DESCRIPTION
Signed-off-by: tpmccallum [tim.mccallum@fermyon.com](mailto:tim.mccallum@fermyon.com)
Added symlink from cloud/cli-reference.md to spin/cli-reference.md
Added new menu item in Spin section
In reference to https://github.com/fermyon/developer/issues/279
