### PR TITLE
fix(check-broken-links.sh): increase timeout to 60s

### DIFF
--- a/.build/check-broken-links.sh
+++ b/.build/check-broken-links.sh
@@ -54,7 +54,7 @@ npm run spin >/dev/null 2>&1 &
 
 ## wait for portal to be up and running
 export RESP_CODE="$(mktemp)"
-timeout 10s bash -c 'until curl -o /dev/null -s -w "%{http_code}\n" http://localhost:3000 > $RESP_CODE; do sleep 2; done'
+timeout 60s bash -c 'until curl -o /dev/null -s -w "%{http_code}\n" http://localhost:3000 > $RESP_CODE; do sleep 2; done'
 
 echo "checking website health via http://localhost:3000"
 


### PR DESCRIPTION
Follow-up to https://github.com/fermyon/developer/pull/443

Although the updated test passed on the PR as well as [my fork](https://github.com/vdice/developer/actions/runs/4599007771/jobs/8123833996), we're seeing a timeout failure after merging: https://github.com/fermyon/developer/actions/runs/4598971134/jobs/8123874389

Indeed, perhaps my reducing from 60s to 10s was a bit to aggressive.  This bumps the timeout (to wait for the local version of the website to come up) back up to 60s.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has run `npm run build-index`
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
