### PR TITLE
Fix missing = in environment variable example

### DIFF
--- a/content/spin/writing-apps.md
+++ b/content/spin/writing-apps.md
@@ -288,7 +288,7 @@ The environment variables can then be accessed inside the component. For example
 ```rs
 #[http_component]
 fn handle_hello_rust(req: Request) -> Result<Response> {
-    let response format!("My {} likes to eat {}", std::env::var("PET")?, std::env::var("FOOD")?);
+    let response = format!("My {} likes to eat {}", std::env::var("PET")?, std::env::var("FOOD")?);
     Ok(http::Response::builder()
         .status(200)
         .header("foo", "bar")


### PR DESCRIPTION
Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has run `npm run build-index`
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
