### PR TITLE
add sidebar when 404ing on particular project

### DIFF
--- a/templates/main.hbs
+++ b/templates/main.hbs
@@ -5,16 +5,27 @@
     <div class="columns">
 
         {{! This adds the sidebar }}
-
+        {{#if (active_project request.spin-path-info "/spin/" )}}
+        {{> spin_sidebar }}
+        {{else}}
+        {{#if (active_project request.spin-path-info "/cloud/" )}}
+        {{> cloud_sidebar }}
+        {{else}}
+        {{#if (active_project request.spin-path-info "/bartholomew/" )}}
+        {{> bartholomew_sidebar }}
+        {{/if}}
+        {{/if}}
+        {{/if}}
+        
         <article class="column content content-docs content-docs-wide">
             <section id="type">
 
-            {{#if (eq page.head.title "Not Found")}}
+                {{#if (eq page.head.title "Not Found")}}
                 {{> 404 }}
-            {{else}}
+                {{else}}
                 <h1 class="blog-post-title border-bottom">{{page.head.title}}</h1>
                 {{{page.body}}}
-            {{/if}}
+                {{/if}}
             </section>
         </article>
 
@@ -25,4 +36,5 @@
 {{> content_bottom }}
 
 </body>
+
 </html>


### PR DESCRIPTION
This adds the project sidebar when failing to find a page on particular projects

before
![image](https://github.com/fermyon/developer/assets/25023490/d029f2d2-4e87-4627-b21f-d350adb51a66)

after
![Screenshot 2023-05-20 at 12 14 40 PM](https://github.com/fermyon/developer/assets/25023490/f0ad21fc-a3e7-407b-81b8-118688f1a45c)
