### PR TITLE
ci(*): fix plugins/templates links

### DIFF
--- a/content/spin/managing-plugins.md
+++ b/content/spin/managing-plugins.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/fermyon/spin/blob/main/docs/content/plugin-managing.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/managing-plugins.md"
 
 ---
 - [Installing Plugins](#installing-plugins)

--- a/content/spin/managing-templates.md
+++ b/content/spin/managing-templates.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/fermyon/spin/blob/main/docs/content/template-managing.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/managing-templates.md"
 
 ---
 - [Installing Templates](#installing-templates)


### PR DESCRIPTION
Not sure where/how these links crept in, but this should fix recent CI failures eg https://github.com/fermyon/developer/actions/runs/4476335410/jobs/7866592934

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [x] Has run `npm run build-index`
- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors
