### PR TITLE
Updated `scss` instead of `css` so that rendering is sustainable.

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -138,7 +138,7 @@ TABLE OF CONTENTS
 			padding: 0 !important;
 
 			code {
-				padding: 1.25em 1.5em !important;
+				padding: 1.25em 3.5em !important;
 			}
 		}
 


### PR DESCRIPTION
Signed-off-by: tpmccallum tim.mccallum@fermyon.com

Refers to:
- https://github.com/fermyon/developer/pull/342/files (erroneous css update; which is now closed)
- https://github.com/fermyon/developer/issues/253 (original issue reported)
