### PR TITLE
Random API Update - Ready for approval

### DIFF
--- a/content/spin/go-components.md
+++ b/content/spin/go-components.md
@@ -88,7 +88,6 @@ inserts a custom header into the response before returning:
 package main
 
 import (
- "bytes"
  "fmt"
  "net/http"
  "os"
@@ -98,10 +97,10 @@ import (
 
 func init() {
  spinhttp.Handle(func(w http.ResponseWriter, r *http.Request) {
-  r, _ := spinhttp.Get("https://random-data-api.fermyon.app/animals/json")
+    resp, _ := spinhttp.Get("https://random-data-api.fermyon.app/animals/json")
 
-  fmt.Fprintln(w, r.Body)
-  fmt.Fprintln(w, r.Header.Get("content-type"))
+  fmt.Fprintln(w, resp.Body)
+  fmt.Fprintln(w, resp.Header.Get("content-type"))
 
   // `spin.toml` is not configured to allow outbound HTTP requests to this host,
   // so this request will fail.

--- a/content/spin/go-components.md
+++ b/content/spin/go-components.md
@@ -123,7 +123,7 @@ $ tinygo build -wasm-abi=generic -target=wasi -no-debug -o main.wasm main.go
 ```
 
 Before we can execute this component, we need to add the
-`fermyon.app` domain to the application manifest `allowed_http_hosts`
+`random-data-api.fermyon.app` domain to the application manifest `allowed_http_hosts`
 list containing the list of domains the component is allowed to make HTTP
 requests to:
 

--- a/content/spin/go-components.md
+++ b/content/spin/go-components.md
@@ -76,14 +76,14 @@ familiar if you are a Go developer
 
 If allowed, Spin components can send outbound requests to HTTP endpoints. Let's
 see an example of a component that makes a request to
-[an API that returns random dog facts](https://some-random-api.ml/facts/dog) and
+[an API that returns random animal facts](https://random-data-api.fermyon.app/animals/json) and
 inserts a custom header into the response before returning:
 
 <!-- @nocpy -->
 
 ```go
 // A Spin component written in Go that sends a request to an API
-// with random dog facts.
+// with random animal facts.
 
 package main
 
@@ -98,7 +98,7 @@ import (
 
 func init() {
  spinhttp.Handle(func(w http.ResponseWriter, r *http.Request) {
-  r, _ := spinhttp.Get("https://some-random-api.ml/facts/dog")
+  r, _ := spinhttp.Get("https://random-data-api.fermyon.app/animals/json")
 
   fmt.Fprintln(w, r.Body)
   fmt.Fprintln(w, r.Header.Get("content-type"))
@@ -123,7 +123,7 @@ $ tinygo build -wasm-abi=generic -target=wasi -no-debug -o main.wasm main.go
 ```
 
 Before we can execute this component, we need to add the
-`some-random-api.ml` domain to the application manifest `allowed_http_hosts`
+`fermyon.app` domain to the application manifest `allowed_http_hosts`
 list containing the list of domains the component is allowed to make HTTP
 requests to:
 
@@ -139,7 +139,7 @@ version = "1.0.0"
 [[component]]
 id = "tinygo-hello"
 source = "main.wasm"
-allowed_http_hosts = [ "some-random-api.ml" ]
+allowed_http_hosts = [ "fermyon.app" ]
 [component.trigger]
 route = "/hello"
 ```
@@ -160,7 +160,7 @@ server: spin/0.1.0
 content-length: 85
 date: Fri, 18 Mar 2022 23:27:33 GMT
 
-{{"fact":"Seventy percent of people sign their dog's name on their holiday cards."}}
+{"timestamp":1684299253331,"fact":"Reindeer grow new antlers every year"}
 ```
 
 > Without the `allowed_http_hosts` field populated properly in `spin.toml`,

--- a/content/spin/go-components.md
+++ b/content/spin/go-components.md
@@ -139,7 +139,7 @@ version = "1.0.0"
 [[component]]
 id = "tinygo-hello"
 source = "main.wasm"
-allowed_http_hosts = [ "fermyon.app" ]
+allowed_http_hosts = [ "random-data-api.fermyon.app" ]
 [component.trigger]
 route = "/hello"
 ```

--- a/content/spin/http-outbound.md
+++ b/content/spin/http-outbound.md
@@ -93,7 +93,7 @@ HTTP functions and classes are available in the `spin_http` module. The function
 from spin_http import Request, Response, http_send
 
 response = http_send(
-    Request("GET", "https://some-random-api.ml/facts/dog", [], None))
+    Request("GET", "https://random-data-api.fermyon.app/animals/json", [], None))
 ```
 
 **Notes**
@@ -115,7 +115,7 @@ import (
 	spinhttp "github.com/fermyon/spin/sdk/go/http"
 )
 
-res1, err1 := spinhttp.Get("https://some-random-api.ml/facts/dog")
+res1, err1 := spinhttp.Get("https://random-data-api.fermyon.app/animals/json")
 res2, err2 := spinhttp.Post("https://example.com/users", "application/json", json)
 
 request, err := http.NewRequest("PUT", "https://example.com/users/1", bytes.NewBufferString(user1))
@@ -142,7 +142,7 @@ By default, Spin components are not allowed to make outgoing HTTP requests. This
 
 ```toml
 [component]
-allowed_http_hosts = [ "dog-facts.example.com", "api.example.com:8080" ]
+allowed_http_hosts = [ "random-data-api.fermyon.app", "api.example.com:8080" ]
 ```
 
 The Wasm module can make HTTP requests _only_ to the specified hosts. If a port is specified, the module can make requests only to that port; otherwise, the module can make requests only on the default HTTP and HTTPS ports. Requests to other hosts (or ports) will fail with an error.

--- a/content/spin/javascript-components.md
+++ b/content/spin/javascript-components.md
@@ -217,7 +217,7 @@ let text = JSON.parse(decoder.decode(request.body))
 
 If allowed, Spin components can send outbound HTTP requests.
 Let's see an example of a component that makes a request to
-[an API that returns random dog facts](https://some-random-api.ml/facts/dog) and
+[an API that returns random animal facts](https://random-data-api.fermyon.app/animals/json) and
 inserts a custom header into the response before returning:
 
 <!-- @nocpy -->
@@ -230,13 +230,13 @@ const decoder = new TextDecoder()
 
 export const handleRequest: HandleRequest = async function (request: HttpRequest): Promise<HttpResponse> {
 
-    const dogFact = await fetch("https://some-random-api.ml/facts/dog")
+    const animalFact = await fetch("https://random-data-api.fermyon.app/animals/json")
 
-    const dogFactBody = await dogFact.text()
+    const animalFactBody = await animalFact.text()
 
     const env = JSON.stringify(process.env)
 
-    const body = `Here's a dog fact: ${dogFactBody}\n`
+    const body = `Here's an animal fact: ${animalFactBody}\n`
 
     return {
         status: 200,
@@ -246,7 +246,7 @@ export const handleRequest: HandleRequest = async function (request: HttpRequest
 }
 ```
 
-Before we can execute this component, we need to add the `some-random-api.ml`
+Before we can execute this component, we need to add the `fermyon.app`
 domain to the application manifest `allowed_http_hosts` list containing the list of
 domains the component is allowed to make HTTP requests to:
 
@@ -266,7 +266,7 @@ object = { default = "teapot" }
 [[component]]
 id = "hello"
 source = "target/spin-http-js.wasm"
-allowed_http_hosts = ["https://some-random-api.ml"]
+allowed_http_hosts = ["https://fermyon.app"]
 [component.trigger]
 route = "/hello"
 [component.build]
@@ -287,7 +287,7 @@ content-type: application/json; charset=utf-8
 content-length: 185
 server: spin/0.1.0
 
-Here's a dog fact: {"fact":"It's a myth that dogs only see in black and white. In fact, it's believed that dogs see primarily in blue, greenish-yellow, yellow and various shades of gray."}
+Here's an animal fact: {"timestamp":1684299253331,"fact":"Reindeer grow new antlers every year"}
 ```
 
 > Without the `allowed_http_hosts` field populated properly in `spin.toml`,

--- a/content/spin/javascript-components.md
+++ b/content/spin/javascript-components.md
@@ -266,7 +266,7 @@ object = { default = "teapot" }
 [[component]]
 id = "hello"
 source = "target/spin-http-js.wasm"
-allowed_http_hosts = ["https://fermyon.app"]
+allowed_http_hosts = ["random-data-api.fermyon.app"]
 [component.trigger]
 route = "/hello"
 [component.build]

--- a/content/spin/javascript-components.md
+++ b/content/spin/javascript-components.md
@@ -223,16 +223,13 @@ inserts a custom header into the response before returning:
 <!-- @nocpy -->
 
 ```javascript
-import { HandleRequest, HttpRequest, HttpResponse } from "@fermyon/spin-sdk"
+const encoder = new TextEncoder("utf-8")
+const decoder = new TextDecoder("utf-8")
 
-const encoder = new TextEncoder()
-const decoder = new TextDecoder()
-
-export const handleRequest: HandleRequest = async function (request: HttpRequest): Promise<HttpResponse> {
-
+export async function handleRequest(request) {
     const animalFact = await fetch("https://random-data-api.fermyon.app/animals/json")
 
-    const animalFactBody = await animalFact.text()
+    const animalFactBody = decoder.decode(await animalFact.arrayBuffer() || new Uint8Array())
 
     const env = JSON.stringify(process.env)
 

--- a/content/spin/javascript-components.md
+++ b/content/spin/javascript-components.md
@@ -246,7 +246,7 @@ export const handleRequest: HandleRequest = async function (request: HttpRequest
 }
 ```
 
-Before we can execute this component, we need to add the `fermyon.app`
+Before we can execute this component, we need to add the `random-data-api.fermyon.app`
 domain to the application manifest `allowed_http_hosts` list containing the list of
 domains the component is allowed to make HTTP requests to:
 

--- a/content/spin/python-components.md
+++ b/content/spin/python-components.md
@@ -205,7 +205,7 @@ version = "0.1.0"
 [[component]]
 id = "hello-world"
 source = "app.wasm"
-allowed_http_hosts = ["https://random-data-api.fermyon.app"]
+allowed_http_hosts = ["random-data-api.fermyon.app"]
 [component.trigger]
 route = "/..."
 [component.build]

--- a/content/spin/python-components.md
+++ b/content/spin/python-components.md
@@ -171,7 +171,7 @@ Hello from the Python SDK
 
 ## An Outbound HTTP Example
 
-This next example will create an outbound request, to obtain a random fact about dogs, which will be returned to the calling code. If you would like to try this out, you can go ahead and update your existing `app.py` file from the previous step; using the following source code:
+This next example will create an outbound request, to obtain a random fact about animals, which will be returned to the calling code. If you would like to try this out, you can go ahead and update your existing `app.py` file from the previous step; using the following source code:
 
 <!-- @nocpy -->
 
@@ -183,16 +183,16 @@ from os import environ
 def handle_request(request):
 
     response = http_send(
-        Request("GET", "https://some-random-api.ml/facts/dog", [], None))
+        Request("GET", "https://random-data-api.fermyon.app/animals/json", [], None))
 
     return Response(200,
                     [("content-type", "text/plain")],
-                    bytes(f"Here is a dog fact: {str(response.body, 'utf-8')}, the environment: {environ}", "utf-8"))
+                    bytes(f"Here is an animal fact: {str(response.body, 'utf-8')}, the environment: {environ}", "utf-8"))
 ```
 
 ### Configuration
 
-The Spin framework protects your code from making outbound requests to just any URL. For example, if we try to run the above code **without any additional configuration**, we will correctly get the following error `AssertionError: HttpError::DestinationNotAllowed`. To allow our component to request the `some-random-api.ml` domain, all we have to do is add that domain to the specific component of the application that is making the request. Here is an example of an updated `spin.toml` file where we have added `allowed_http_hosts`:
+The Spin framework protects your code from making outbound requests to just any URL. For example, if we try to run the above code **without any additional configuration**, we will correctly get the following error `AssertionError: HttpError::DestinationNotAllowed`. To allow our component to request the `random-data-api.fermyon.app` domain, all we have to do is add that domain to the specific component of the application that is making the request. Here is an example of an updated `spin.toml` file where we have added `allowed_http_hosts`:
 
 ```
 spin_manifest_version = "1"
@@ -205,7 +205,7 @@ version = "0.1.0"
 [[component]]
 id = "hello-world"
 source = "app.wasm"
-allowed_http_hosts = ["https://some-random-api.ml"]
+allowed_http_hosts = ["https://random-data-api.fermyon.app"]
 [component.trigger]
 route = "/..."
 [component.build]
@@ -214,7 +214,7 @@ command = "spin py2wasm app -o app.wasm"
 
 ### Building and Running the Application
 
-If we re-build the application with this new configuration and re-run, we will get our new dog fact:
+If we re-build the application with this new configuration and re-run, we will get our new animal fact:
 
 <!-- @selectiveCpy -->
 
@@ -223,7 +223,7 @@ $ spin build
 $ spin up
 ```
 
-A new request now correctly returns a dog fact from the some-random API endpoint.
+A new request now correctly returns an animal fact from the API endpoint.
 
 <!-- @selectiveCpy -->
 
@@ -234,7 +234,7 @@ HTTP/1.1 200 OK
 content-type: text/plain
 content-length: 130
 
-Here is a dog fact: {"fact":"Dogs and wolves split from a common ancestor around 34,000 years ago."}    
+Here is an animal fact: {"timestamp":1684299253331,"fact":"Reindeer grow new antlers every year"}   
 ```
 
 ## An Outbound Redis Example

--- a/content/spin/rust-components.md
+++ b/content/spin/rust-components.md
@@ -208,7 +208,7 @@ Hello, there!
 
 If allowed, Spin components can send outbound HTTP requests.
 Let's see an example of a component that makes a request to
-[an API that returns random dog facts](https://some-random-api.ml/facts/dog) and
+[an API that returns random animal facts](https://random-data-api.fermyon.app/animals/json) and
 inserts a custom header into the response before returning:
 
 <!-- @nocpy -->
@@ -219,7 +219,7 @@ fn hello_world(_req: Request) -> Result<Response> {
     let mut res = spin_sdk::http::send(
         http::Request::builder()
             .method("GET")
-            .uri("https://some-random-api.ml/facts/dog")
+            .uri("https://random-data-api.fermyon.app/animals/json")
             .body(None)?,
     )?;
 
@@ -267,9 +267,7 @@ content-type: application/json; charset=utf-8
 content-length: 185
 server: spin/0.1.0
 
-{"fact":"It's rumored that, at the end of the Beatles song, 
-\"A Day in the Life,\" Paul McCartney recorded an ultrasonic whistle, 
-audible only to dogs, just for his Shetland sheepdog."}
+{"timestamp":1684299253331,"fact":"Reindeer grow new antlers every year"}   
 ```
 
 > Without the `allowed_http_hosts` field populated properly in `spin.toml`,

--- a/content/spin/rust-components.md
+++ b/content/spin/rust-components.md
@@ -214,25 +214,31 @@ inserts a custom header into the response before returning:
 <!-- @nocpy -->
 
 ```rust
+use anyhow::Result;
+use spin_sdk::{
+    http::{Request, Response},
+    http_component,
+};
+
+/// Send an HTTP request and return the response.
 #[http_component]
-fn hello_world(_req: Request) -> Result<Response> {
-    let mut res = spin_sdk::http::send(
+fn send_outbound(_req: Request) -> Result<Response> {
+    let mut res = spin_sdk::outbound_http::send_request(
         http::Request::builder()
             .method("GET")
             .uri("https://random-data-api.fermyon.app/animals/json")
             .body(None)?,
     )?;
-
     res.headers_mut()
-        .insert(http::header::SERVER, "spin/0.1.0".try_into()?);
-
+        .insert("spin-component", "rust-outbound-http".try_into()?);
+    println!("{:?}", res);
     Ok(res)
 }
 ```
 
 > The `http::Request::builder()` method is provided by the Rust `http` crate. The `http` crate is already added to projects using the Spin `http-rust` template. If you create a project without using this template, you'll need to add the `http` crate yourself via `cargo add http`.
 
-Before we can execute this component, we need to add the `some-random-api.ml`
+Before we can execute this component, we need to add the `random-data-api.fermyon.app`
 domain to the application manifest `allowed_http_hosts` list containing the list of
 domains the component is allowed to make HTTP requests to:
 
@@ -248,7 +254,7 @@ version = "1.0.0"
 [[component]]
 id = "hello"
 source = "target/wasm32-wasi/release/spinhelloworld.wasm"
-allowed_http_hosts = [ "some-random-api.ml" ]
+allowed_http_hosts = ["random-data-api.fermyon.app"]
 [component.trigger]
 route = "/outbound"
 ```


### PR DESCRIPTION
First draft to replace random API endpoint:
- [x] Javascript examples need testing
- [x] Python examples need testing
- [x] Rust examples need testing
- [x] Go examples need testing
- [x] HTTP Outbound examples need testing
- [x] `allowed_http_hosts` needs to be normalised across all examples (Is the protocol needed i.e. `https://`, will subdomain work in config i.e. `random-data-api.fermyon.app` as apposed to just `fermyon.app`?)