### PR TITLE
Trying out preview deployment from fermyon org

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,25 @@
+name: deploy docs preview
+on:
+  pull_request:
+    branches: "main"
+    types: ['opened', 'synchronize', 'reopened', 'closed']
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'fermyon' }}
+    name: Build and deploy
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup `spin`
+        uses: fermyon/actions/spin/setup@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: build and deploy preview
+        uses: fermyon/actions/spin/preview@v1
+        with:
+          fermyon_token: ${{ secrets.FERMYON_CLOUD_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          undeploy: ${{ github.event.pull_request && github.event.action == 'closed' }}


### PR DESCRIPTION
this is the PR that will add preview support for developer docs. Few gotchas:

- It can deploy previews only if PR is from a branch in `fermyon` org only. This is because of security considerations.
- we can deploy a max of 5 preview only right now.
- The action can delete old previews when it is out of limits (disabled right now), we should probably enable it. Pls let me know
- The action deletes the preview when the PR is closed. (merged or not).
- It currently uses browser automation to do the cloud login
- It is currently using a Github account I have setup using one of my personal domain (I am working on configuring a Fermyon account for this. will update the secrets in repo once we are ready for that.)

