### PR TITLE
Install cloud plugin in install script

### DIFF
--- a/content/spin/install.md
+++ b/content/spin/install.md
@@ -166,7 +166,7 @@ This does not install any Spin templates or plugins. For a starter list, see the
 ## Installing Templates and Plugins
 
 Spin has a variety of templates and plugins to make it easier to create Spin applications in your favorite programming language. 
-The install script automatically installs a starter set of templates and plugins, namely templates from the Spin repository and JavaScript and Python toolchain plugins. If you used a different installation method, we recommend you install these templates and plugins manually, as follows:
+The install script automatically installs a starter set of templates and plugins, namely templates from the Spin repository and JavaScript and Python toolchain plugins and the Fermyon Cloud plugin. If you used a different installation method, we recommend you install these templates and plugins manually, as follows:
 
 ```sh
 spin templates install --git https://github.com/fermyon/spin --upgrade
@@ -175,6 +175,7 @@ spin templates install --git https://github.com/fermyon/spin-js-sdk --upgrade
 spin plugins update
 spin plugins install js2wasm --yes
 spin plugins install py2wasm --yes
+spin plugins install cloud --yes
 ```
 
 To list installed templates, run:

--- a/downloads/install.sh
+++ b/downloads/install.sh
@@ -136,6 +136,7 @@ fancy_print 0 "Step 5: Install default plugins"
 ./spin plugins update
 ./spin plugins install js2wasm --yes
 ./spin plugins install py2wasm --yes
+./spin plugins install cloud --yes
 
 # Direct to quicks-start doc
 fancy_print 0 "You're good to go. Check here for the next steps: https://developer.fermyon.com/spin/quickstart"


### PR DESCRIPTION
I didn't update the other references to what the install script installs to say it also installs the cloud plugin. It didn't seem necessary to state since if not preinstalled it will be automatically installed later

DO NOT MERGE until after the 1.3 spin release

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
