### PR TITLE
ci(*): add/use build and watch config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,12 +16,10 @@ jobs:
         with:
           node-version: 16
 
-      - name: Install spin
-        uses: engineerd/configurator@v0.0.8
+      - name: Setup Spin
+        uses: fermyon/actions/spin/setup@v1
         with:
-          name: "spin"
-          url: "https://github.com/fermyon/spin/releases/download/v0.10.1/spin-v0.10.1-linux-amd64.tar.gz"
-          pathInArchive: "spin"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install bart
         run: |
@@ -36,6 +34,10 @@ jobs:
       - name: Install npm packages
         run: |
           npm ci
+
+      - name: Build app
+        run: |
+          spin build
 
       - name: Run npm tests
         run: |

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -21,9 +21,9 @@ jobs:
         run: |
           npm ci
 
-      - name: Create search index
+      - name: Build app
         run: |
-          npm run build-index
+          spin build
 
       - name: build and deploy preview
         uses: fermyon/actions/spin/preview@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,9 +74,9 @@ jobs:
           run: |
             npm ci
 
-        - name: Create search index
+        - name: Build app
           run: |
-            npm run build-index
+            spin build
 
         - name: Construct OCI image reference
           id: oci_ref

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Build and run the website locally:
 
 ```bash
 npm install
-npm run spin # Uses spin watch to run the website and reload when content changes
+spin watch # Uses spin watch to run the website and reload when content changes
 ```
 
 1. View the website at `http://localhost:3000`

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Build and run the website locally:
 
 ```bash
 npm install
-npm run spin # Runs nodemon to spin up the website and reload when content changes
+npm run spin # Uses spin watch to run the website and reload when content changes
 ```
 
 1. View the website at `http://localhost:3000`

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "yaml-front-matter": "^4.1.1"
   },
   "scripts": {
-    "spin": "nodemon --watch content --watch static --watch templates --ext md,rhai,hbs,css,js --verbose --legacy-watch --signal SIGINT --exec 'npm run build-index && spin up --file spin.toml --quiet --env PREVIEW_MODE=$PREVIEW_MODE'",
-    "bundle-scripts": " parcel build static/js/src/main.js --dist-dir static/js --no-source-maps",
+    "spin": "spin watch --file spin.toml --quiet --env PREVIEW_MODE=$PREVIEW_MODE",
+    "bundle-scripts": "parcel build static/js/src/main.js --dist-dir static/js --no-source-maps",
     "styles": "parcel watch static/sass/styles.scss --dist-dir static/css",
     "test": "npx markdownlint-cli2 content/**/*.md \"#node_modules\" && npm run check-broken-links",
     "build-index": "node md_parser.mjs --dir=./content/ --out=./static/data.json",

--- a/spin.toml
+++ b/spin.toml
@@ -12,6 +12,9 @@ environment = { PREVIEW_MODE = "0" }
 files = [ "content/**/*" , "templates/*", "scripts/*", "config/*", "shortcodes/*"]
 [component.trigger]
 route = "/..."
+[component.build]
+command = "npm run build-index"
+watch = [ "content/**/*", "templates/*", "scripts/*", "config/*", "shortcodes/*", "static/*"]
 
 [[component]]
 source = "modules/spin_static_fs.wasm"


### PR DESCRIPTION
- Adds build and watch config to the main bartholomew component for the website app
- Updates CI to run `spin build` (also aligns build.yml to install spin via the [setup action](https://github.com/fermyon/actions#install-spin-cli-and-plugins---fermyonactionsspinsetupv1) like the others)

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
