### PR TITLE
Update installing from source to include 2 wasm32 targets.

### DIFF
--- a/content/spin/install.md
+++ b/content/spin/install.md
@@ -138,12 +138,13 @@ If you have [`cargo`](https://doc.rust-lang.org/cargo/getting-started/installati
 
 <pre class="bash spin-install" id="spin-install-source-cargo"><code>$ git clone https://github.com/fermyon/spin -b v1.0.0
 $ cd spin
+$ rustup target add wasm32-unknown-unknown
 $ rustup target add wasm32-wasi
 $ cargo install --locked --path .
 $ spin --help
 </code></pre>
 
-> Please note: Spin v1.0.0 requires `wasmtime v5.0.0` which requires rustc 1.66.0 or newer. You can update Rust using the following command:
+> Please note: Spin v1.0.0 requires `wasmtime v5.0.0` which requires rustc 1.67.0 or newer. You can update your version of Rust using the following command:
 
 <!-- @selectiveCpy -->
 


### PR DESCRIPTION
Signed-off-by: tpmccallum tim.mccallum@fermyon.com

Since (and including) Spin's [eb8239756e85d3c1bfd4d9e4b94bb4f6a0bb4fe4](https://github.com/fermyon/spin/commit/eb8239756e85d3c1bfd4d9e4b94bb4f6a0bb4fe4) commit, the `wasm32-unknown-unknown` is required in order for Spin to build from source. In addition, the Rust version required is `1.67.0` and above/newer.

Tested with both `make build` and `cargo` on main at 

```bash
$ cd ~
$ git clone https://github.com/fermyon/spin
$ cd spin
$ rustup target add wasm32-wasi
$ rustup target add wasm32-unknown-unknown
$ make build
    cargo build --release
    Compiling spin-cli v1.1.0-pre0 (/home/tpmccallum/spin)
    Finished release [optimized] target(s) in 53.91s
```
