### PR TITLE
fix the blockquote light mode shading on docs

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1813,8 +1813,9 @@ html.dark-theme .search-modal-container .result-section-container .suggested-pro
 }
 
 .documentation .content section blockquote p {
-  background-color: #00000040;
+  background-color: #d3c3d940;
   border-radius: .5rem;
+  line-height: 1.725;
   margin: 1.67rem auto 2.67rem !important;
   font-size: 1rem !important;
 }
@@ -2155,6 +2156,10 @@ html.dark-theme body .content a.anchor-link:hover {
 
 html.dark-theme body .content a.anchor-link {
   fill: #fff;
+}
+
+html.dark-theme body .content blockquote p {
+  background-color: #00000040;
 }
 
 html.dark-theme .dropdown-content a {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -103,7 +103,8 @@ TABLE OF CONTENTS
 				font-size: 1rem !important;
 				margin: 1.67rem auto 2.67rem !important;
 				border-radius: 0.5rem;
-				background-color: rgba(0,0,0,0.25);
+				background-color: rgba(211, 195, 217, 0.25);
+				line-height: 1.725;
 			}
 
 			table {
@@ -508,6 +509,10 @@ html.dark-theme {
 
 			a.anchor-link {
 				fill: #fff;
+			}
+
+			blockquote p {
+				background-color: rgba(0,0,0,0.25);
 			}
 		}
 	}


### PR DESCRIPTION
Small bug fix following #428 - the blockquotes in light mode were too dark to be legible. This PR corrects the color scheme.

before/after preview of change:

![light-blockquote](https://user-images.githubusercontent.com/686194/224471107-775c94bc-a1c0-425f-ba50-e76e3c64f859.gif)
