### PR TITLE
chore(docs): update routing docs

### DIFF
--- a/content/spin/http-trigger.md
+++ b/content/spin/http-trigger.md
@@ -64,8 +64,11 @@ which means the component will be invoked for every request starting with the
 `/base/bar/baz/qux/quux` and so on).
 
 If multiple components could potentially handle the same request based on their
-defined routes, the last component defined in `spin.toml` takes precedence.
-In the following example:
+defined routes, the component whose route has the longest matching prefix 
+takes precedence. 
+
+In the following example, any request starting with the  `/foo/` prefix (e.g. `/foo/bar`)
+will be handled by `component-1`:
 
 ```toml
 # spin.toml
@@ -75,16 +78,16 @@ trigger = { type = "http", base = "/"}
 [[component]]
 id = "component-1"
 [component.trigger]
-route = "/..."
+route = "/foo/..."
 
 [[component]]
 id = "component-2"
 [component.trigger]
-route = "/foo/..."
+route = "/..."
 ```
 
-Any request starting with the  `/foo/` prefix  will be handled by `component-2`,
-which is the last one defined in `spin.toml`.
+> Note: Although the route defined by `component-2` also matches `/foo/bar`, the route 
+> defined by `component-1` has the longer matching prefix, i.e. `/foo/`.
 
 Every HTTP application has a special route always configured at `/.well-known/spin/health`, which
 returns `OK 200` when the Spin instance is healthy.


### PR DESCRIPTION
Update `routing` docs for `http-trigger.md` given the implementation of [spin#1109](https://github.com/fermyon/spin/pull/1109)

Welcome any wordsmith suggestions!

Signed-off-by: Brian H <brian.hardock@fermyon.com>
