### PR TITLE
Links not showing in preview - added inline URL to solve

### DIFF
--- a/content/cloud/changelog/custom-fermyon-subdomain.md
+++ b/content/cloud/changelog/custom-fermyon-subdomain.md
@@ -8,7 +8,7 @@ type= "changelog_post"
 
 ---
 
-Fermyon Cloud users can now apply custom Fermyon subdomains to their Spin applications. By default, every Spin application recieves a domain name that has the following format: `<app-name>-<randomstring>.fermyon.app`. With custom Fermyon subdomains, users can choose their preferred subdomain name to be appended to the `.fermyon.app` apex domain. To learn more, follow the custom Fermyon subdomain tutorial linked below. 
+Fermyon Cloud users can now apply custom Fermyon subdomains to their Spin applications. By default, every Spin application recieves a domain name that has the following format: `<app-name>-<randomstring>.fermyon.app`. With custom Fermyon subdomains, users can choose their preferred subdomain name to be appended to the `.fermyon.app` apex domain. To learn more, follow the [custom Fermyon subdomain tutorial](https://developer.fermyon.com/cloud/custom-fermyon-subdomain). 
 
 <!-- break -->
 


### PR DESCRIPTION
Signed-off-by: tpmccallum tim.mccallum@fermyon.com

Added an inline URL because the changelog preview talks about "below" but the preview page does not show anything below.

![Screenshot 2023-04-26 at 9 47 40 am](https://user-images.githubusercontent.com/9831342/234432143-ce8f771c-24d0-413d-8cd7-01aa45e21a5d.png)

![Screenshot 2023-04-26 at 9 53 23 am](https://user-images.githubusercontent.com/9831342/234432398-f5b65906-272f-425e-9ac9-d561888a4a99.png)