### PR TITLE
Align menu names across projects

### DIFF
--- a/content/spin/writing-apps.md
+++ b/content/spin/writing-apps.md
@@ -388,6 +388,7 @@ channel = "messages"
 ```
 
 ## Next Steps
+
 - Learn about how to [build your Spin application code](build)
 - Try [running your application locally](running-apps)
 - Discover how Spin application authors [design and organise applications](designing-spin-apps)

--- a/templates/bartholomew_sidebar.hbs
+++ b/templates/bartholomew_sidebar.hbs
@@ -17,7 +17,7 @@
         </ul>
 
         <p class="menu-label">
-            Tools
+            Building Sites
         </p>
         <ul class="menu-list">
             <li><a {{#if (active_content request.spin-path-info "/bartholomew/templates" )}} class="active" {{/if}} href="{{site.info.base_url}}/bartholomew/templates">Templates</a></li>

--- a/templates/bartholomew_sidebar.hbs
+++ b/templates/bartholomew_sidebar.hbs
@@ -13,7 +13,7 @@
             Building Sites
         </p>
         <ul class="menu-list">
-            <li><a {{#if (active_content request.spin-path-info "/bartholomew/markdown" )}} class="active" {{/if}} href="{{site.info.base_url}}/bartholomew/markdown">Writing Markdown</a></li>
+            <li><a {{#if (active_content request.spin-path-info "/bartholomew/markdown" )}} class="active" {{/if}} href="{{site.info.base_url}}/bartholomew/markdown">Markdown</a></li>
             <li><a {{#if (active_content request.spin-path-info "/bartholomew/templates" )}} class="active" {{/if}} href="{{site.info.base_url}}/bartholomew/templates">Templates</a></li>
             <li><a {{#if (active_content request.spin-path-info "/bartholomew/themes" )}} class="active" {{/if}} href="{{site.info.base_url}}/bartholomew/themes">Themes</a></li>
             <li><a {{#if (active_content request.spin-path-info "/bartholomew/scripting" )}} class="active" {{/if}} href="{{site.info.base_url}}/bartholomew/scripting">Scripting</a></li>

--- a/templates/bartholomew_sidebar.hbs
+++ b/templates/bartholomew_sidebar.hbs
@@ -10,16 +10,10 @@
         </ul>
 
         <p class="menu-label">
-            Tutorials
-        </p>
-        <ul class="menu-list">
-            <li><a {{#if (active_content request.spin-path-info "/bartholomew/markdown" )}} class="active" {{/if}} href="{{site.info.base_url}}/bartholomew/markdown">Writing Markdown</a></li>
-        </ul>
-
-        <p class="menu-label">
             Building Sites
         </p>
         <ul class="menu-list">
+            <li><a {{#if (active_content request.spin-path-info "/bartholomew/markdown" )}} class="active" {{/if}} href="{{site.info.base_url}}/bartholomew/markdown">Writing Markdown</a></li>
             <li><a {{#if (active_content request.spin-path-info "/bartholomew/templates" )}} class="active" {{/if}} href="{{site.info.base_url}}/bartholomew/templates">Templates</a></li>
             <li><a {{#if (active_content request.spin-path-info "/bartholomew/themes" )}} class="active" {{/if}} href="{{site.info.base_url}}/bartholomew/themes">Themes</a></li>
             <li><a {{#if (active_content request.spin-path-info "/bartholomew/scripting" )}} class="active" {{/if}} href="{{site.info.base_url}}/bartholomew/scripting">Scripting</a></li>

--- a/templates/bartholomew_sidebar.hbs
+++ b/templates/bartholomew_sidebar.hbs
@@ -1,16 +1,28 @@
 <div class="menu-wrap is-narrow is-fixed-desktop" id="docsMenu">
     <aside class="menu">
         <p class="menu-label">
-            Using Bartholomew
+            Get Started
         </p>
         <ul class="menu-list">
             <li><a {{#if (active_content request.spin-path-info "/bartholomew/index" )}} class="active" {{/if}} href="{{site.info.base_url}}/bartholomew/">Introduction</a></li>
             <li><a {{#if (active_content request.spin-path-info "/bartholomew/quickstart" )}} class="active" {{/if}} href="{{site.info.base_url}}/bartholomew/quickstart">Quickstart</a></li>
-            <li><a {{#if (active_content request.spin-path-info "/bartholomew/templates" )}} class="active" {{/if}} href="{{site.info.base_url}}/bartholomew/templates">Templates</a></li>
             <li><a {{#if (active_content request.spin-path-info "/bartholomew/configuration" )}} class="active" {{/if}} href="{{site.info.base_url}}/bartholomew/configuration">Configuration</a></li>
+        </ul>
+
+        <p class="menu-label">
+            Tutorials
+        </p>
+        <ul class="menu-list">
+            <li><a {{#if (active_content request.spin-path-info "/bartholomew/markdown" )}} class="active" {{/if}} href="{{site.info.base_url}}/bartholomew/markdown">Writing Markdown</a></li>
+        </ul>
+
+        <p class="menu-label">
+            Tools
+        </p>
+        <ul class="menu-list">
+            <li><a {{#if (active_content request.spin-path-info "/bartholomew/templates" )}} class="active" {{/if}} href="{{site.info.base_url}}/bartholomew/templates">Templates</a></li>
             <li><a {{#if (active_content request.spin-path-info "/bartholomew/themes" )}} class="active" {{/if}} href="{{site.info.base_url}}/bartholomew/themes">Themes</a></li>
             <li><a {{#if (active_content request.spin-path-info "/bartholomew/scripting" )}} class="active" {{/if}} href="{{site.info.base_url}}/bartholomew/scripting">Scripting</a></li>
-            <li><a {{#if (active_content request.spin-path-info "/bartholomew/markdown" )}} class="active" {{/if}} href="{{site.info.base_url}}/bartholomew/markdown">Markdown Guide</a></li>
             <li><a {{#if (active_content request.spin-path-info "/bartholomew/shortcodes" )}} class="active" {{/if}} href="{{site.info.base_url}}/bartholomew/shortcodes">Shortcodes</a></li>
         </ul>
 

--- a/templates/cloud_sidebar.hbs
+++ b/templates/cloud_sidebar.hbs
@@ -1,7 +1,7 @@
 <div class="menu-wrap is-narrow is-fixed-desktop" id="docsMenu">
     <aside class="menu">
         <p class="menu-label">
-            Using the Fermyon Cloud
+            Get Started
         </p>
         <ul class="menu-list">
             <li><a {{#if (active_content request.spin-path-info "/cloud/index" )}} class="active" {{/if}} href="{{site.info.base_url}}/cloud/">Introduction</a></li>
@@ -9,7 +9,7 @@
         </ul>
 
         <p class="menu-label">
-            How-To
+            Applications
         </p>
         <ul class="menu-list">
             <li><a {{#if (active_content request.spin-path-info "/cloud/develop" )}} class="active" {{/if}} href="{{site.info.base_url}}/cloud/develop">Develop a Spin Application</a></li>

--- a/templates/spin_sidebar.hbs
+++ b/templates/spin_sidebar.hbs
@@ -70,14 +70,6 @@
         </ul>
 
         <p class="menu-label">
-            References
-        </p>
-        <ul class="menu-list">
-            <li><a {{#if (active_content request.spin-path-info "/common/cli-reference" )}} class="active" {{/if}} href="{{site.info.base_url}}/common/cli-reference">CLI Reference</a></li>
-            <li><a {{#if (active_content request.spin-path-info "/common/manifest-reference" )}} class="active" {{/if}} href="{{site.info.base_url}}/spin/manifest-reference">Application Manifest Reference</a></li>
-        </ul>
-
-        <p class="menu-label">
             Advanced
         </p>
         <ul class="menu-list">
@@ -90,6 +82,14 @@
             <li><a {{#if (active_content request.spin-path-info "/spin/template-authoring" )}} class="active" {{/if}} href="{{site.info.base_url}}/spin/template-authoring">Creating Spin Templates</a></li>
             <li><a {{#if (active_content request.spin-path-info "/spin/plugin-authoring" )}} class="active" {{/if}} href="{{site.info.base_url}}/spin/plugin-authoring">Creating Spin Plugins</a></li>
             <li><a {{#if (active_content request.spin-path-info "/spin/kubernetes" )}} class="active" {{/if}} href="{{site.info.base_url}}/spin/kubernetes">Spin on Kubernetes</a></li>
+        </ul>
+
+        <p class="menu-label">
+            References
+        </p>
+        <ul class="menu-list">
+            <li><a {{#if (active_content request.spin-path-info "/common/cli-reference" )}} class="active" {{/if}} href="{{site.info.base_url}}/common/cli-reference">CLI Reference</a></li>
+            <li><a {{#if (active_content request.spin-path-info "/common/manifest-reference" )}} class="active" {{/if}} href="{{site.info.base_url}}/spin/manifest-reference">Application Manifest Reference</a></li>
         </ul>
 
         <p class="menu-label">


### PR DESCRIPTION
Updated sidebar menu items for Cloud, Spin and Bartholomew:
Each uses the same menu terminology i.e. "Get Started"
There are some additional (unique to each project) menu labels but after this update, the shared labels are ordered. For example shared menu labels between each project now fall in the same order i.e. "Get Started" -> "Application" -> "Tutorials" -> "References" -> "Contributing".
Also shared sub-menu labels (pages) terminologies like "Templates" all fall under the menu label of "Tools"; whereas before pages and menu labels were not 100% aligned (across different projects).
We will soon use accordion (collapsable) menus, at which point the top-level menu label becomes more important.

