### PR TITLE
Hide log spew in `npm run spin`

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "yaml-front-matter": "^4.1.1"
   },
   "scripts": {
-    "spin": "nodemon --watch content --watch static --watch templates --ext md,rhai,hbs,css,js --verbose --legacy-watch --signal SIGINT --exec 'npm run build-index && spin up --file spin.toml --env PREVIEW_MODE=$PREVIEW_MODE'",
+    "spin": "nodemon --watch content --watch static --watch templates --ext md,rhai,hbs,css,js --verbose --legacy-watch --signal SIGINT --exec 'npm run build-index && spin up --file spin.toml --quiet --env PREVIEW_MODE=$PREVIEW_MODE'",
     "bundle-scripts": " parcel build static/js/src/main.js --dist-dir static/js --no-source-maps",
     "styles": "parcel watch static/sass/styles.scss --dist-dir static/css",
     "test": "npx markdownlint-cli2 content/**/*.md \"#node_modules\" && npm run check-broken-links",


### PR DESCRIPTION
In recent versions of Spin, guest output is printed to the console by default.  Unfortunately, something in either `nodemon` or Bartholomew is causing the index page to be re-requested every second or less, and this now prints a _lot_ of diagnostic data every single time.

This PR passes `--quiet` to `spin up` so the noise goes away, though it might be useful to know why the page is re-requested so often in the first place.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has run `npm run build-index`
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
