### PR TITLE
Preliminary commit to kick off CLI Reference Docs and 0.9.0 installation guide

### DIFF
--- a/content/spin/install.md
+++ b/content/spin/install.md
@@ -121,6 +121,14 @@ $ cargo install --locked --path .
 $ spin --help
 </code></pre>
 
+> Please note: Spin v0.9.0 requires `wasmtime v5.0.0` which requires rustc 1.66.0 or newer. You can update Rust using the following command:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ rustup update
+```
+
 ## Next Steps
 
 - [Take Spin for a spin](./quickstart.md)


### PR DESCRIPTION
Signed-off-by: tpmccallum tim.mccallum@fermyon.com

Commencing the CLI Reference Docs and 0.9.0 installation nuances/usage.

Updating the Spin 0.9.0 CLI Reference and noticed one thing that got me thinking i.e. I noticed straight away that the login subcommand is not in the standard spin `--help`. There are evidently naturally expected changes; if there are any nuances that you would like explained in a certain way, please just leave a few notes in this PR's comments and I will return to working on this first thing next week.

For the most part this will just be a CLI Reference (listing all of the permutations of `--help` but any explanations that will assist users will be greatly appreciated (even in short note form below).



