### PR TITLE
First draft of troubleshooting_and_sdk_work

### DIFF
--- a/content/spin/go-components.md
+++ b/content/spin/go-components.md
@@ -1,6 +1,8 @@
 title = "Building Spin components in Go"
 template = "spin_main"
 date = "2022-03-14T00:22:56Z"
+enable_shortcodes = true
+enable_shortcodes = true
 [extra]
 url = "https://github.com/fermyon/developer/blob/main//content/spin/go-components.md"
 
@@ -12,6 +14,8 @@ url = "https://github.com/fermyon/developer/blob/main//content/spin/go-component
 - [Redis Components](#redis-components)
 - [Storing Data in Redis From Go Components](#storing-data-in-redis-from-go-components)
 - [Using Go Packages in Spin Components](#using-go-packages-in-spin-components)
+- [Troubleshooting](#troubleshooting)
+  - [SDK Version](#sdk-version)
 
 > This guide assumes you have Spin installed. If this is your first encounter with Spin, please see the [Quick Start](quickstart), which includes information about installing Spin with the Go templates, installing required tools, and creating Go applications.
 
@@ -343,3 +347,34 @@ WASI can be used when implementing a Spin component.
 
 > Make sure to read [the page describing the HTTP trigger](./http-trigger.md) for more
 > details about building HTTP applications.
+
+## Troubleshooting
+
+If you bump into issues building and running your Go component, here are some common causes of problems.
+
+### SDK Version
+
+{{ tabs "sdk-type" }}
+
+{{ startTab "TinyGo" }}
+
+Upgrade to the latest version of Spin. Then ensure that the application's `go.mod` file reflects your Spin version:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin --version
+spin 1.1.0
+```
+
+Go.mod file example:
+
+```
+// -- snip --
+require github.com/fermyon/spin/sdk/go v1.1.0
+// -- snip --
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}

--- a/content/spin/go-components.md
+++ b/content/spin/go-components.md
@@ -2,7 +2,6 @@ title = "Building Spin components in Go"
 template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
-enable_shortcodes = true
 [extra]
 url = "https://github.com/fermyon/developer/blob/main//content/spin/go-components.md"
 

--- a/content/spin/javascript-components.md
+++ b/content/spin/javascript-components.md
@@ -17,6 +17,8 @@ url = "https://github.com/fermyon/developer/blob/main//content/spin/javascript-c
 - [Using External NPM Libraries](#using-external-npm-libraries)
   - [Suggested Libraries for Common Tasks](#suggested-libraries-for-common-tasks)
 - [Caveats](#caveats)
+- [Troubleshooting](#troubleshooting)
+  - [SDK Version](#sdk-version)
 
 With JavaScript being a very popular language, Spin provides support for building components with it using the experimental SDK. The development of the JavaScript SDK is continually being worked on to improve user experience and add features. 
 
@@ -403,3 +405,39 @@ These are some of the suggested libraries that have been tested and confired to 
 - All `spinSdk` related functions and methods can be called only inside the `handleRequest` function. This includes the usage of `fetch`. Any attempts to use it outside the function will lead to an error. This is due to Wizer using only Wasmtime to execute the script at build time, which does not include any Spin SDK support.
 - Only a subset of the browser and `Node.js` APIs are implemented.
 - The support for Crypto  module is limited. The methods currently supported are `crypto.getRandomValues`, `crypto.subtle.digest`, `cryto.createHash` and `crypto.createHmac`
+
+## Troubleshooting
+
+If you bump into issues building and running your Javascript component, here are some common causes of problems.
+
+### SDK Version
+
+{{ tabs "sdk-type" }}
+
+{{ startTab "TypeScript" }}
+
+Run the Spin CLIs [plugin update](/common/cli-reference#update-plugins) and [plugin upgrade](/common/cli-reference#upgrade-plugins) commands. Then check the plugin version via the Spin CLIs [spin plugins list](https://developer.fermyon.com/common/cli-reference#list-plugins) command:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin plugins list  
+js2wasm 0.1.0
+js2wasm 0.2.0
+js2wasm 0.3.0
+js2wasm 0.4.0 [installed]
+// -- snip --
+```
+
+Ensure that the application's `package.json` file reflects the above version:
+
+```json
+// -- snip --
+  "devDependencies": {
+    "@fermyon/spin-sdk": "^0.4.0",
+// -- snip --
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}

--- a/content/spin/python-components.md
+++ b/content/spin/python-components.md
@@ -1,6 +1,7 @@
 title = "Building Spin Components in Python"
 template = "spin_main"
 date = "2023-02-28T02:00:00Z"
+enable_shortcodes = true
 [extra]
 url = "https://github.com/fermyon/developer/blob/main//content/spin/python-components.md"
 
@@ -16,6 +17,8 @@ url = "https://github.com/fermyon/developer/blob/main//content/spin/python-compo
 - [An Outbound Redis Example](#an-outbound-redis-example)
   - [Configuration](#configuration-1)
   - [Building and Running the Application](#building-and-running-the-application-2)
+- [Troubleshooting](#troubleshooting)
+  - [SDK Version](#sdk-version)
 
 With <a href="https://www.python.org/" target="_blank">Python</a> being a very popular language, Spin provides support for building components with Python; [using an experimental SDK](https://github.com/fermyon/spin-python-sdk). The development of the Python SDK is continually being worked on to improve user experience and also add new features. 
 
@@ -329,3 +332,18 @@ redis-cli
 127.0.0.1:6379> get foo
 "bar"
 ```
+## Troubleshooting
+
+If you bump into issues building and running your Python component, here are some common causes of problems.
+
+### SDK Version
+
+{{ tabs "sdk-type" }}
+
+{{ startTab "Python" }}
+
+Spin applications written in Python do not require explicit SDK version configuration. Just ensure that you have the latest version of the `http-py` template and `py2wasm` plugin installed. For information please see the [Python section](/spin/python-components) of the language guide, as well as the [managing templates](/spin/managing-templates) and [managing plugins](/spin/managing-plugins) documentation.
+
+{{ blockEnd }}
+
+{{ blockEnd }}

--- a/content/spin/python-components.md
+++ b/content/spin/python-components.md
@@ -332,6 +332,7 @@ redis-cli
 127.0.0.1:6379> get foo
 "bar"
 ```
+
 ## Troubleshooting
 
 If you bump into issues building and running your Python component, here are some common causes of problems.

--- a/content/spin/rust-components.md
+++ b/content/spin/rust-components.md
@@ -1,6 +1,7 @@
 title = "Building Spin components in Rust"
 template = "spin_main"
 date = "2022-03-14T00:22:56Z"
+enable_shortcodes = true
 [extra]
 url = "https://github.com/fermyon/developer/blob/main//content/spin/rust-components.md"
 
@@ -16,8 +17,9 @@ url = "https://github.com/fermyon/developer/blob/main//content/spin/rust-compone
   - [Serializing Objects to the Key-Value Store](#serializing-objects-to-the-key-value-store)
 - [Storing Data in Relational Databases](#storing-data-in-relational-databases)
 - [Using External Crates in Rust Components](#using-external-crates-in-rust-components)
-- [Troubleshooting](#troubleshooting)
 - [Manually Creating New Projects With Cargo](#manually-creating-new-projects-with-cargo)
+- [Troubleshooting](#troubleshooting)
+  - [SDK Version](#sdk-version)
 
 Spin aims to have best-in-class support for building components in Rust, and
 writing such components should be familiar for Rust developers.
@@ -448,22 +450,6 @@ annotated using the `http_component` macro, compiled to the
 This means that any [crate](https://crates.io) that compiles to `wasm32-wasi` can
 be used when implementing the component.
 
-## Troubleshooting
-
-If you bump into issues building and running your Rust component, here are some common causes of problems:
-
-- Make sure `cargo` is present in your path
-- Make sure the [Rust](https://www.rust-lang.org/) version is recent.
-  - To check: run  `cargo --version`.  The Spin SDK needs Rust 1.64 or above.
-  - To update: run `rustup update`.
-- Make sure the `wasm32-wasi` compiler target is installed.
-  - To check: run `rustup target list --installed` and check that `wasm32-wasi` is on the list.
-  - To install: run `rustup target add wasm32-wasi`.
-- Make sure you are building in `release` mode.  Spin manifests refer to your Wasm file by a path, and the default path corresponds to `release` builds.
-  - To build manually: run `cargo build --release --target wasm32-wasi`.
-  - If you're using `spin build` and the templates, this should be set up correctly for you.
-- Make sure that the `source` field in the component manifest match the path and name of the Wasm file in `target/wasm32-wasi/release`. These could get out of sync if you renamed the Rust package in its `Cargo.toml`.
-
 ## Manually Creating New Projects With Cargo
 
 The recommended way of creating new Spin projects is by starting from a template.
@@ -505,3 +491,48 @@ wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", re
 ```
 
 > `wit-bindgen` evolves rapidly to track draft standards.  Very recent versions of `wit-bindgen` are unlikely to work correctly with Spin.  So the dependency must be pinned to a specific `rev`.  Over time, Spin expects to track "peninsulas of stability" in the evolving standards.
+
+## Troubleshooting
+
+If you bump into issues building and running your Rust component, here are some common causes of problems:
+
+- Make sure `cargo` is present in your path
+- Make sure the [Rust](https://www.rust-lang.org/) version is recent.
+  - To check: run  `cargo --version`.  The Spin SDK needs Rust 1.64 or above.
+  - To update: run `rustup update`.
+- Make sure the `wasm32-wasi` compiler target is installed.
+  - To check: run `rustup target list --installed` and check that `wasm32-wasi` is on the list.
+  - To install: run `rustup target add wasm32-wasi`.
+- Make sure the `wasm32-unknown-unknown` compiler target is installed.
+  - To check: run `rustup target list --installed` and check that `wasm32-unknown-unknown` is on the list.
+  - To install: run `rustup target add wasm32-unknown-unknown`.
+- Make sure you are building in `release` mode.  Spin manifests refer to your Wasm file by a path, and the default path corresponds to `release` builds.
+  - To build manually: run `cargo build --release --target wasm32-wasi`.
+  - If you're using `spin build` and the templates, this should be set up correctly for you.
+- Make sure that the `source` field in the component manifest match the path and name of the Wasm file in `target/wasm32-wasi/release`. These could get out of sync if you renamed the Rust package in its `Cargo.toml`.
+
+### SDK Version
+
+{{ tabs "sdk-type" }}
+
+{{ startTab "Rust"}}
+
+Upgrade to the latest version of Spin. Then ensure that the application's `Cargo.toml` file reflects your Spin version in its `tag` value:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin --version
+spin 1.1.0
+```
+
+Cargo.toml example:
+
+```toml
+# The Spin SDK.
+spin-sdk = { git = "https://github.com/fermyon/spin", tag = "v1.1.0" }
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}


### PR DESCRIPTION
Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.

## Error messages
- [ ] Induce and then add SDK related error messages in code blocks for findability
- [ ] Reword the SDK sections in each of the Troubleshooting sections to relate to errors only when expected features are missing (instead of just always suggesting that SDKs are set to the latest version; because this is not always necessary)
- [ ] Add mention of SDK versions in the writing applications page

