### PR TITLE
ci(deploy.yml): use digest for oci_ref

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
       runs-on: ubuntu-latest
       if: ${{ github.repository_owner == 'fermyon' }}
       outputs:
-        oci_ref: ${{ steps.oci_ref.outputs.oci_ref }}
+        oci_ref: ${{ env.OCI_REGISTRY }}/${{ env.OCI_IMAGE_NAME }}@${{ steps.push.outputs.digest }}
       steps:
         - uses: actions/checkout@v3
 
@@ -78,22 +78,21 @@ jobs:
           run: |
             npm run build-index
 
-        - name: Construct OCI image reference
-          id: oci_ref
+        - name: Construct OCI image tag
+          shell: bash
           run: |
-            tag=latest
-            if [[ "${{ github.event_name }}" != "push" ]]; then
-              tag=canary
-            fi
-            echo "oci_ref=${{ env.OCI_REGISTRY }}/${{ env.OCI_IMAGE_NAME }}:${tag}" >> $GITHUB_OUTPUT
+            [[ "${{ github.event_name }}" == "push" ]] && \
+              echo "IMAGE_TAG=latest" >> $GITHUB_ENV || \
+              echo "IMAGE_TAG=canary" >> $GITHUB_ENV
 
         - name: Login and Publish Spin app
+          id: push
           uses: fermyon/actions/spin/push@v1
           with:
             registry: ${{ env.OCI_REGISTRY }}
             registry_username: fermyon
             registry_password: ${{ secrets.DOCKERHUB_PAT }}
-            registry_reference: ${{ steps.oci_ref.outputs.oci_ref }}
+            registry_reference: ${{ env.OCI_REGISTRY }}/${{ env.OCI_IMAGE_NAME }}:${{ env.IMAGE_TAG }}
 
         - name: Cleanup login
           if: ${{ always() }}


### PR DESCRIPTION
- Use the pushed image digest for the oci ref passed to the nomad job

- [x] Depends on https://github.com/fermyon/actions/pull/52

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
