### PR TITLE
Update install script to install default plugins and templates

### DIFF
--- a/content/spin/install.md
+++ b/content/spin/install.md
@@ -16,13 +16,13 @@ keywords = "install"
 
 ## Installing Spin
 
-Spin runs on Linux (amd64 and arm64), macOS (Intel and Apple Silicon), and Windows (amd64).
+Spin runs on Linux (amd64 and arm64), macOS (Intel and Apple Silicon), and Windows (amd64):
 
 {{ tabs "os" }}
 
 {{ startTab "Linux"}}
 
-There are multiple ways to install Spin. The easiest is to use the installer script, hosted on this site. The script installs Spin along with a starter set of language templates and plugins.
+There are multiple ways to install Spin. The easiest is to use the installer script, hosted on this site. The script installs Spin along with a starter set of language templates and plugins:
 
 <!-- @selectiveCpy -->
 
@@ -52,7 +52,7 @@ To install the canary version of spin, you should pass the argument `-v canary`.
 
 {{ startTab "macOS"}}
 
-There are multiple ways to install Spin. The easiest is to use the installer script, hosted on this site. The script installs Spin along with a starter set of templates and plugins.
+There are multiple ways to install Spin. The easiest is to use the installer script, hosted on this site. The script installs Spin along with a starter set of templates and plugins:
 
 <!-- @selectiveCpy -->
 

--- a/content/spin/install.md
+++ b/content/spin/install.md
@@ -167,7 +167,7 @@ The install script automatically installs a starter set of templates and plugins
 ```sh
 spin templates install --git https://github.com/fermyon/spin --upgrade
 spin templates install --git https://github.com/fermyon/spin-python-sdk --upgrade
-spin templates install --git "https://github.com/fermyon/spin-js-sdk" --upgrade
+spin templates install --git https://github.com/fermyon/spin-js-sdk --upgrade
 spin plugins update
 spin plugins install js2wasm --yes
 spin plugins install py2wasm --yes

--- a/content/spin/install.md
+++ b/content/spin/install.md
@@ -86,7 +86,7 @@ If using Windows (PowerShell / cmd.exe), you can download <a href="https://githu
 
 Simply unzip the binary release and place the `spin.exe` in your system path.
 
-Next, we recommend you [install a starter set of templates and plugins](#installing-templates-and-plugins).
+This does not install any Spin templates or plugins. For a starter list, see the [Installing Templates and Plugins section](#installing-templates-and-plugins).
 
 If you want to use WSL2 (Windows Subsystem for Linux 2), please follow the instructions for using Linux.
 

--- a/content/spin/install.md
+++ b/content/spin/install.md
@@ -166,7 +166,7 @@ The install script automatically installs a starter set of templates and plugins
 
 ```sh
 spin templates install --git https://github.com/fermyon/spin --upgrade
-spin templates install --git "https://github.com/fermyon/spin-python-sdk" --upgrade
+spin templates install --git https://github.com/fermyon/spin-python-sdk --upgrade
 spin templates install --git "https://github.com/fermyon/spin-js-sdk" --upgrade
 spin plugins update
 spin plugins install js2wasm --yes

--- a/content/spin/install.md
+++ b/content/spin/install.md
@@ -162,7 +162,7 @@ This does not install any Spin templates or plugins. For a starter list, see the
 ## Installing Templates and Plugins
 
 Spin has a variety of templates and plugins to make it easier to create Spin applications in your favorite programming language. 
-The install script automatically installs a starter set of templates and plugins, namely templates from the Spin repository and JavaScript and Python toolchain plugins. If you used a different installation method, the following is a recommended post-installation step:
+The install script automatically installs a starter set of templates and plugins, namely templates from the Spin repository and JavaScript and Python toolchain plugins. If you used a different installation method, we recommend you install these templates and plugins manually, as follows:
 
 ```sh
 spin templates install --git https://github.com/fermyon/spin --upgrade

--- a/content/spin/install.md
+++ b/content/spin/install.md
@@ -86,7 +86,7 @@ If using Windows (PowerShell / cmd.exe), you can download <a href="https://githu
 
 Simply unzip the binary release and place the `spin.exe` in your system path.
 
-Next, we recommend following the steps to install a starter set of [templates and plugins](#installing-templates-and-plugins).
+Next, we recommend you [install a starter set of templates and plugins](#installing-templates-and-plugins).
 
 If you want to use WSL2 (Windows Subsystem for Linux 2), please follow the instructions for using Linux.
 

--- a/content/spin/install.md
+++ b/content/spin/install.md
@@ -52,7 +52,7 @@ To install the canary version of spin, you should pass the argument `-v canary`.
 
 {{ startTab "macOS"}}
 
-There are multiple ways to install Spin. The easiest is to use the installer script, hosted on this site. The script installs Spin along with a starter set of templates and plugins:
+There are multiple ways to install Spin. The easiest is to use the installer script, hosted on this site. The script installs Spin along with a starter set of language templates and plugins:
 
 <!-- @selectiveCpy -->
 

--- a/content/spin/install.md
+++ b/content/spin/install.md
@@ -165,7 +165,7 @@ Spin has a variety of templates and plugins to make it easier to create Spin app
 The install script automatically installs a starter set of templates and plugins, namely templates from the Spin repository and JavaScript and Python toolchain plugins. If you used a different installation method, the following is a recommended post-installation step:
 
 ```sh
