### PR TITLE
Document command to lint files (and not check all URLs after each local change)

### DIFF
--- a/content/common/contributing-docs.md
+++ b/content/common/contributing-docs.md
@@ -206,13 +206,26 @@ If you have not done so already, please go ahead and perform the `npm install` c
 $ npm install
 ```
 
-With all Node dependencies installed, you can now check for broken links and also lint your markdown files. Simply run the following command, from the root of the developer repository. Note, this does take several minutes to complete; as it literally checks all URLs in the entire site:
+With all Node dependencies installed, you can now check for broken links (which takes several minutes) and also lint your markdown files. Simply run the following command, from the root of the developer repository:
 
 <!-- @selectiveCpy -->
 
 ```bash
 $ npm run test
 ```
+
+**Hint:** To save time, by not checking for broken URLs during each **local** change, use the optional `npx` linting only approach:
+
+<!-- @nocpy -->
+
+```bash
+# Example of how to lint all Markdown files in a local folder (in this case the spin folder) 
+npx markdownlint-cli2 content/spin/*.md \"#node_modules\"
+# Example of how to lint a local Markdown file
+npx markdownlint-cli2 content/spin/install.md \"#node_modules\"
+```
+
+**Note:** Whilst the `npm run test` command (which lints and also programmatically checks all URLs) does take extra time to complete it **must** be utilized before you [push changes](/common/contributing-docs#10-push-changes); preventing the potential pushing of broken URLs to the developer documentation site.
 
 ### 6.2 Generating Indexing For Your Content
 

--- a/content/common/contributing-docs.md
+++ b/content/common/contributing-docs.md
@@ -214,7 +214,7 @@ With all Node dependencies installed, you can now check for broken links (which 
 $ npm run test
 ```
 
-**Hint:** To save time, by not checking for broken URLs during each **local** change, use the optional `npx` linting only approach:
+**Hint:** Optionally you can run only the linter with the following command:
 
 <!-- @nocpy -->
 


### PR DESCRIPTION
Signed-off-by: tpmccallum tim.mccallum@fermyon.com

A quick way to run lint tests over content during local writing and reviewing.

<img width="877" alt="Screenshot 2023-03-16 at 3 09 53 pm" src="https://user-images.githubusercontent.com/9831342/225520750-8a84314d-c4ff-4349-a3d2-53cd51ff7a23.png">
