### PR TITLE
Update Bartholomew in workflow, to lastest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install bart
         run: |
-          curl -LOs https://github.com/fermyon/bartholomew/releases/download/v0.3.0/bart
+          curl -LOs https://github.com/fermyon/bartholomew/releases/download/v0.7.0/bart
           chmod +x bart
           mv bart /usr/local/bin
 


### PR DESCRIPTION
The version of Bartholomew in the build/workflow config can be at the latest version as new versions of Bartholomew are released.