### PR TITLE
SQLite documentation

### DIFF
--- a/content/cloud/faq.md
+++ b/content/cloud/faq.md
@@ -64,6 +64,7 @@ Fermyon Cloud supports Spin CLI v0.6.0 or newer. That being said, there are cert
 | [Outbound HTTP](/spin/rust-components.md#sending-outbound-http-requests) | Supported |
 | [Configuration Variables](/spin/variables) | Supported |
 | [Key Value Storage](/spin/kv-store-api-guide) | Supported (only default store) |
+| [SQLite Storage](/spin/sqlite-api-guide) | Not supported |
 | [MySQL](/spin/rdbms-storage#using-mysql-and-postgresql-from-applications) | Supported |
 | [PostgreSQL](/spin/rdbms-storage#using-mysql-and-postgresql-from-applications) | Supported |
 | [Outbound Redis](/spin/rust-components.md#storing-data-in-redis-from-rust-components) | Supported |

--- a/content/spin/api-guides-overview.md
+++ b/content/spin/api-guides-overview.md
@@ -18,5 +18,6 @@ The following table shows the status of the interfaces Spin provides to applicat
 | [PostgreSQL](/spin/rdbms-storage)                             | Experimental | Yes |
 | [MySQL](/spin/rdbms-storage)                                  | Experimental | Yes |
 | [Key-value Storage](/spin/kv-store-api-guide)                      | Stabilizing | Yes |
+| [SQLite Storage](/spin/sqlite-api-guide)                      | Experimental | No |
 
 For more information about what is possible in the programming language of your choice, please see our [Language Support Overview](/spin/language-support-overview).

--- a/content/spin/dynamic-configuration.md
+++ b/content/spin/dynamic-configuration.md
@@ -216,13 +216,13 @@ To use libSQL, set `type = "libsql"` in your `runtime-config.toml` entry.  You m
 # This tells Spin to use the remote host as its default database
 [sqlite_database.default]
 type = "libsql"
-url = "sensational-penguin-ahacker.libsql.example.com"
+url = "https://sensational-penguin-ahacker.libsql.example.com"
 token = "a secret"
 ```
 
 Spin does _not_ create libSQL databases.  Use your hosting service's tools to create them (or `sqld` if you are self-hosting) .  You can still set up tables and data in a libSQL database via `spin up --sqlite`.
 
-> Some libSQL service documentation shows URLs with a `libsql://` scheme.  Don't include a scheme in the `runtime-config.toml` `url` field.  Include only the host name.
+> You must include the scheme in the `url` field. The scheme must be `http` or `https`. Non-HTTP libSQL protocols are not supported.
 
 The `default` database will still be defined, even if you add other databases.
 

--- a/content/spin/dynamic-configuration.md
+++ b/content/spin/dynamic-configuration.md
@@ -204,7 +204,7 @@ path = "/planning/todo.db"
 path = "/super/secret/monies.db"
 ```
 
-Spin creates any database files that don't exist.
+Spin creates any database files that don't exist.  However, it is up to you to delete them when you no longer need them.
 
 Spin can also use [libSQL](https://libsql.org/) databases accessed over HTTPS.  libSQL is fully compatible with SQLite but provides additional features including remote, distributed databases.
 

--- a/content/spin/dynamic-configuration.md
+++ b/content/spin/dynamic-configuration.md
@@ -183,7 +183,7 @@ You must individually grant each component access to the stores that it needs to
 
 ### SQLite Storage Runtime Configuration
 
-Spin provides built-in SQLite storage. By default, this is backed by a database that Spin creates for you. However, you can use the Spin runtime configuration file (`runtime-config.toml`) to add and customize SQLite databases.
+Spin provides built-in SQLite storage. By default, this is backed by a database that Spin creates for you underneath your application directory (in the `.spin` subdirectory). However, you can use the Spin runtime configuration file (`runtime-config.toml`) to add and customize SQLite databases.
 
 The following example `runtime-config.toml` tells Spin to map the `default` database to an SQLite database elsewhere in the file system:
 
@@ -208,7 +208,7 @@ Spin creates any database files that don't exist.  However, it is up to you to d
 
 Spin can also use [libSQL](https://libsql.org/) databases accessed over HTTPS.  libSQL is fully compatible with SQLite but provides additional features including remote, distributed databases.
 
-> Spin does not provide libSQL access to file-based databases, only databases served over HTTPS.
+> Spin does not provide libSQL access to file-based databases, only databases served over HTTPS. Specifically, Spin supports [the `sqld` libSQL server](https://github.com/libsql/sqld).
 
 To use libSQL, set `type = "libsql"` in your `runtime-config.toml` entry.  You must then provide a `url` and authentication `token` instead of a file path.  For example, this entry tells Spin to map the `default` database to a libSQL service running on `libsql.example.com`:
 
@@ -220,7 +220,7 @@ url = "sensational-penguin-ahacker.libsql.example.com"
 token = "a secret"
 ```
 
-Spin does _not_ create libSQL databases.  Use your hosting service's tools, or the `libsql` command line, to create them.  You can still set up tables and data in a libSQL database via `spin up --sqlite`.
+Spin does _not_ create libSQL databases.  Use your hosting service's tools to create them (or `sqld` if you are self-hosting) .  You can still set up tables and data in a libSQL database via `spin up --sqlite`.
 
 > Some libSQL service documentation shows URLs with a `libsql://` scheme.  Don't include a scheme in the `runtime-config.toml` `url` field.  Include only the host name.
 

--- a/content/spin/kv-store-api-guide.md
+++ b/content/spin/kv-store-api-guide.md
@@ -26,8 +26,8 @@ The set of operations is common across all SDKs:
 
 | Operation  | Parameters | Returns | Behavior |
 |------------|------------|---------|----------|
-| `open`  | name | store  | Open the store with the specified name. If `name` is the string "default", the default store is opened for the component that was granted access in the component manifest from `spin.toml`. Otherwise, `name` must refer to a store defined and configured in a [runtime configuration file](./dynamic-configuration.md#key-value-store-runtime-configuration) supplied with the application.|
-| `get` | store, key | key | Get the value associated with the specified `key` from the specified `store`. |
+| `open`  | name | store  | Open the store with the specified name. If `name` is the string "default", the default store is opened, provided that the component that was granted access in the component manifest from `spin.toml`. Otherwise, `name` must refer to a store defined and configured in a [runtime configuration file](./dynamic-configuration.md#key-value-store-runtime-configuration) supplied with the application.|
+| `get` | store, key | value | Get the value associated with the specified `key` from the specified `store`. |
 | `set` | store, key, value | - | Set the `value` associated with the specified `key` in the specified `store`, overwriting any existing value. |
 | `delete` | store, key | - | Delete the tuple with the specified `key` from the specified `store`. `error::invalid-store` will be raised if `store` is not a valid handle to an open store.  No error is raised if a tuple did not previously exist for `key`.|
 | `exists` | store, key | boolean | Return whether a tuple exists for the specified `key` in the specified `store`.|

--- a/content/spin/language-support-overview.md
+++ b/content/spin/language-support-overview.md
@@ -42,7 +42,7 @@ This page contains information about language support for Spin features:
 | [Outbound HTTP](/spin/javascript-components#sending-outbound-http-requests) | Supported |
 | [Configuration Variables](/spin/dynamic-configuration#custom-config-variables) | Supported |
 | [Key Value Storage](/spin/kv-store-api-guide) | Supported |
-| SQLite Storage | Not supported |
+| [SQLite Storage](/spin/sqlite-api-guide) | Supported |
 | MySQL | Not Supported |
 | PostgreSQL| Not Supported |
 | [Outbound Redis](/spin/javascript-components#storing-data-in-redis-from-jsts-components) | Supported |
@@ -62,7 +62,7 @@ This page contains information about language support for Spin features:
 | [Outbound HTTP](/spin/python-components#an-outbound-http-example) | Supported |
 | [Configuration Variables](/spin/dynamic-configuration#custom-config-variables) | Supported |
 | [Key Value Storage](/spin/kv-store-api-guide) | Supported |
-| SQLite Storage | Not supported |
+| [SQLite Storage](/spin/sqlite-api-guide) | Supported |
 | MySQL | Not Supported |
 | PostgreSQL | Not Supported |
 | [Outbound Redis](/spin/python-components#an-outbound-redis-example) | Supported |

--- a/content/spin/language-support-overview.md
+++ b/content/spin/language-support-overview.md
@@ -22,6 +22,7 @@ This page contains information about language support for Spin features:
 | [Outbound HTTP](/spin/rust-components.md#sending-outbound-http-requests) | Supported |
 | [Configuration Variables](/spin/variables) | Supported |
 | [Key Value Storage](/spin/kv-store-api-guide) | Supported |
+| [SQLite Storage](/spin/sqlite-api-guide) | Supported |
 | [MySQL](/spin/rdbms-storage#using-mysql-and-postgresql-from-applications) | Supported |
 | [PostgreSQL](/spin/rdbms-storage#using-mysql-and-postgresql-from-applications) | Supported |
 | [Outbound Redis](/spin/rust-components.md#storing-data-in-redis-from-rust-components) | Supported |
@@ -41,6 +42,7 @@ This page contains information about language support for Spin features:
 | [Outbound HTTP](/spin/javascript-components#sending-outbound-http-requests) | Supported |
 | [Configuration Variables](/spin/dynamic-configuration#custom-config-variables) | Supported |
 | [Key Value Storage](/spin/kv-store-api-guide) | Supported |
+| SQLite Storage | Not supported |
 | MySQL | Not Supported |
 | PostgreSQL| Not Supported |
 | [Outbound Redis](/spin/javascript-components#storing-data-in-redis-from-jsts-components) | Supported |
@@ -60,6 +62,7 @@ This page contains information about language support for Spin features:
 | [Outbound HTTP](/spin/python-components#an-outbound-http-example) | Supported |
 | [Configuration Variables](/spin/dynamic-configuration#custom-config-variables) | Supported |
 | [Key Value Storage](/spin/kv-store-api-guide) | Supported |
+| SQLite Storage | Not supported |
 | MySQL | Not Supported |
 | PostgreSQL | Not Supported |
 | [Outbound Redis](/spin/python-components#an-outbound-redis-example) | Supported |
@@ -79,6 +82,7 @@ This page contains information about language support for Spin features:
 | [Outbound HTTP](/spin/go-components#sending-outbound-http-requests) | Supported |
 | [Configuration Variables](/spin/dynamic-configuration#custom-config-variables) | Supported |
 | [Key Value Storage](/spin/kv-store-api-guide) | Supported |
+| SQLite Storage | Not supported |
 | MySQL | Not Supported |
 | PostgreSQL | Not Supported |
 | [Outbound Redis](/spin/go-components#storing-data-in-redis-from-go-components) | Supported |
@@ -98,6 +102,7 @@ This page contains information about language support for Spin features:
 | [Outbound HTTP](https://github.com/fermyon/spin-dotnet-sdk#making-outbound-http-requests) | Supported |
 | [Configuration Variables](/spin/dynamic-configuration#custom-config-variables) | Supported |
 | Key Value Storage | Not Supported |
+| SQLite Storage | Not supported |
 | MySQL | Not Supported |
 | [PostgreSQL](https://github.com/fermyon/spin-dotnet-sdk#working-with-postgres) | Supported |
 | [Outbound Redis](https://github.com/fermyon/spin-dotnet-sdk#making-redis-requests) | Supported |

--- a/content/spin/rdbms-storage.md
+++ b/content/spin/rdbms-storage.md
@@ -8,7 +8,12 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/rdbms-storage
 ---
 - [Using MySQL and PostgreSQL From Applications](#using-mysql-and-postgresql-from-applications)
 
-Spin provides an interface for you to access relational (SQL) databases, specifically MySQL and PostgreSQL.
+Spin provides two interfaces for relational (SQL) databases:
+
+* A built-in [SQLite database](/spin/sqlite-api-guide), which is always available and requires no management on your part.
+* "Bring your own database" support for MySQL and PostgreSQL, where you host and manage the database outside of Spin.
+
+This page covers the "bring your own database" scenario.  See [SQLite Storage](/spin/sqlite-api-guide) for the built-in service.
 
 {{ details "Why do I need a Spin interface? Why can't I just use my language's database libraries?" "The current version of the WebAssembly System Interface (WASI) doesn't provide a sockets interface, so database libraries that depend on sockets can't be built to Wasm. The Spin interface means Wasm modules can bypass this limitation by asking Spin to make the database connection on their behalf." }}
 

--- a/content/spin/sqlite-api-guide.md
+++ b/content/spin/sqlite-api-guide.md
@@ -1,0 +1,151 @@
+title = "SQLite Storage"
+template = "spin_main"
+date = "2023-04-14T00:22:56Z"
+enable_shortcodes = true
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/sqlite-api-guide.md"
+
+---
+- [Using SQLite Storage From Applications](#using-sqlite-storage-from-applications)
+- [Preparing an SQLite Database](#preparing-an-sqlite-database)
+- [Custom SQLite Databases](#custom-sqlite-databases)
+- [Granting SQLite Database Permissions to Components](#granting-sqlite-database-permissions-to-components)
+
+Spin provides an interface for you to persist data in an SQLite database managed by Spin. This database allows Spin developers to persist relational data across application invocations.
+
+{{ details "Why do I need a Spin interface? Why can't I just use my own external database?" "You can absolutely still use your own external database either with the MySQL or Postgres APIs. However, if you're interested in quick, local relational storage without any infrastructure set-up then Spin's SQLite database is a great option." }}
+
+## Using SQLite Storage From Applications
+
+The Spin SDK surfaces the Spin SQLite database interface to your language.
+
+The set of operations is common across all SDKs:
+
+| Operation  | Parameters | Returns | Behavior |
+|------------|------------|---------|----------|
+| `open`  | name | connection  | Open the database with the specified name. If `name` is the string "default", the default database is opened, provided that the component that was granted access in the component manifest from `spin.toml`. Otherwise, `name` must refer to a store defined and configured in a [runtime configuration file](/spin/dynamic-configuration.md#sqlite-storage-runtime-configuration) supplied with the application.|
+| `execute` | connection, sql, parameters | database records | Executes the SQL statement and returns the results of the statement. SELECT statements typically return records or scalars. INSERT, UPDATE, and DELETE statements typically return empty result sets, but may return values in some cases. |
+| `close` | connection | - | Close the specified `connection`. |
+
+The exact detail of calling these operations from your application depends on your language:
+
+{{ tabs "sdk-type" }}
+
+{{ startTab "Rust"}}
+
+SQLite functions are available in the `spin_sdk::sqlite` module. The function names match the operations above. For example:
+
+```rust
+use anyhow::Result;
+use serde::Serialize;
+use spin_sdk::{
+    http::{Request, Response},
+    http_component,
+    sqlite::{DataTypeParam, Error, Connection},
+};
+
+#[http_component]
+fn handle_request(req: Request) -> Result<Response> {
+    let connection = Connection::open_default()?;
+
+    let execute_params = [
+        ValueParam::Text("Try out Spin SQLite"),
+        ValueParam::Text("Friday"),
+    ];
+    connection.execute(
+        "INSERT INTO todos (description, due) VALUES (?, ?)",
+        execute_params.as_slice(),
+    )?;
+
+    let rowset = connection.execute(
+        "SELECT id, description, due FROM todos",
+        &[]
+    )?;
+
+    let todos = rowset.rows().map(|row|
+        ToDo {
+            id: row.get::<u32>("id").unwrap(),
+            description: row.get::<&str>("description").unwrap().to_owned(),
+            due: row.get::<&str>("due").unwrap().to_owned(),
+        }
+    );
+
+    let body = serde_json::to_vec(&todos)?;
+    Ok(http::Response::builder().status(200).body(Some(body.into()))?)
+}
+
+// Helper for returning the query results as JSON
+#[derive(Serialize)]
+struct ToDo {
+    id: u32,
+    description: String,
+    due: String,
+}
+```
+
+**General Notes** 
+* Parameters are instances of the `ValueParam` enum; you must wrap raw values in this type.
+* The `query` function returns a `QueryResult`. To iterate over the rows use the `rows()` function. This returns an iterator; use `collect()` if you want to load it all into a collection.
+* The values in rows are instances of the `ValueResult` enum.  However, you can use `row.get(column_name)` to extract a specific column from a row.  `get` casts the database value to the target Rust type. If the compiler can't infer the target type, write `row.get::<&str>(column_name)` (or whatever the desired type is).
+* All functions wrap the return in `Result`, with the error type being `spin_sdk::sqlite::Error`.
+
+{{ blockEnd }}
+
+{{ startTab "Typescript"}}
+
+The JavaScript/TypeScript SDK doesn't currently surface the SQLite API.
+
+{{ blockEnd }}
+
+{{ startTab "Python"}}
+
+The Python SDK doesn't currently surface the SQLite API.
+
+{{ blockEnd }}
+
+{{ startTab "TinyGo"}}
+
+The Go SDK doesn't currently surface the SQLite API.
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+## Preparing an SQLite Database
+
+Although Spin provides SQLite as a built-in database, SQLite still needs you to create its tables.  Although you can do this using Spin components and the SQLite API, this usually results in database setup getting uncomfortably mixed in with application logic.
+
+Instead, you can use the `spin up --sqlite` option to run whatever SQL statements you need before your application starts.  This is typically used to create or alter tables, but can be used for whatever other maintenance or troubleshooting tasks you need.
+
+You can run a SQL script from a file using the `@filename` syntax:
+
+<!-- @nocpy -->
+
+```bash
+spin up --sqlite @migration.sql
+```
+
+Or you can pass SQL statements directly on the command line as a (quoted) string:
+
+<!-- @nocpy -->
+
+```bash
+spin up --sqlite "CREATE TABLE IF NOT EXISTS todos (id INTEGER PRIMARY KEY AUTOINCREMENT, description TEXT NOT NULL, due TEXT NOT NULL)"
+```
+
+You can provide the `--sqlite` flag more than once; Spin runs the statements in the order you provide them.
+
+## Custom SQLite Databases
+
+Spin defines a database named `"default"` and provides automatic backing storage.  If you need to customize Spin with additional databases, or to change the backing storage for the default database, you can do so via the `--runtime-config-file` flag and the `runtime-config.toml` file.  See [SQLite Database Runtime Configuration](/spin/dynamic-configuration#sqlite-storage-runtime-configuration) for details.
+
+## Granting SQLite Database Permissions to Components
+
+By default, a given component of an app will not have access to any SQLite databases. Access must be granted specifically to each component via the component manifest:
+
+```toml
+[component]
+sqlite_databases = ["default", "sales"]
+```
+
+For example, a component could be given access to the default store using `sqlite_databases = ["default"]`.

--- a/templates/spin_sidebar.hbs
+++ b/templates/spin_sidebar.hbs
@@ -87,6 +87,8 @@
                             href="{{site.info.base_url}}/spin/rdbms-storage">Relational Database Storage</a></li>
                     <li><a {{#if (active_content request.spin-path-info "/spin/kv-store-api-guide" )}} class="active"
                             {{/if}} href="{{site.info.base_url}}/spin/kv-store-api-guide">Key Value Store</a></li>
+                    <li><a {{#if (active_content request.spin-path-info "/spin/sqlite-api-guide" )}} class="active"
+                            {{/if}} href="{{site.info.base_url}}/spin/sqlite-api-guide">SQLite Storage</a></li>
                     <li><a {{#if (active_content request.spin-path-info "/spin/variables" )}} class="active"
                             {{/if}} href="{{site.info.base_url}}/spin/variables">Application Variables</a></li>
                 </ul>

--- a/templates/spin_sidebar.hbs
+++ b/templates/spin_sidebar.hbs
@@ -81,14 +81,14 @@
                             {{/if}} href="{{site.info.base_url}}/spin/api-guides-overview">API Support Overview</a></li>
                     <li><a {{#if (active_content request.spin-path-info "/spin/http-outbound" )}} class="active" {{/if}}
                             href="{{site.info.base_url}}/spin/http-outbound">Making HTTP Requests</a></li>
-                    <li><a {{#if (active_content request.spin-path-info "/spin/redis-outbound" )}} class="active"
-                            {{/if}} href="{{site.info.base_url}}/spin/redis-outbound">Redis Storage</a></li>
-                    <li><a {{#if (active_content request.spin-path-info "/spin/rdbms-storage" )}} class="active" {{/if}}
-                            href="{{site.info.base_url}}/spin/rdbms-storage">Relational Database Storage</a></li>
                     <li><a {{#if (active_content request.spin-path-info "/spin/kv-store-api-guide" )}} class="active"
                             {{/if}} href="{{site.info.base_url}}/spin/kv-store-api-guide">Key Value Store</a></li>
                     <li><a {{#if (active_content request.spin-path-info "/spin/sqlite-api-guide" )}} class="active"
                             {{/if}} href="{{site.info.base_url}}/spin/sqlite-api-guide">SQLite Storage</a></li>
+                    <li><a {{#if (active_content request.spin-path-info "/spin/redis-outbound" )}} class="active"
+                            {{/if}} href="{{site.info.base_url}}/spin/redis-outbound">Redis Storage</a></li>
+                    <li><a {{#if (active_content request.spin-path-info "/spin/rdbms-storage" )}} class="active" {{/if}}
+                            href="{{site.info.base_url}}/spin/rdbms-storage">Relational Database Storage</a></li>
                     <li><a {{#if (active_content request.spin-path-info "/spin/variables" )}} class="active"
                             {{/if}} href="{{site.info.base_url}}/spin/variables">Application Variables</a></li>
                 </ul>


### PR DESCRIPTION
~This is extremely WIP at the moment - just punting it up so it's tracked.~ This is not as WIP as it used to be - it probably needs some redrafting but should be ready to review.

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)

`sqlite-api-guide.md` has a new menu link but thankfully the frontmatter's date in the `sqlite-api-guide.md` is before today's date so this won't be an issue.

- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)

<img width="850" alt="Screenshot 2023-07-06 at 11 48 53 am" src="https://github.com/fermyon/developer/assets/9831342/421e9767-bd98-4313-9a71-29fd09058c3c">

- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)

![Screenshot 2023-07-06 at 11 50 08 am](https://github.com/fermyon/developer/assets/9831342/9bc3270b-6394-4651-89f6-d99983f0beed)

- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors

<img width="424" alt="Screenshot 2023-07-06 at 11 50 52 am" src="https://github.com/fermyon/developer/assets/9831342/147e6b38-0a1e-4f66-bacf-47f746ebe9e7">

- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
