### PR TITLE
replace prior google analytics 4 with gtm method

### DIFF
--- a/config/site.toml
+++ b/config/site.toml
@@ -7,7 +7,6 @@ index_site_pages = ["sitemap"]
 copyright = "Fermyon"
 github = "https://github.com/fermyon/developer"
 twitter = "https://twitter.com/fermyontech"
-ga_measurement_id = "G-E1JG1JN662"
 
 # Static assets that we need to provide
 favicon = "/static/image/favicon.png"

--- a/templates/content_top.hbs
+++ b/templates/content_top.hbs
@@ -64,77 +64,13 @@
     <link href="https://fonts.googleapis.com/css2?family=Sen:wght@400;700&amp;display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="{{site.info.base_url}}/static/css/styles.css" />
 
-<link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.1.1/cookieconsent.min.css" />
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.1.1/cookieconsent.min.js" data-cfasync="false"></script>
-    <script>
-      const propertyID = "{{site.info.extra.ga_measurement_id}}";
-      var popup;
-      window.addEventListener('load', function(){
-        window.cookieconsent.initialise({
-          type: "opt-in",
-          theme: "classic",
-          palette: {
-            popup: {
-              background: "#525776",
-              text: "#fff"
-            },
-            button: {
-              background: "#1fbca0",
-              text: "#fff"
-            }
-          },
-          onInitialise: function(status) {
-            // request gtag.js on page-load when the client already consented
-            if(status == cookieconsent.status.allow) setCookies();
-          },
-          onStatusChange: function(status) {
-            // resquest gtag cookies on a new consent
-            if (this.hasConsented()) setCookies();
-            else deleteCookies(this.options.cookie.name)
-          },
-          /* enable this to hide the cookie banner outside GDPR regions
-              law: {
-                regionalLaw: false,
-              },
-              location: true,
-              },
-          */
-          function (p) {
-            popup = p;
-          }
-        });
-      });
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', propertyID);
-      function setCookies() {
-          var s = document.createElement('script');
-          s.type = "text/javascript"
-          s.async = "true";
-          s.src = `https://www.googletagmanager.com/gtag/js?id=${propertyID}`;
-          var x = document.getElementsByTagName('script')[0];
-          x.parentNode.insertBefore(s, x);
-      };
-      function deleteCookies(cookieconsent_name) {
-        var keep = [cookieconsent_name, "DYNSRV"];
-        document.cookie.split(';').forEach(function(c) {
-          c = c.split('=')[0].trim();
-          if (!~keep.indexOf(c))
-              document.cookie = c + '=;' + 'expires=Thu, 01 Jan 1970 00:00:00 UTC;path=/';
-        });
-      };
-    </script>
-    {{#if site.info.extra.ga_measurement_id }}
-    <script async src="https://www.googletagmanager.com/gtag/js?id={{site.info.extra.ga_measurement_id}}"></script>
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){window.dataLayer.push(arguments);}
-        gtag('js', new Date());
-        gtag('config', '{{site.info.extra.ga_measurement_id}}');
-        gtag('config', '{{site.info.extra.ga4_measurement_id}}');
-    </script>
-    {{/if}}
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-T28H3XL');</script>
+    <!-- End Google Tag Manager -->
 
     <script>
         const systemTheme = window.matchMedia("(prefers-color-scheme: dark)").matches
@@ -192,5 +128,8 @@
 
 </head>
 <body class="documentation">
-
-    {{> content_navbar }}
+   <!-- Google Tag Manager (noscript) -->
+   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T28H3XL" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+   <!-- End Google Tag Manager (noscript) -->
+   
+   {{> content_navbar }}


### PR DESCRIPTION
Review of our analytics config has led to recommendation that we  (i) use [GTM](https://tagmanager.google.com) across the board as the best method to study user patterns in our docs and between subdomains and (ii) we use the same script in each situation.

This PR replaces the prior GA4 embed with GTM. I've validated the new code with [the accompanying inspector tool ✅  ](https://dl3.pushbulletusercontent.com/AgetWW2a7CkOAMzl0Zt2De0HisB2jZ6S/dev-gtm.gif)

--

This doesn't impact the data - GTM will load GA4 (and cookie consent will be set via GTM as we did on fermyon.com)