### PR TITLE
Add Python tab to code blocks (in k/v docs) 

### DIFF
--- a/content/spin/kv-store.md
+++ b/content/spin/kv-store.md
@@ -96,7 +96,7 @@ $ spin plugin install py2wasm
 $ spin templates install --git https://github.com/fermyon/spin-python-sdk
 # Create the new http-py application
 $ spin new --accept-defaults http-py hello
-# Install toml
+# Install toml, using pipenv (Note: "pip3 install pipenv" will install pipenv if necessary).
 $ pipenv install toml
 
 # Reference: https://www.fermyon.com/blog/spin-python-sdk


### PR DESCRIPTION
This allows the language support overview page to link to documentation relating to Python key/value storage.

Relates to the work at https://github.com/fermyon/developer/pull/457/files#r1139721437
