### PR TITLE
Add docs on component environment variables

### DIFF
--- a/content/spin/writing-apps.md
+++ b/content/spin/writing-apps.md
@@ -270,6 +270,30 @@ If your files list would match some files or directories that you _don't_ want i
 
 > By default, Spin takes a snapshot of your included files, and components access that snapshot. This ensures that when you test your application, you are checking it with the set of files it will be deployed with. However, it also means that your component does not pick up changes to the files while it is running. When testing a Web site, you might want to be able to edit a HTML or CSS file, and see the changes reflected without restarting Spin. You can tell Spin to give components access to the original, "live" files by passing the `--direct-mounts` flag to `spin up`.
 
+## Adding Environment Variables to Components
+
+Environment variables can be provided to components via the Spin application manifest.
+
+To do this, use the `environment` field in the component manifest:
+```toml
+[component]
+environment = { ANIMAL = "CAT", FOOD = "WATERMELON" }
+```
+The field accepts a map of environment variable key/value pairs. They are mapped inside the component at runtime.
+
+The environment variables can then be accessed inside the component. For example, in Rust:
+
+```rs
+#[http_component]
+fn handle_hello_rust(req: Request) -> Result<Response> {
+    let response format!("My {} likes to eat {}", std::env::var("PET")?, std::env::var("FOOD")?);
+    Ok(http::Response::builder()
+        .status(200)
+        .header("foo", "bar")
+        .body(Some(response.into()))?)
+}
+```
+
 ## Granting Networking Permissions to Components
 
 By default, Spin components are not allowed to make outgoing HTTP requests.  This follows the general Wasm rule that modules must be explicitly granted capabilities, which is important to sandboxing.  To grant a component permission to make HTTP requests to a particular host, use the `allowed_http_hosts` field in the component manifest:

--- a/content/spin/writing-apps.md
+++ b/content/spin/writing-apps.md
@@ -275,10 +275,12 @@ If your files list would match some files or directories that you _don't_ want i
 Environment variables can be provided to components via the Spin application manifest.
 
 To do this, use the `environment` field in the component manifest:
+
 ```toml
 [[component]]
 environment = { PET = "CAT", FOOD = "WATERMELON" }
 ```
+
 The field accepts a map of environment variable key/value pairs. They are mapped inside the component at runtime.
 
 The environment variables can then be accessed inside the component. For example, in Rust:

--- a/content/spin/writing-apps.md
+++ b/content/spin/writing-apps.md
@@ -257,7 +257,7 @@ You can include files with a component.  This means that:
 To do this, use the `files` field in the component manifest:
 
 ```toml
-[component]
+[[component]]
 files = [ "images/**/*.jpg", { source = "styles/dist", destination = "/styles" } ]
 ```
 
@@ -276,8 +276,8 @@ Environment variables can be provided to components via the Spin application man
 
 To do this, use the `environment` field in the component manifest:
 ```toml
-[component]
-environment = { ANIMAL = "CAT", FOOD = "WATERMELON" }
+[[component]]
+environment = { PET = "CAT", FOOD = "WATERMELON" }
 ```
 The field accepts a map of environment variable key/value pairs. They are mapped inside the component at runtime.
 
@@ -299,7 +299,7 @@ fn handle_hello_rust(req: Request) -> Result<Response> {
 By default, Spin components are not allowed to make outgoing HTTP requests.  This follows the general Wasm rule that modules must be explicitly granted capabilities, which is important to sandboxing.  To grant a component permission to make HTTP requests to a particular host, use the `allowed_http_hosts` field in the component manifest:
 
 ```toml
-[component]
+[[component]]
 allowed_http_hosts = [ "dog-facts.example.com", "api.example.com:8080" ]
 ```
 
@@ -312,7 +312,7 @@ For development-time convenience, you can also pass the string `"insecure:allow-
 By default, Spin components are not allowed to access Spin's storage services.  This follows the general Wasm rule that modules must be explicitly granted capabilities, which is important to sandboxing.  To grant a component permission to use a Spin-provided store, use the `key_value_stores` field in the component manifest:
 
 ```toml
-[component]
+[[component]]
 key_value_stores = [ "default" ]
 ```
 


### PR DESCRIPTION
While we have docs on the [environment config provider](https://developer.fermyon.com/spin/dynamic-configuration.md#environment-variable-provider), it looks like setting component environment variables is no longer documented.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has run `npm run build-index`
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [x] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
