### PR TITLE
Update PR checklist to prevent menu items linking to content before the doc's `date` of publication goes live.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,7 @@ Content must go through a pre-merge checklist.
 This documentation has been checked to ensure that:
 
 - [ ] The `title, `template`, and `date` are all set
+- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
 - [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
 - [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
 - [ ] Has run `npm run build-index`


### PR DESCRIPTION
Signed-off-by: tpmccallum tim.mccallum@fermyon.com