### PR TITLE
docs(python-components): correct spelling

### DIFF
--- a/content/spin/python-components.md
+++ b/content/spin/python-components.md
@@ -320,7 +320,7 @@ date: Mon, 27 Feb 2023 05:16:03 GMT
 Executed outbound Redis commands: /hello
 ```
 
-If we go into our Redis CLI on locahost we can see that the value `foo` which was set in the Python source code ( `redis_set(redis_address, "foo", b"bar")` ) is now correctly set to the value of `bar`:
+If we go into our Redis CLI on localhost we can see that the value `foo` which was set in the Python source code ( `redis_set(redis_address, "foo", b"bar")` ) is now correctly set to the value of `bar`:
 
 <!-- @nocpy -->
 


### PR DESCRIPTION
Correct spelling from `locahost` to `localhost`.

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [X] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [X] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [X] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [X] Has run `npm run build-index`
- [X] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [X] Headings are using Title Case
- [X] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [X] Have tested with `npm run test` and resolved all errors
