### PR TITLE
make comments brighter

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1882,6 +1882,10 @@ html.dark-theme .search-modal-container .result-section-container .suggested-pro
   padding: 1.125em 1.25rem !important;
 }
 
+.documentation .content pre code .hljs-comment {
+  color: #bbb !important;
+}
+
 .documentation .content h1 code, .documentation .content h2 code, .documentation .content h3 code, .documentation .content h4 code, .documentation .content h5 code, .documentation .content h6 code {
   font-weight: 600;
   font-size: .825em !important;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -173,6 +173,10 @@ TABLE OF CONTENTS
 			code {
 				padding: 1.125em 1.25rem !important;
 				margin-right: 2.75rem;
+
+				.hljs-comment {
+					color: #bbb !important;
+				  }
 			}
 		}
 


### PR DESCRIPTION
Changes the color of the comments to `#bbb` to make it more visible. We could also bump the font-weight to bring more attention to it.

fixes #420 

![image](https://user-images.githubusercontent.com/25023490/225136374-52f2c2ea-d725-4ad2-937c-9cbc14a4d41e.png)
