### PR TITLE
up should be stabilizing until we figure out what path we want to go with bindle options

### DIFF
--- a/content/common/cli-reference.md
+++ b/content/common/cli-reference.md
@@ -1230,7 +1230,7 @@ CLI commands have four phases that indicate levels of stability:
 | `spin new`                                                 | Stable      |
 | `spin plugins <install\|list\|uninstall\|update\|upgrade>` | Stable      |
 | `spin templates <install\|list\|uninstall\|upgrade>`       | Stable      |
-| `spin up`                                                  | Stable      |
+| `spin up`                                                  | Stabilizing |
 | `spin cloud <deploy\|login>`                               | Stabilizing |
 | `spin registry`                                            | Stabilizing |
 | `spin bindle <prepare\|push>`                              | Deprecated  |


### PR DESCRIPTION
Merged the CLI stability table but realized we should have the status of `spin up` be `Stabilizing` until we reconcile @itowlson's question about the bindle options.