### PR TITLE
styling changes for TOC, codeblocks and setting theme

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1822,6 +1822,12 @@ html.dark-theme .search-modal-container .result-section-container .suggested-pro
   }
 }
 
+@media screen and (max-width: 1661px) {
+  .documentation .content section h1:first-of-type + ul {
+    display: none;
+  }
+}
+
 .documentation .content.content-docs section {
   max-width: 880px !important;
 }
@@ -1838,6 +1844,11 @@ html.dark-theme .search-modal-container .result-section-container .suggested-pro
 
 .documentation .content pre {
   max-width: 800px;
+  padding: 0 !important;
+}
+
+.documentation .content pre code {
+  padding: 1.25em 1.5em !important;
 }
 
 .documentation .content details {
@@ -1972,8 +1983,8 @@ html.dark-theme .search-modal-container .result-section-container .suggested-pro
 .documentation .multitab-content {
   max-width: 800px;
   background-color: #ece5ee;
-  border-radius: .25em;
-  padding: 1px 1.25rem .125rem;
+  border-radius: .33em;
+  padding: .67rem 1.25rem;
 }
 
 .documentation .multitab-content pre:last-of-type {
@@ -2018,6 +2029,10 @@ html.dark-theme .search-modal-container .result-section-container .suggested-pro
 
 .documentation .tabs.is-boxed a.is-active:hover {
   background-color: #ece5ee !important;
+}
+
+html.dark-theme:root {
+  color-scheme: dark;
 }
 
 html.dark-theme body aside.menu a.active {
@@ -2099,8 +2114,6 @@ html.dark-theme .dropdown-content a {
 
 html.dark-theme .multitab-content {
   background-color: #0d203f;
-  border-radius: .33em;
-  padding: .67rem 1.25rem;
 }
 
 .dropdown {
@@ -3075,8 +3088,8 @@ html.dark-theme .developer-home-wrap .external {
 }
 
 .cc-revoke.cc-top {
-  border-bottom-left-radius: .5em;
   border-bottom-right-radius: .5em;
+  border-bottom-left-radius: .5em;
   top: 0;
   left: 3em;
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -108,6 +108,11 @@ TABLE OF CONTENTS
 					border-radius: 0.333rem;
 				}
 			}
+			@media screen and (max-width: 1661px) {
+				h1:first-of-type + ul {
+					display: none;
+				}
+			}
 		}
 
 		&.content-docs {
@@ -130,6 +135,11 @@ TABLE OF CONTENTS
 
 		pre {
 			max-width: 800px;
+			padding: 0 !important;
+
+			code {
+				padding: 1.25em 1.5em !important;
+			}
 		}
 
 		details {
@@ -301,9 +311,9 @@ TABLE OF CONTENTS
 	}
 	.multitab-content {
 		max-width: 800px;
-		padding: 1px 1.25rem 0.125rem;
+		padding: 0.67rem 1.25rem;
 		background-color: $lightlavender;
-		border-radius: 0.25em;
+		border-radius: 0.33em;
 
 		pre:last-of-type {
 			margin-bottom: 1rem !important;
@@ -349,6 +359,9 @@ TABLE OF CONTENTS
 }
 
 html.dark-theme {
+	&:root {
+		color-scheme: dark;
+	}
 	body {
 		aside.menu {
 			a {
@@ -446,9 +459,7 @@ html.dark-theme {
 		}
 	}
 	.multitab-content {
-		padding: 0.67rem 1.25rem;
 		background-color: $oxfordblue;
-		border-radius: 0.33em;
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: karthik Ganeshram <karthik.ganeshram@fermyon.com>

closes #281 

The changes due to this PR are 

## Changes to code block:

From main:
![image](https://user-images.githubusercontent.com/25023490/217604270-c97368fa-c2f7-41ec-9731-9e4567aa50ae.png)

With this PR:
![image](https://user-images.githubusercontent.com/25023490/217604343-36716f43-beab-4fa3-9c6b-ca3ffc7876d6.png)

## Changes to TOC:

Hides the TOC on smaller screen sizes

## Setting `color-scheme` to dark in dark mode

This fixes the issues of where a white scrollbar is rendered in dark mode.

Main:
![image](https://user-images.githubusercontent.com/25023490/217604722-c16895c3-1e9c-430b-8c14-7c9aca7b5977.png)
Patch:
![image](https://user-images.githubusercontent.com/25023490/217604767-2c63275e-cf2d-4d16-91b6-c4509fdd7f2a.png)


