### PR TITLE
Update location of favicon in site's config

### DIFF
--- a/config/site.toml
+++ b/config/site.toml
@@ -9,6 +9,6 @@ github = "https://github.com/fermyon/developer"
 twitter = "https://twitter.com/fermyontech"
 
 # Static assets that we need to provide
-favicon = "/static/image/favicon.png"
+favicon = "/static/image/icon/favicon.png"
 twitter_card_type = "summary"
 twitter_card = "/static/image/twitter_card_summary.png"


### PR DESCRIPTION
Signed-off-by: tpmccallum tim.mccallum@fermyon.com

Closes https://github.com/fermyon/developer/issues/578

I am a little perplexed because currently (without this change), the developer documentation correctly provides the URL to the favicon in the `head` of the HTML pages already.

![Screenshot 2023-04-27 at 9 30 45 am](https://user-images.githubusercontent.com/9831342/234724252-1e1b0958-7c4e-4ab7-9a5c-dd4f3b4a7e69.png)

This update seems more correct than the `site.toml` linking to a folder other than `icon` (where the icons live). But any advice would be appreciated. @flynnduism do you have any thoughts on this?
