### PR TITLE
Updating GH Actions TypeScript example

### DIFF
--- a/content/cloud/github-actions.md
+++ b/content/cloud/github-actions.md
@@ -269,6 +269,9 @@ jobs:
         with:
           plugins: js2wasm
 
+      - name: Run npm install
+        run: npm install
+
       - name: Build and deploy
         uses: fermyon/actions/spin/deploy@v1
         with:

--- a/content/cloud/github-actions.md
+++ b/content/cloud/github-actions.md
@@ -257,12 +257,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: 1.66
-          targets: wasm32-wasi
-
       # TypeScript/JavaScript build requires the js2wasm plugin
       - name: Install Spin
         uses: fermyon/actions/spin/setup@v1
@@ -300,12 +294,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: 1.66
-          targets: wasm32-wasi
-
       # Python build requires the py2wasm plugin
       - name: Install Spin
         uses: fermyon/actions/spin/setup@v1
@@ -339,12 +327,6 @@ jobs:
     name: Build and deploy
     steps:
       - uses: actions/checkout@v3
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: 1.66
-          targets: wasm32-wasi
 
       - name: "Install Go"
         uses: actions/setup-go@v3

--- a/content/cloud/github-actions.md
+++ b/content/cloud/github-actions.md
@@ -257,6 +257,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.66
+          targets: wasm32-wasi
+
       # TypeScript/JavaScript build requires the js2wasm plugin
       - name: Install Spin
         uses: fermyon/actions/spin/setup@v1
@@ -291,6 +297,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.66
+          targets: wasm32-wasi
+
       # Python build requires the py2wasm plugin
       - name: Install Spin
         uses: fermyon/actions/spin/setup@v1
@@ -324,6 +336,12 @@ jobs:
     name: Build and deploy
     steps:
       - uses: actions/checkout@v3
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.66
+          targets: wasm32-wasi
 
       - name: "Install Go"
         uses: actions/setup-go@v3


### PR DESCRIPTION
This PR addresses Issue #563 to by correcting adding `npm install` to the TypeScript for deploying with Github Actions.

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has run `npm run build-index`
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
