### PR TITLE
Upgrade of Bartholomew Wasm Module

### DIFF
--- a/content/bartholomew/contributing-bartholomew.md
+++ b/content/bartholomew/contributing-bartholomew.md
@@ -271,7 +271,7 @@ The output from the above command will be similar to the following (depending on
 
 To run Bartholomew, you will need a Spin-capable runtime. 
 
-For Spin, follow [the Spin quickstart guide](https://developer.fermyon.com/spin/quickstart) which details how to either:
+For Spin, follow [the Spin quickstart guide](/spin/quickstart) which details how to either:
 - download the latest Spin binary release,
 - clone and install Spin using cargo, or
 - clone and build Spin from source.

--- a/content/bartholomew/index.md
+++ b/content/bartholomew/index.md
@@ -10,7 +10,7 @@ url = "https://github.com/fermyon/developer/blob/main//content/bartholomew/index
 - [Taking Bartholomew for a Spin](#taking-bartholomew-for-a-spin)
 
 Bartholomew is a simple CMS-like (Content Management System) tool for managing a
-website. It is compiled to WebAssembly, and can run in any [Spin](https://developer.fermyon.com/spin)
+website. It is compiled to WebAssembly, and can run in any [Spin](/spin)
 environment.
 
 At a glance, with Bartholomew you can:
@@ -29,7 +29,7 @@ one you might find in AWS Lambda or Azure Functions. The CMS is only running whe
 it needs to handle incoming requests, reducing the load on the servers
 running it.
 
-Bartholomew is a [Spin](https://developer.fermyon.com/spin) component, and
+Bartholomew is a [Spin](/spin) component, and
 websites built with Bartholomew are Spin applications that can run in any
 environment that is capable of running Spin. At Fermyon, we run all of our
 websites using Bartholomew and Spin, on our [Fermyon Platform, running on Nomad](https://www.fermyon.com/blog/spin-nomad).

--- a/content/bartholomew/markdown.md
+++ b/content/bartholomew/markdown.md
@@ -77,7 +77,7 @@ key = "your custom name value pairs go hear, but values MUST be strings"
 
 Markdown support includes all the usual stuff plus fenced codeblocks. Image links are
 supported, but you need to use the external [fileserver](https://github.com/fermyon/spin-fileserver)
-library to display the images. If you are using your deployment of Spin and Bartholomew, you can [read more about how to install the fileserver](https://developer.fermyon.com/bartholomew/contributing-bartholomew) from source.
+library to display the images. If you are using your deployment of Spin and Bartholomew, you can [read more about how to install the fileserver](/bartholomew/contributing-bartholomew) from source.
 
 The last line of the example above is very important. The `---` tells Bartholomew that the head is done, and the body is coming up.
 

--- a/content/bartholomew/quickstart.md
+++ b/content/bartholomew/quickstart.md
@@ -19,11 +19,11 @@ keywords = "install"
   - [Validating Content With Shortcodes](#validating-content-with-shortcodes)
 - [Viewing Your Changes](#viewing-your-changes)
 
-This is a quickstart example of using Spin to deploy a Bartholomew CMS instance, locally on your machine. In this quickstart session, we use a Bartholomew site template which contains some pre-built parts (for your convenience). If you would like to build all of the parts separately from source (Spin, Bartholomew, File Server), please see the [contributing section](https://developer.fermyon.com/bartholomew/contributing-bartholomew) which dives a lot deeper than this quickstart example.
+This is a quickstart example of using Spin to deploy a Bartholomew CMS instance, locally on your machine. In this quickstart session, we use a Bartholomew site template which contains some pre-built parts (for your convenience). If you would like to build all of the parts separately from source (Spin, Bartholomew, File Server), please see the [contributing section](/bartholomew/contributing-bartholomew) which dives a lot deeper than this quickstart example.
 
 ## Getting the `spin` Binary
 
-For Spin, follow [the Spin quickstart guide](https://developer.fermyon.com/spin/quickstart) which details how to either:
+For Spin, follow [the Spin quickstart guide](/spin/quickstart) which details how to either:
 - download the latest Spin binary release,
 - clone and build Spin using cargo, or
 - clone and build Spin from source.

--- a/content/cloud/changelog/cloud-key-value.md
+++ b/content/cloud/changelog/cloud-key-value.md
@@ -8,7 +8,7 @@ type= "changelog_post"
 
 ---
 
-Fermyon Cloud now supports [Key Value Store](https://developer.fermyon.com/spin/kv-store-api-guide). While Spin applications are well suited for event-driven, stateless workloads, these serverless workloads often rely on external services to persist state beyond the lifespan of a single request. With the introduction of [Fermyon Cloud Key Value Store](https://www.fermyon.com/blog/introducing-fermyon-cloud-key-value-store), you can now persist non-relational data in a key/value store that is always available for your serverless application (within milliseconds and without cold starts). No infrastructure provisioning or maintenance is required. Developers can now deploy their Fermyon Cloud Key Value Store applications simply by running `spin cloud deploy`.
+Fermyon Cloud now supports [Key Value Store](/spin/kv-store-api-guide). While Spin applications are well suited for event-driven, stateless workloads, these serverless workloads often rely on external services to persist state beyond the lifespan of a single request. With the introduction of [Fermyon Cloud Key Value Store](https://www.fermyon.com/blog/introducing-fermyon-cloud-key-value-store), you can now persist non-relational data in a key/value store that is always available for your serverless application (within milliseconds and without cold starts). No infrastructure provisioning or maintenance is required. Developers can now deploy their Fermyon Cloud Key Value Store applications simply by running `spin cloud deploy`.
 
 <img src="https://www.fermyon.com/static/image/twc-introducing-fermyon-cloud-key-value-store.jpg" alt="Key Value Store">
 
@@ -16,7 +16,7 @@ Fermyon Cloud now supports [Key Value Store](https://developer.fermyon.com/spin/
 
 References:
 
-- [Spin Key Value API Guide](https://developer.fermyon.com/spin/kv-store-api-guide) 
-- [Spin Key Value Tutorial](https://developer.fermyon.com/spin/kv-store-tutorial)
+- [Spin Key Value API Guide](/spin/kv-store-api-guide) 
+- [Spin Key Value Tutorial](/spin/kv-store-tutorial)
 - [Introducing Fermyon Cloud Key Store](https://www.fermyon.com/blog/introducing-fermyon-cloud-key-value-store)
-- [Cloud Limitations](https://developer.fermyon.com/cloud/faq)
+- [Cloud Limitations](/cloud/faq)

--- a/content/cloud/changelog/custom-fermyon-subdomain.md
+++ b/content/cloud/changelog/custom-fermyon-subdomain.md
@@ -10,7 +10,7 @@ image = "/static/image/twc-custom-subdomains-in-cloud.jpg"
 
 ---
 
-Fermyon Cloud users can now apply custom Fermyon subdomains to their Spin applications. By default, every Spin application recieves a domain name that has the following format: `<app-name>-<randomstring>.fermyon.app`. With custom Fermyon subdomains, users can choose their preferred subdomain name to be appended to the `.fermyon.app` apex domain. To learn more, follow the [custom Fermyon subdomain tutorial](https://developer.fermyon.com/cloud/custom-fermyon-subdomain). 
+Fermyon Cloud users can now apply custom Fermyon subdomains to their Spin applications. By default, every Spin application recieves a domain name that has the following format: `<app-name>-<randomstring>.fermyon.app`. With custom Fermyon subdomains, users can choose their preferred subdomain name to be appended to the `.fermyon.app` apex domain. To learn more, follow the [custom Fermyon subdomain tutorial](/cloud/custom-fermyon-subdomain). 
 
 <img src="/static/image/changelog/twc-custom-subdomains-in-cloud.jpg" alt="Custom Fermyon Subdomains">
 
@@ -18,5 +18,5 @@ Fermyon Cloud users can now apply custom Fermyon subdomains to their Spin applic
 
 References:
 
-- [Custom Fermyon Subdomain Tutorial](https://developer.fermyon.com/cloud/custom-fermyon-subdomain) 
-- [Cloud Limitations](https://developer.fermyon.com/cloud/faq)
+- [Custom Fermyon Subdomain Tutorial](/cloud/custom-fermyon-subdomain) 
+- [Cloud Limitations](/cloud/faq)

--- a/content/cloud/changelog/gh-actions-spin-deploy.md
+++ b/content/cloud/changelog/gh-actions-spin-deploy.md
@@ -13,7 +13,7 @@ Fermyon has recently released a collection of [GitHub Actions](https://github.co
 - `fermyon/actions/spin/push` - pushes a Spin application to a registry
 - `fermyon/actions/spin/deploy` - deploys a Spin application to Fermyon Cloud
 
-Using `spin/deploy`, you can now set up a Continuous Deployment pipeline on Fermyon Cloud. Whenever you merge a pull request into your GitHub repository of choice, `spin/deploy` will trigger a new Spin application deployment. You can learn more about the set-up for this process with our [GitHub Actions tutorial](https://developer.fermyon.com/cloud/github-actions).
+Using `spin/deploy`, you can now set up a Continuous Deployment pipeline on Fermyon Cloud. Whenever you merge a pull request into your GitHub repository of choice, `spin/deploy` will trigger a new Spin application deployment. You can learn more about the set-up for this process with our [GitHub Actions tutorial](/cloud/github-actions).
 
 <img src="/static/image/changelog/spin-gh-actions.png" alt="GitHub Actions">
 

--- a/content/cloud/changelog/request-metrics-in-cloud.md
+++ b/content/cloud/changelog/request-metrics-in-cloud.md
@@ -7,7 +7,7 @@ tags = ["observability"]
 type= "changelog_post"
 ---
 
-You can now see your Spin application’s request count over time in the Fermyon Cloud User Interface (UI). Request count is defined as the number of times your Spin application’s [HTTP trigger](https://developer.fermyon.com/spin/http-trigger) has been called while running on Fermyon Cloud. To view an Spin application’s request count data over time, log into Fermyon Cloud and click on the application of interest. Feel free to reach out to us on [Discord](https://discord.gg/AAFNfS7NGf) and let us know what you think.  
+You can now see your Spin application’s request count over time in the Fermyon Cloud User Interface (UI). Request count is defined as the number of times your Spin application’s [HTTP trigger](/spin/http-trigger) has been called while running on Fermyon Cloud. To view an Spin application’s request count data over time, log into Fermyon Cloud and click on the application of interest. Feel free to reach out to us on [Discord](https://discord.gg/AAFNfS7NGf) and let us know what you think.  
 
 <img src="/static/image/changelog/metrics-request-count.gif" alt="Demo of request count metrics in Fermyon Cloud.">
 

--- a/content/cloud/data-postgres.md
+++ b/content/cloud/data-postgres.md
@@ -50,7 +50,7 @@ Installed 1 template(s)
 
 ## Creating Our New Spin Application
 
-The official Spin CLI documentation also has instructions on how to [create a new Spin application](https://developer.fermyon.com/cloud/cli-reference#new), from an existing template. Using the docs as a reference, we can perform the following:
+The official Spin CLI documentation also has instructions on how to [create a new Spin application](/cloud/cli-reference#new), from an existing template. Using the docs as a reference, we can perform the following:
 
 <!-- @selectiveCpy -->
 

--- a/content/cloud/data-redis.md
+++ b/content/cloud/data-redis.md
@@ -59,7 +59,7 @@ The template we are interested in is `http-rust`.
 
 ## Creating Our New Spin Application
 
-The official Spin CLI documentation also has instructions on how to [create a new Spin application](https://developer.fermyon.com/cloud/cli-reference#new). Let's go ahead and create a new `http-rust` application: 
+The official Spin CLI documentation also has instructions on how to [create a new Spin application](/cloud/cli-reference#new). Let's go ahead and create a new `http-rust` application: 
 
 <!-- @selectiveCpy -->
 

--- a/content/cloud/faq.md
+++ b/content/cloud/faq.md
@@ -42,23 +42,23 @@ Fermyon Cloud supports Spin CLI v0.6.0 or newer. That being said, there are cert
 | Feature | SDK Supported? |
 |-----|-----|
 | **Triggers** |
-| [HTTP](https://developer.fermyon.com/spin/http-trigger) | Supported |
-| [Redis](https://developer.fermyon.com/spin/redis-trigger) | Not supported |
+| [HTTP](/spin/http-trigger) | Supported |
+| [Redis](/spin/redis-trigger) | Not supported |
 | **APIs** |
-| [Outbound HTTP](https://developer.fermyon.com/spin/rust-components.md#sending-outbound-http-requests) | Supported |
-| [Key Value Storage](https://developer.fermyon.com/spin/kv-store-api-guide) | Supported (only default store) |
-| [MySQL](https://developer.fermyon.com/spin/rdbms-storage#using-mysql-and-postgresql-from-applications) | Supported |
-| [PostgreSQL](https://developer.fermyon.com/spin/rdbms-storage#using-mysql-and-postgresql-from-applications) | Supported |
-| [Outbound Redis](https://developer.fermyon.com/spin/rust-components.md#storing-data-in-redis-from-rust-components) | Supported |
+| [Outbound HTTP](/spin/rust-components.md#sending-outbound-http-requests) | Supported |
+| [Key Value Storage](/spin/kv-store-api-guide) | Supported (only default store) |
+| [MySQL](/spin/rdbms-storage#using-mysql-and-postgresql-from-applications) | Supported |
+| [PostgreSQL](/spin/rdbms-storage#using-mysql-and-postgresql-from-applications) | Supported |
+| [Outbound Redis](/spin/rust-components.md#storing-data-in-redis-from-rust-components) | Supported |
 | **Extensibility** |
-| [Custom Triggers](https://developer.fermyon.com/spin/extending-and-embedding) | Not supported |
+| [Custom Triggers](/spin/extending-and-embedding) | Not supported |
 
-To learn more about what feature support looks like for various programming languages, visit the [Spin Language Support Guide](https://developer.fermyon.com/spin/language-support-overview.md).
+To learn more about what feature support looks like for various programming languages, visit the [Spin Language Support Guide](/spin/language-support-overview.md).
 
 ### Other Limitations
 
 - You cannot communicate between Spin applications using local name resolution
-- [Runtime configuration and secrets](https://developer.fermyon.com/spin/dynamic-configuration#runtime-configuration) are not supported at this time
+- [Runtime configuration and secrets](/spin/dynamic-configuration#runtime-configuration) are not supported at this time
 
 ## Frequently Asked Questions
 

--- a/content/common/cli-reference.md
+++ b/content/common/cli-reference.md
@@ -1274,7 +1274,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-**Note:** For additional information, please see the [Managing Plugins](https://developer.fermyon.com/spin/managing-plugins) and/or [Creating Plugins](https://developer.fermyon.com/spin/plugin-authoring) sections of the documentation.
+**Note:** For additional information, please see the [Managing Plugins](/spin/managing-plugins) and/or [Creating Plugins](/spin/plugin-authoring) sections of the documentation.
 
 ### OCI Registry
 
@@ -1808,7 +1808,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-**Note:** For additional information, please see the [Managing Templates](https://developer.fermyon.com/spin/managing-templates) and/or [Creating Templates](https://developer.fermyon.com/spin/template-authoring) sections of the documentation.
+**Note:** For additional information, please see the [Managing Templates](/spin/managing-templates) and/or [Creating Templates](/spin/template-authoring) sections of the documentation.
 
 ### Up
 

--- a/content/common/contributing-docs.md
+++ b/content/common/contributing-docs.md
@@ -145,7 +145,7 @@ The no copy annotation (`<!-- @nocpy -->`) precedes a code block where no copy a
 Some generic code not intended for copying/pasting
 ```
 
-Multi-tab code blocks [have recently been implemented](https://github.com/fermyon/developer/pull/239). Examples can be seen in the [Spin](https://developer.fermyon.com/spin/install#installing-spin) installer documentation](https://developer.fermyon.com/spin/install#installing-spin) and [Spin Key/Value documentation](https://developer.fermyon.com/spin/kv-store-tutorial#the-spin-toml-file). The above examples demonstrate how tabs can either represent platforms i.e. `Windows`, `Linux` and `macOS` or represent specific programming languages i.e. `Rust`, `JavaScript` and `Golang` etc. Here is a brief example of how to implement multi-tab code blocks when writing technical documentation for this site, using markdown.
+Multi-tab code blocks [have recently been implemented](https://github.com/fermyon/developer/pull/239). Examples can be seen in the [Spin](/spin/install#installing-spin) installer documentation](/spin/install#installing-spin) and [Spin Key/Value documentation](/spin/kv-store-tutorial#the-spin-toml-file). The above examples demonstrate how tabs can either represent platforms i.e. `Windows`, `Linux` and `macOS` or represent specific programming languages i.e. `Rust`, `JavaScript` and `Golang` etc. Here is a brief example of how to implement multi-tab code blocks when writing technical documentation for this site, using markdown.
 
 The first step to implementing multi-tab code blocks is placing the `enable_shortcodes = true` configuration at the start of the `.md` file. Specifically, in the `.md` file's frontmatter.
 

--- a/content/spin/api-guides-overview.md
+++ b/content/spin/api-guides-overview.md
@@ -10,13 +10,13 @@ The following table shows the status of the interfaces Spin provides to applicat
 
 | Host Capabilities/Interfaces           | Stability  |    Cloud    |
 |----------------------------------------|----------|-------|
-| [HTTP Trigger](https://developer.fermyon.com/spin/http-trigger)                          | Stable   | Yes   |
-| [Redis Trigger](https://developer.fermyon.com/spin/redis-trigger)                         | Stable   | No  |
-| [Outbound HTTP](https://developer.fermyon.com/spin/http-outbound)                          | Stable   | Yes   |
-| [Outbound Redis](https://developer.fermyon.com/spin/redis-outbound)                         | Stable  | Yes   |
-| [Dynamic Configuration](https://developer.fermyon.com/spin/dynamic-configuration)                         | Experimental | No |
-| [PostgreSQL](https://developer.fermyon.com/spin/rdbms-storage)                             | Experimental | Yes |
-| [MySQL](https://developer.fermyon.com/spin/rdbms-storage)                                  | Experimental | Yes |
-| [Key-value Storage](https://developer.fermyon.com/spin/kv-store-api-guide)                      | Stabilizing | Yes |
+| [HTTP Trigger](/spin/http-trigger)                          | Stable   | Yes   |
+| [Redis Trigger](/spin/redis-trigger)                         | Stable   | No  |
+| [Outbound HTTP](/spin/http-outbound)                          | Stable   | Yes   |
+| [Outbound Redis](/spin/redis-outbound)                         | Stable  | Yes   |
+| [Dynamic Configuration](/spin/dynamic-configuration)                         | Experimental | No |
+| [PostgreSQL](/spin/rdbms-storage)                             | Experimental | Yes |
+| [MySQL](/spin/rdbms-storage)                                  | Experimental | Yes |
+| [Key-value Storage](/spin/kv-store-api-guide)                      | Stabilizing | Yes |
 
-For more information about what is possible in the programming language of your choice, please see our [Language Support Overview](https://developer.fermyon.com/spin/language-support-overview).
+For more information about what is possible in the programming language of your choice, please see our [Language Support Overview](/spin/language-support-overview).

--- a/content/spin/cache.md
+++ b/content/spin/cache.md
@@ -13,7 +13,7 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/cache.md"
 
 ## The Spin Registry Cache
 
-A running Spin application can [fetch resources from remote registries](https://developer.fermyon.com/spin/spin-oci) and individual component sources via HTTP endpoints. These resources naturally consume network bandwidth. To ensure network efficiency, and to prevent waiting to download the same files every time an application is started, Spin automatically maintains a local `spin/registry` cache.
+A running Spin application can [fetch resources from remote registries](/spin/spin-oci) and individual component sources via HTTP endpoints. These resources naturally consume network bandwidth. To ensure network efficiency, and to prevent waiting to download the same files every time an application is started, Spin automatically maintains a local `spin/registry` cache.
 
 ## Clearing the Registry Cache
 

--- a/content/spin/distributing-apps.md
+++ b/content/spin/distributing-apps.md
@@ -80,7 +80,7 @@ $ spin up -f ghcr.io/alyssa-p-hacker/hello-world:v1
 
 > Remember that if the artifact is private you will need to be logged in, with permission to access it.
 
-> Spin optimises downloads using a local [registry cache](https://developer.fermyon.com/spin/cache).
+> Spin optimises downloads using a local [registry cache](/spin/cache).
 
 ### Running Published Applications by Digest
 

--- a/content/spin/dynamic-configuration.md
+++ b/content/spin/dynamic-configuration.md
@@ -151,7 +151,7 @@ url = "redis://localhost"
 
 Whilst a single default store may be sufficient for certain application use cases, each Spin application can be configured to support multiple stores of any `type`, as shown in the `runtime-config.toml` file below:
 
-> **Note:** At present, when deploying an application to Fermyon Cloud only the single "default" key-value store is supported. To see more about Spin support on Fermyon Cloud, visit the [limitations documentation](http://localhost:3000/cloud/faq#spin-limitations):
+> **Note:** At present, when deploying an application to Fermyon Cloud only the single "default" key-value store is supported. To see more about Spin support on Fermyon Cloud, visit the [limitations documentation](/cloud/faq#spin-limitations):
 
 ```toml
 # This defines a new store named user_data

--- a/content/spin/kv-store-tutorial.md
+++ b/content/spin/kv-store-tutorial.md
@@ -6,9 +6,9 @@ enable_shortcodes = true
 url = "https://github.com/fermyon/developer/blob/main/content/spin/kv-store-tutorial.md"
 
 ---
-- [Key Value Storage With Spin Applications](#key-value-storage-with-spin-applications)
+- [Key Value Store With Spin Applications](#key-value-store-with-spin-applications)
 - [Tutorial Prerequisites](#tutorial-prerequisites)
-- [Creating a New Application](#creating-a-new-application)
+- [Creating a New Spin Application](#creating-a-new-spin-application)
 - [Configuration](#configuration)
   - [The Spin TOML File](#the-spin-toml-file)
 - [Write Code to Save and Load Data](#write-code-to-save-and-load-data)
@@ -43,7 +43,7 @@ $ spin --version
 
 ## Creating a New Spin Application
 
-Let's create a Spin application that will send and retreive data from a key value store. To make things easy, we'll start from a template using the following commands ([learn more](https://developer.fermyon.com/spin/quickstart#creating-a-new-spin-application-from-a-template)):
+Let's create a Spin application that will send and retreive data from a key value store. To make things easy, we'll start from a template using the following commands ([learn more](/spin/quickstart#creating-a-new-spin-application-from-a-template)):
 
 {{ tabs "sdk-type" }}
 

--- a/content/spin/language-support-overview.md
+++ b/content/spin/language-support-overview.md
@@ -16,16 +16,16 @@ This page contains information about language support for Spin features:
 | Feature | SDK Supported? |
 |-----|-----|
 | **Triggers** |
-| [HTTP](https://developer.fermyon.com/spin/http-trigger) | Supported |
-| [Redis](https://developer.fermyon.com/spin/redis-trigger) | Supported |
+| [HTTP](/spin/http-trigger) | Supported |
+| [Redis](/spin/redis-trigger) | Supported |
 | **APIs** |
-| [Outbound HTTP](https://developer.fermyon.com/spin/rust-components.md#sending-outbound-http-requests) | Supported |
-| [Key Value Storage](https://developer.fermyon.com/spin/kv-store-api-guide) | Supported |
-| [MySQL](https://developer.fermyon.com/spin/rdbms-storage#using-mysql-and-postgresql-from-applications) | Supported |
-| [PostgreSQL](https://developer.fermyon.com/spin/rdbms-storage#using-mysql-and-postgresql-from-applications) | Supported |
-| [Outbound Redis](https://developer.fermyon.com/spin/rust-components.md#storing-data-in-redis-from-rust-components) | Supported |
+| [Outbound HTTP](/spin/rust-components.md#sending-outbound-http-requests) | Supported |
+| [Key Value Storage](/spin/kv-store-api-guide) | Supported |
+| [MySQL](/spin/rdbms-storage#using-mysql-and-postgresql-from-applications) | Supported |
+| [PostgreSQL](/spin/rdbms-storage#using-mysql-and-postgresql-from-applications) | Supported |
+| [Outbound Redis](/spin/rust-components.md#storing-data-in-redis-from-rust-components) | Supported |
 | **Extensibility** |
-| [Authoring Custom Triggers](https://developer.fermyon.com/spin/extending-and-embedding) | Supported |
+| [Authoring Custom Triggers](/spin/extending-and-embedding) | Supported |
 
 {{ blockEnd }}
 
@@ -34,14 +34,14 @@ This page contains information about language support for Spin features:
 | Feature | SDK Supported? |
 |-----|-----|
 | **Triggers** |
-| [HTTP](https://developer.fermyon.com/spin/javascript-components#http-components) | Supported |
+| [HTTP](/spin/javascript-components#http-components) | Supported |
 | Redis | Not Supported |
 | **APIs** |
-| [Outbound HTTP](https://developer.fermyon.com/spin/javascript-components#sending-outbound-http-requests) | Supported |
-| [Key Value Storage](https://developer.fermyon.com/spin/kv-store-api-guide) | Supported |
+| [Outbound HTTP](/spin/javascript-components#sending-outbound-http-requests) | Supported |
+| [Key Value Storage](/spin/kv-store-api-guide) | Supported |
 | MySQL | Not Supported |
 | PostgreSQL| Not Supported |
-| [Outbound Redis](https://developer.fermyon.com/spin/javascript-components#storing-data-in-redis-from-jsts-components) | Supported |
+| [Outbound Redis](/spin/javascript-components#storing-data-in-redis-from-jsts-components) | Supported |
 | **Extensibility** |
 | Authoring Custom Triggers | Not Supported |
 
@@ -52,14 +52,14 @@ This page contains information about language support for Spin features:
 | Feature | SDK Supported? |
 |-----|-----|
 | **Triggers** |
-| [HTTP](https://developer.fermyon.com/spin/python-components#a-simple-http-components-example) | Supported |
+| [HTTP](/spin/python-components#a-simple-http-components-example) | Supported |
 | Redis | Not Supported |
 | **APIs** |
-| [Outbound HTTP](https://developer.fermyon.com/spin/python-components#an-outbound-http-example) | Supported |
-| [Key Value Storage](https://developer.fermyon.com/spin/kv-store-api-guide) | Supported |
+| [Outbound HTTP](/spin/python-components#an-outbound-http-example) | Supported |
+| [Key Value Storage](/spin/kv-store-api-guide) | Supported |
 | MySQL | Not Supported |
 | PostgreSQL | Not Supported |
-| [Outbound Redis](https://developer.fermyon.com/spin/python-components#an-outbound-redis-example) | Supported |
+| [Outbound Redis](/spin/python-components#an-outbound-redis-example) | Supported |
 | **Extensibility** |
 | Authoring Custom Triggers | Not Supported |
 
@@ -70,14 +70,14 @@ This page contains information about language support for Spin features:
 | Feature | SDK Supported? |
 |-----|-----|
 | **Triggers** |
-| [HTTP](https://developer.fermyon.com/spin/go-components#http-components) | Supported |
-| [Redis](https://developer.fermyon.com/spin/go-components#redis-components) | Supported |
+| [HTTP](/spin/go-components#http-components) | Supported |
+| [Redis](/spin/go-components#redis-components) | Supported |
 | **APIs** |
-| [Outbound HTTP](https://developer.fermyon.com/spin/go-components#sending-outbound-http-requests) | Supported |
-| [Key Value Storage](https://developer.fermyon.com/spin/kv-store-api-guide) | Supported |
+| [Outbound HTTP](/spin/go-components#sending-outbound-http-requests) | Supported |
+| [Key Value Storage](/spin/kv-store-api-guide) | Supported |
 | MySQL | Not Supported |
 | PostgreSQL | Not Supported |
-| [Outbound Redis](https://developer.fermyon.com/spin/go-components#storing-data-in-redis-from-go-components) | Supported |
+| [Outbound Redis](/spin/go-components#storing-data-in-redis-from-go-components) | Supported |
 | **Extensibility** |
 | Authoring Custom Triggers | Not Supported |
 

--- a/content/spin/plugin-authoring.md
+++ b/content/spin/plugin-authoring.md
@@ -57,7 +57,7 @@ $ spin plugins install js2wasm
 With the plugin installed, you can now call `spin js2wasm` to run it. In this
 case, for example, you might call it from your JavaScript application's npm
 build script. Learn more about building Spin components in JavaScript
-[here](https://developer.fermyon.com/spin/javascript-components.md).
+[here](/spin/javascript-components.md).
 
 To upgrade installed plugins to newer versions, run `spin plugin update` to
 fetch the latest plugins to the local catalogue and `spin plugin upgrade` to perform the

--- a/content/spin/python-components.md
+++ b/content/spin/python-components.md
@@ -38,7 +38,7 @@ $ spin plugin update
 $ spin plugin install py2wasm
 ```
 
-**Please note:** For more information about managing `spin plugins`, see the [plugins section](https://developer.fermyon.com/common/cli-reference#plugins) in the Spin Command Line Interface (CLI) documentation.
+**Please note:** For more information about managing `spin plugins`, see the [plugins section](/common/cli-reference#plugins) in the Spin Command Line Interface (CLI) documentation.
 
 ## Spin's Python HTTP Request Handler Template
 
@@ -66,7 +66,7 @@ Installed 1 template(s)
 +---------------------------------------------+
 ```
 
-**Please note:** For more information about managing `spin templates`, see the [templates section](https://developer.fermyon.com/common/cli-reference#templates) in the Spin Command Line Interface (CLI) documentation.
+**Please note:** For more information about managing `spin templates`, see the [templates section](/common/cli-reference#templates) in the Spin Command Line Interface (CLI) documentation.
 
 ## Structure of a Python Component
 

--- a/content/spin/spin-oci.md
+++ b/content/spin/spin-oci.md
@@ -22,7 +22,7 @@ With Spin's Open Container Initiative (OCI) support, you can package and save yo
 
 ## Prerequisites
 
-First, follow [this guide](https://developer.fermyon.com/spin/install) to ensure you have the latest version of Spin installed (this tutorial refers to Spin 1.0 and above). You can check the Spin version using the following command:
+First, follow [this guide](/spin/install) to ensure you have the latest version of Spin installed (this tutorial refers to Spin 1.0 and above). You can check the Spin version using the following command:
 
 <!-- @selectiveCpy -->
 
@@ -77,7 +77,7 @@ Now we're ready to push the application. Run the `spin registry push` command to
 $ spin registry push ghcr.io/USERNAME/spin-react-fullstack:v1
 ```
 
-> **Note:** You can find more information on `spin registry` options and subcommands in the [Spin CLI Reference documentation](https://developer.fermyon.com/common/cli-reference#oci-registry).
+> **Note:** You can find more information on `spin registry` options and subcommands in the [Spin CLI Reference documentation](/common/cli-reference#oci-registry).
 
 You now have a Spin application stored in your registry. You can see the artifact under packages in the [GitHub UI](https://docs.github.com/en/packages/learn-github-packages/viewing-packages#viewing-a-repositorys-packages).
 


### PR DESCRIPTION
This is an update of the `bartholomew.wasm` file in the modules directory to implement fixes for relative vs absolute URLs and also improvements i.e. allowing dynamic URLs (so a user is not thrust over to the `common` section's menu if clicking on a shared document that exists in the common area).