### PR TITLE
ci(*): add test-website.sh; use in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,3 +40,7 @@ jobs:
       - name: Run npm tests
         run: |
           npm test
+
+      - name: Test website
+        run: |
+          npm run test-website

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "bundle-scripts": " parcel build static/js/src/main.js --dist-dir static/js --no-source-maps",
     "styles": "parcel watch static/sass/styles.scss --dist-dir static/css",
     "test": "npx markdownlint-cli2 content/**/*.md \"#node_modules\" && npm run check-broken-links",
+    "test-website": "./tests/test-website.sh",
     "build-index": "node md_parser.mjs --dir=./content/ --out=./static/data.json",
     "check-broken-links": ".build/check-broken-links.sh"
   }

--- a/tests/test-website.sh
+++ b/tests/test-website.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+spin up &
+pid=$!
+
+timeout 10s bash -c 'until curl -q 127.0.0.1:3000 &>/dev/null; do sleep 1; done'
+
+resp_code=$(curl -o /dev/null -s -w "%{http_code}\n" 127.0.0.1:3000)
+[[ "${resp_code}" == "200" ]] && \
+  (echo "Success: server returned 200" && kill ${pid}) || \
+  (echo "Failure: unexpected response code: ${resp_code}" && kill ${pid} && exit 1)


### PR DESCRIPTION
I noticed we didn't appear to have a quick 'spin up' test for this website to verify it runs as expected (and, minimally, returns 200).  It can be handy to double-check this on PRs, so added one.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has run `npm run build-index`
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