-spin templates install --git "https://github.com/fermyon/spin" --upgrade
+spin templates install --git https://github.com/fermyon/spin --upgrade
 spin templates install --git "https://github.com/fermyon/spin-python-sdk" --upgrade
 spin templates install --git "https://github.com/fermyon/spin-js-sdk" --upgrade
 spin plugins update

--- a/content/spin/install.md
+++ b/content/spin/install.md
@@ -11,7 +11,7 @@ keywords = "install"
 - [Verifying the Release Signature](#verifying-the-release-signature)
 - [Building Spin From Source](#building-spin-from-source)
 - [Using Cargo to Install Spin](#using-cargo-to-install-spin)
-- [Install Default Templates and Plugins](#installing-default-templates-and-plugins)
+- [Installing Templates and Plugins](#installing-templates-and-plugins)
 - [Next Steps](#next-steps)
 
 ## Installing Spin
@@ -22,7 +22,7 @@ Spin runs on Linux (amd64 and arm64), macOS (Intel and Apple Silicon), and Windo
 
 {{ startTab "Linux"}}
 
-There are multiple ways to install Spin. The easiest is to use the installer script, hosted on this site. The script installs Spin along with [default templates and plugins](#installing-default-templates-and-plugins).
+There are multiple ways to install Spin. The easiest is to use the installer script, hosted on this site. The script installs Spin along with a starter set of language templates and plugins.
 
 <!-- @selectiveCpy -->
 
@@ -52,7 +52,7 @@ To install the canary version of spin, you should pass the argument `-v canary`.
 
 {{ startTab "macOS"}}
 
-There are multiple ways to install Spin. The easiest is to use the installer script, hosted on this site. The script installs Spin along with [default templates and plugins](#installing-default-templates-and-plugins).
+There are multiple ways to install Spin. The easiest is to use the installer script, hosted on this site. The script installs Spin along with a starter set of templates and plugins.
 
 <!-- @selectiveCpy -->
 
@@ -86,7 +86,7 @@ If using Windows (PowerShell / cmd.exe), you can download <a href="https://githu
 
 Simply unzip the binary release and place the `spin.exe` in your system path.
 
-Next, follow the steps to install the [default templates and plugins](#installing-default-templates-and-plugins).
+Next, we recommend following the steps to install a starter set of [templates and plugins](#installing-templates-and-plugins).
 
 If you want to use WSL2 (Windows Subsystem for Linux 2), please follow the instructions for using Linux.
 
@@ -133,6 +133,8 @@ $ ./target/release/spin --help
 $ sudo apt-get install build-essential libssl-dev pkg-config
 ```
 
+This does not install any Spin templates or plugins. For a starter list, see the [Installing Templates and Plugins section](#installing-templates-and-plugins).
+
 ## Using Cargo to Install Spin
 
 If you have [`cargo`](https://doc.rust-lang.org/cargo/getting-started/installation.html), you can clone the repo and install it to your path:
@@ -155,10 +157,12 @@ $ spin --help
 $ rustup update
 ```
 
-## Installing Default Templates and Plugins
+This does not install any Spin templates or plugins. For a starter list, see the [Installing Templates and Plugins section](#installing-templates-and-plugins).
+
+## Installing Templates and Plugins
 
 Spin has a variety of templates and plugins to make it easier to create Spin applications in your favorite programming language. 
-While the install script automatically installs these, if you used a different installation method, the following is a recommended post-installation step:
+The install script automatically installs a starter set of templates and plugins, namely templates from the Spin repository and JavaScript and Python toolchain plugins. If you used a different installation method, the following is a recommended post-installation step:
 
 ```sh
 spin templates install --git "https://github.com/fermyon/spin" --upgrade
@@ -169,10 +173,15 @@ spin plugins install js2wasm --yes
 spin plugins install py2wasm --yes
 ```
 
-To list installed templates and plugins, run:
+To list installed templates, run:
 
 ```sh
 spin templates list
+```
+
+To list installed and available plugins, run:
+
+```sh
 spin plugins list
 ```
 

--- a/content/spin/install.md
+++ b/content/spin/install.md
@@ -11,6 +11,7 @@ keywords = "install"
 - [Verifying the Release Signature](#verifying-the-release-signature)
 - [Building Spin From Source](#building-spin-from-source)
 - [Using Cargo to Install Spin](#using-cargo-to-install-spin)
+- [Install Default Templates and Plugins](#installing-default-templates-and-plugins)
 - [Next Steps](#next-steps)
 
 ## Installing Spin
@@ -21,7 +22,7 @@ Spin runs on Linux (amd64 and arm64), macOS (Intel and Apple Silicon), and Windo
 
 {{ startTab "Linux"}}
 
-There are multiple ways to install Spin. The easiest is to use the installer script, hosted on this site:
+There are multiple ways to install Spin. The easiest is to use the installer script, hosted on this site. The script installs Spin along with [default templates and plugins](#installing-default-templates-and-plugins).
 
 <!-- @selectiveCpy -->
 
@@ -51,7 +52,7 @@ To install the canary version of spin, you should pass the argument `-v canary`.
 
 {{ startTab "macOS"}}
 
-There are multiple ways to install Spin. The easiest is to use the installer script, hosted on this site:
+There are multiple ways to install Spin. The easiest is to use the installer script, hosted on this site. The script installs Spin along with [default templates and plugins](#installing-default-templates-and-plugins).
 
 <!-- @selectiveCpy -->
 
@@ -84,6 +85,8 @@ To install the canary version of spin, you should pass the argument `-v canary`.
 If using Windows (PowerShell / cmd.exe), you can download <a href="https://github.com/fermyon/spin/releases/latest" class="spin-install" id="spin-install-windows">the Windows binary release of Spin</a>.
 
 Simply unzip the binary release and place the `spin.exe` in your system path.
+
+Next, follow the steps to install the [default templates and plugins](#installing-default-templates-and-plugins).
 
 If you want to use WSL2 (Windows Subsystem for Linux 2), please follow the instructions for using Linux.
 
@@ -150,6 +153,27 @@ $ spin --help
 
 ```bash
 $ rustup update
+```
+
+## Installing Default Templates and Plugins
+
+Spin has a variety of templates and plugins to make it easier to create Spin applications in your favorite programming language. 
+While the install script automatically installs these, if you used a different installation method, the following is a recommended post-installation step:
+
+```sh
+spin templates install --git "https://github.com/fermyon/spin" --upgrade
+spin templates install --git "https://github.com/fermyon/spin-python-sdk" --upgrade
+spin templates install --git "https://github.com/fermyon/spin-js-sdk" --upgrade
+spin plugins update
+spin plugins install js2wasm --yes
+spin plugins install py2wasm --yes
+```
+
+To list installed templates and plugins, run:
+
+```sh
+spin templates list
+spin plugins list
 ```
 
 ## Next Steps

--- a/content/spin/quickstart.md
+++ b/content/spin/quickstart.md
@@ -26,7 +26,7 @@ Let's get Spin and take it from nothing to a "hello world" application!
 
 {{ startTab "Linux"}}
 
-Download the `spin` binary along with a starter set pf templates and plugins using the `install.sh` script hosted on this site:
+Download the `spin` binary along with a starter set of templates and plugins using the `install.sh` script hosted on this site:
 
 <!-- @selectiveCpy -->
 

--- a/content/spin/quickstart.md
+++ b/content/spin/quickstart.md
@@ -45,7 +45,7 @@ $ sudo mv ./spin /usr/local/bin/spin
 
 {{ startTab "macOS"}}
 
-Download the `spin` binary along with language templates and plugins using the `install.sh` script hosted on this site:
+Download the `spin` binary along with a starter set of templates and plugins using the `install.sh` script hosted on this site:
 
 <!-- @selectiveCpy -->
 

--- a/content/spin/quickstart.md
+++ b/content/spin/quickstart.md
@@ -26,7 +26,7 @@ Let's get Spin and take it from nothing to a "hello world" application!
 
 {{ startTab "Linux"}}
 
-Download the `spin` binary using the `install.sh` script hosted on this site:
+Download the `spin` binary along with [default templates and plugins](install.md#installing-default-templates-and-plugins) using the `install.sh` script hosted on this site:
 
 <!-- @selectiveCpy -->
 
@@ -45,7 +45,7 @@ $ sudo mv ./spin /usr/local/bin/spin
 
 {{ startTab "macOS"}}
 
-Download the `spin` binary using the `install.sh` script hosted on this site:
+Download the `spin` binary along with [default templates and plugins](install.md#installing-default-templates-and-plugins) using the `install.sh` script hosted on this site:
 
 <!-- @selectiveCpy -->
 
@@ -68,6 +68,8 @@ Download <a href="https://github.com/fermyon/spin/releases/latest" class="spin-i
 
 Unzip the binary release and place the `spin.exe` in your system path.
 
+Next, follow the steps to install the [default templates and plugins](#installing-default-templates-and-plugins).
+
 {{ blockEnd }}
 {{ blockEnd }}
 
@@ -75,9 +77,13 @@ Unzip the binary release and place the `spin.exe` in your system path.
 
 ## Install the Prerequisites
 
+> If you installed Spin with the install script, you can skip these steps, as the script installs the [default templates and plugins](install.md#installing-default-templates-and-plugins). List installed templates and plugins by running `spin templates list` and `spin plugins list`.
+
 ### Install a Template
 
-The quickest and most convenient way to start a new application is to use a Spin template.  Let's install the templates for your preferred language.
+The quickest and most convenient way to start a new application is to use a Spin template.
+
+Let's install the templates for your preferred language.
 
 {{ tabs "sdk-type" }}
 

--- a/content/spin/quickstart.md
+++ b/content/spin/quickstart.md
@@ -77,9 +77,7 @@ Unzip the binary release and place the `spin.exe` in your system path.
 
 ### Install a Template
 
-The quickest and most convenient way to start a new application is to use a Spin template.
-
-Let's install the templates for your preferred language.
+The quickest and most convenient way to start a new application is to install and use a Spin template for your preferred language:
 
 {{ tabs "sdk-type" }}
 
@@ -176,7 +174,7 @@ Some languages require additional tool support for Wasm.
 
 {{ startTab "Rust"}}
 
-You'll need the `wasm32-wasi` target for Rust.
+You'll need the `wasm32-wasi` target for Rust:
 
 <!-- @selectiveCpy -->
 
@@ -190,7 +188,7 @@ $ rustup target add wasm32-wasi
 
 {{ startTab "TypeScript" }}
 
-You'll need the Spin `js2wasm` plugin.
+You'll need the Spin `js2wasm` plugin:
 
 <!-- @selectiveCpy -->
 
@@ -205,7 +203,7 @@ $ spin plugins install js2wasm --yes
 
 {{ startTab "Python" }}
 
-You'll need the Spin `py2wasm` plugin.
+You'll need the Spin `py2wasm` plugin:
 
 <!-- @selectiveCpy -->
 
@@ -236,7 +234,7 @@ Now you are ready to create your first Spin application.
 
 {{ startTab "Rust"}}
 
-Use the `spin new` command and the `http-rust` template to scaffold a new Spin application.
+Use the `spin new` command and the `http-rust` template to scaffold a new Spin application:
 
 <!-- @selectiveCpy -->
 
@@ -276,7 +274,7 @@ $ tree
     └── lib.rs
 ```
 
-The additional `spin.toml` file is the manifest file, which tells Spin what events should trigger what components.  In this case our trigger is HTTP, for a Web application, and we have only one component, at the route `/...`.  This is a wildcard that matches any route.
+The additional `spin.toml` file is the manifest file, which tells Spin what events should trigger what components.  In this case our trigger is HTTP, for a Web application, and we have only one component, at the route `/...`.  This is a wildcard that matches any route:
 
 <!-- @nocpy -->
 

--- a/content/spin/quickstart.md
+++ b/content/spin/quickstart.md
@@ -168,7 +168,7 @@ Note: The Go templates are in a repo that contains several other languages; they
 
 ### Install the Tools
 
-Some languages require additional tool support for Wasm.
+Some languages require additional tool support for Wasm:
 
 {{ tabs "sdk-type" }}
 
@@ -228,7 +228,7 @@ You'll need the TinyGo compiler, as the standard Go compiler does not yet suppor
 
 ## Create Your First Application
 
-Now you are ready to create your first Spin application.
+Now you are ready to create your first Spin application:
 
 {{ tabs "sdk-type" }}
 
@@ -334,7 +334,7 @@ fn handle_hello_rust(req: Request) -> Result<Response> {
 
 {{ startTab "TypeScript"}}
 
-Use the `spin new` command and the `http-ts` template to scaffold a new Spin application.  (If you prefer JavaScript to TypeScript, the `http-js` template is very similar.)
+Use the `spin new` command and the `http-ts` template to scaffold a new Spin application.  (If you prefer JavaScript to TypeScript, the `http-js` template is very similar.):
 
 <!-- @selectiveCpy -->
 
@@ -366,7 +366,7 @@ $ tree
 └── webpack.config.js
 ```
 
-The additional `spin.toml` file is the manifest file, which tells Spin what events should trigger what components.  In this case our trigger is HTTP, for a Web application, and we have only one component, at the route `/...`.  This is a wildcard that matches any route.
+The additional `spin.toml` file is the manifest file, which tells Spin what events should trigger what components.  In this case our trigger is HTTP, for a Web application, and we have only one component, at the route `/...`.  This is a wildcard that matches any route:
 
 <!-- @nocpy -->
 
@@ -401,7 +401,7 @@ code for a Spin HTTP component written in TypeScript — a regular function name
 takes an HTTP request as a parameter and returns an HTTP response.  (The
 JavaScript version looks slightly different, but is still a function with
 the same signature.)  The Spin `js2wasm` plugin looks for the `handleRequest` function
-by name when building your application into a Wasm module.
+by name when building your application into a Wasm module:
 
 <!-- @nocpy -->
 
@@ -597,7 +597,7 @@ func main() {}
 
 ## Build Your Application
 
-The Spin template creates starter source code.  Now you need to turn that into a Wasm module.  The template puts build instructions for each component into the manifest.  Use the `spin build` command to run them!
+The Spin template creates starter source code.  Now you need to turn that into a Wasm module.  The template puts build instructions for each component into the manifest.  Use the `spin build` command to run them:
 
 {{ tabs "sdk-type" }}
 

--- a/content/spin/quickstart.md
+++ b/content/spin/quickstart.md
@@ -26,7 +26,7 @@ Let's get Spin and take it from nothing to a "hello world" application!
 
 {{ startTab "Linux"}}
 
-Download the `spin` binary along with [default templates and plugins](install.md#installing-default-templates-and-plugins) using the `install.sh` script hosted on this site:
+Download the `spin` binary along with a starter set pf templates and plugins using the `install.sh` script hosted on this site:
 
 <!-- @selectiveCpy -->
 
@@ -45,7 +45,7 @@ $ sudo mv ./spin /usr/local/bin/spin
 
 {{ startTab "macOS"}}
 
-Download the `spin` binary along with [default templates and plugins](install.md#installing-default-templates-and-plugins) using the `install.sh` script hosted on this site:
+Download the `spin` binary along with language templates and plugins using the `install.sh` script hosted on this site:
 
 <!-- @selectiveCpy -->
 
@@ -68,16 +68,12 @@ Download <a href="https://github.com/fermyon/spin/releases/latest" class="spin-i
 
 Unzip the binary release and place the `spin.exe` in your system path.
 
-Next, follow the steps to install the [default templates and plugins](#installing-default-templates-and-plugins).
-
 {{ blockEnd }}
 {{ blockEnd }}
 
 [See more options for installing Spin.](install)
 
 ## Install the Prerequisites
-
-> If you installed Spin with the install script, you can skip these steps, as the script installs the [default templates and plugins](install.md#installing-default-templates-and-plugins). List installed templates and plugins by running `spin templates list` and `spin plugins list`.
 
 ### Install a Template
 

--- a/downloads/install.sh
+++ b/downloads/install.sh
@@ -125,6 +125,18 @@ fancy_print 0 "Step 3: Removing the downloaded tarball"
 rm $FILE
 fancy_print 0 "Done...\n"
 
+# Install default templates
+fancy_print 0 "Step 4: Install default templates"
+./spin templates install --git "https://github.com/fermyon/spin" --upgrade
+./spin templates install --git "https://github.com/fermyon/spin-python-sdk" --upgrade
+./spin templates install --git "https://github.com/fermyon/spin-js-sdk" --upgrade
+
+# Install default plugins
+fancy_print 0 "Step 5: Install default plugins"
+./spin plugins update
+./spin plugins install js2wasm --yes
+./spin plugins install py2wasm --yes
+
 # Direct to quicks-start doc
 fancy_print 0 "You're good to go. Check here for the next steps: https://developer.fermyon.com/spin/quickstart"
 fancy_print 0 "Run './spin' to get started"


### PR DESCRIPTION
Updates the install script to install default templates and all language plugins and associated documentation.

Note: This can set a precedent for installations of spin to come with this set plugins and templates. For example, future package manager installations can follow this practice. 


## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors

<img width="388" alt="Screenshot 2023-05-26 at 10 58 01 am" src="https://github.com/fermyon/developer/assets/9831342/6a1fae95-52c4-4158-ac9b-3a9363dd9004">

- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
