### PR TITLE
Add Cloud Command Reference page

### DIFF
--- a/content/cloud/cloud-plugin.md
+++ b/content/cloud/cloud-plugin.md
@@ -17,7 +17,7 @@ url = "https://github.com/fermyon/developer/blob/main/content/cloud/cloud-plugin
 
 ## Spin Cloud Command
 
-Fermyon provides a `cloud` plugin for the Spin CLI for you to manage Spin applications in Fermyon Cloud. This page documents the `spin cloud` command. Specifically, all of the available options and subcommands. For more information on subcommand stability, see the [subcommands stability table](#subcommand-stability-table). You can reproduce the Spin Cloud command documentation on your machine by using the --help flag. For example:
+Fermyon provides a []`cloud` plugin](https://github.com/fermyon/cloud-plugin) for the Spin CLI for you to manage Spin applications in Fermyon Cloud. This page documents the `spin cloud` command. Specifically, all of the available options and subcommands. For more information on subcommand stability, see the [subcommands stability table](#subcommand-stability-table). You can reproduce the Spin Cloud command documentation on your machine by using the `--help` flag. For example:
 
 {{ tabs "cloud-plugin-version" }}
 

--- a/content/cloud/cloud-plugin.md
+++ b/content/cloud/cloud-plugin.md
@@ -16,11 +16,12 @@ url = "https://github.com/fermyon/developer/blob/main/content/cloud/cloud-plugin
   - [Subcommands Stability Table](#subcommands-stability-table)
 
 ## Spin Cloud Command
+
 Fermyon provides a `cloud` plugin for the Spin CLI for you to manage Spin applications in Fermyon Cloud. This page documents the `spin cloud` command. Specifically, all of the available options and subcommands. For more information on subcommand stability, see the [subcommands stability table](#subcommand-stability-table). You can reproduce the Spin Cloud command documentation on your machine by using the --help flag. For example:
 
 {{ tabs "cloud-plugin-version" }}
 
-{{ startTab "v0.1.0"}}
+{{ startTab "v0.1.0 (Spin >= v1.3)"}}
 
 <!-- @selectiveCpy -->
 
@@ -28,31 +29,6 @@ Fermyon provides a `cloud` plugin for the Spin CLI for you to manage Spin applic
 $ spin cloud --help
 
 cloud-plugin 0.1.0
-Fermyon Engineering <engineering@fermyon.com>
-
-USAGE:
-    cloud <SUBCOMMAND>
-
-OPTIONS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-
-SUBCOMMANDS:
-    deploy    Package and upload an application to the Fermyon Cloud
-    help      Print this message or the help of the given subcommand(s)
-    login     Login to Fermyon Cloud
-```
-
-{{ blockEnd }}
-
-{{ startTab "v0.1.1"}}
-
-<!-- @selectiveCpy -->
-
-```console
-$ spin cloud --help
-
-cloud-plugin 0.1.1
 Fermyon Engineering <engineering@fermyon.com>
 
 USAGE:
@@ -73,12 +49,11 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
-
 ### Deploy
 
 {{ tabs "cloud-plugin-version" }}
 
-{{ startTab "v.1.0"}}
+{{ startTab "v0.1.0 (Spin >= v1.3)"}}
 
 <!-- @selectiveCpy -->
 ```console
@@ -124,72 +99,21 @@ OPTIONS:
 
     -V, --version
             Print version information
-```
-
-{{ blockEnd }}
-
-{{ startTab "v0.1.1"}}
-
-<!-- @selectiveCpy -->
-```console
-$ spin cloud deploy --help
-
-cloud-deploy 0.1.1
-Package and upload an application to the Fermyon Cloud
-
-USAGE:
-    cloud deploy [OPTIONS]
-
-OPTIONS:
-        --buildinfo <BUILDINFO>
-            Build metadata to append to the bindle version
-
-    -d, --staging-dir <STAGING_DIR>
-            Path to assemble the bindle before pushing (defaults to a temporary directory)
-
-    -e, --deploy-existing-bindle
-            Deploy existing bindle if it already exists on bindle server
-
-        --environment-name <environment-name>
-            Deploy to the Fermyon instance saved under the specified name. If omitted, Spin deploys
-            to the default unnamed instance [env: FERMYON_DEPLOYMENT_ENVIRONMENT=]
-
-    -f, --from <APP_MANIFEST_FILE>
-            The application to deploy. This may be a manifest (spin.toml) file, or a directory
-            containing a spin.toml file. If omitted, it defaults to "spin.toml" [default: spin.toml]
-
-    -h, --help
-            Print help information
-
-        --key-value <KEY_VALUES>
-            Set a key/value pair (key=value) in the deployed application's default store. Any
-            existing value will be overwritten. Can be used multiple times
-
-        --no-buildinfo
-            Disable attaching buildinfo [env: SPIN_DEPLOY_NO_BUILDINFO=]
-
-        --readiness-timeout <READINESS_TIMEOUT_SECS>
-            How long in seconds to wait for a deployed HTTP application to become ready. The default
-            is 60 seconds. Set it to 0 to skip waiting for readiness [default: 60]
-
-    -V, --version
-            Print version information
 
         --variable <VARIABLES>
             Set a variable pair (variable=value) in the deployed application. Any existing value
             will be overwritten. Can be used multiple times
 ```
-{{ blockEnd }}
 
 {{ blockEnd }}
 
+{{ blockEnd }}
 
 ## Login
 
-
 {{ tabs "cloud-plugin-version" }}
 
-{{ startTab "v0.1.0"}}
+{{ startTab "v0.1.0 (Spin >= v1.3)"}}
 
 <!-- @selectiveCpy -->
 ```console
@@ -234,64 +158,19 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v0.1.1"}}
-
-<!-- @selectiveCpy -->
-```console
-$ spin cloud login --help
-
-cloud-login 0.1.1
-Login to Fermyon Cloud
-
-USAGE:
-    cloud login [OPTIONS]
-
-OPTIONS:
-        --auth-method <auth-method>
-            [env: AUTH_METHOD=] [possible values: github, token]
-
-        --environment-name <environment-name>
-            Save the login details under the specified name instead of making them the default. Use
-            named environments with `spin deploy --environment-name <name>` [env:
-            FERMYON_DEPLOYMENT_ENVIRONMENT=]
-
-    -h, --help
-            Print help information
-
-    -k, --insecure
-            Ignore server certificate errors
-
-        --list
-            List saved logins
-
-        --status
-            Display login status
-
-        --token <TOKEN>
-            Auth Token [env: SPIN_AUTH_TOKEN=]
-
-        --url <CLOUD_SERVER_URL>
-            URL of Fermyon Cloud Instance [env: CLOUD_URL=] [default: https://cloud.fermyon.com/]
-
-    -V, --version
-            Print version information
-```
-
-{{ blockEnd }}
-
 {{ blockEnd }}
 
 ### Variables
 
 {{ tabs "cloud-plugin-version" }} 
 
-{{ startTab "v0.1.1"}}
+{{ startTab "v0.1.0 (Spin >= v1.3)"}}
 
 <!-- @selectiveCpy -->
 ```console
 $ spin cloud variables --help
 
-cloud-variables 0.1.1
+cloud-variables 0.1.0
 Manage Spin application variables
 
 USAGE:
@@ -323,17 +202,7 @@ CLI commands have four phases that indicate levels of stability:
 
 {{ tabs "command-version" }}
 
-{{ startTab "v0.1.0"}}
-
-| Command                                                    | Stability   |
-| ---------------------------------------------------------- | ----------- |
-| <code>cloud deploy</code>                                                 | Stabilizing      |
-| <code>cloud login</code>                                               | Stabilizing      |
-| <code>cloud variables</code>                                                 | Stabilizing      |
-
-{{ blockEnd }}
-
-{{ startTab "v0.1.1"}}
+{{ startTab "v0.1.0 (Spin >= v1.3)"}}
 
 | Command                                                    | Stability   |
 | ---------------------------------------------------------- | ----------- |

--- a/content/cloud/cloud-plugin.md
+++ b/content/cloud/cloud-plugin.md
@@ -17,36 +17,9 @@ url = "https://github.com/fermyon/developer/blob/main/content/cloud/cloud-plugin
 
 ## Spin Cloud Command
 
-Fermyon provides a []`cloud` plugin](https://github.com/fermyon/cloud-plugin) for the Spin CLI for you to manage Spin applications in Fermyon Cloud. This page documents the `spin cloud` command. Specifically, all of the available options and subcommands. For more information on subcommand stability, see the [subcommands stability table](#subcommand-stability-table). You can reproduce the Spin Cloud command documentation on your machine by using the `--help` flag. For example:
+Fermyon provides a [`cloud` plugin](https://github.com/fermyon/cloud-plugin) for the Spin CLI for you to manage Spin applications in Fermyon Cloud. This page documents the `spin cloud` command. Specifically, all of the available options and subcommands. For more information on subcommand stability, see the [subcommands stability table](#subcommand-stability-table). You can reproduce the Spin Cloud command documentation on your machine by using the `--help` flag. For example:
 
 {{ tabs "cloud-plugin-version" }}
-
-{{ startTab "v0.1.0"}}
-
-Spin compatibility: `>= v1.3`
-
-<!-- @selectiveCpy -->
-
-```console
-$ spin cloud --help
-
-cloud-plugin 0.1.0
-Fermyon Engineering <engineering@fermyon.com>
-
-USAGE:
-    cloud <SUBCOMMAND>
-
-OPTIONS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-
-SUBCOMMANDS:
-    deploy       Package and upload an application to the Fermyon Cloud
-    help         Print this message or the help of the given subcommand(s)
-    login        Login to Fermyon Cloud
-```
-
-{{ blockEnd }}
 
 {{ startTab "v0.1.1"}}
 
@@ -81,58 +54,6 @@ SUBCOMMANDS:
 ### Deploy
 
 {{ tabs "cloud-plugin-version" }}
-
-{{ startTab "v0.1.0"}}
-
-Spin compatibility: `>= v1.3`
-
-<!-- @selectiveCpy -->
-```console
-$ spin cloud deploy --help
-
-cloud-deploy 0.1.0
-Package and upload an application to the Fermyon Cloud
-
-USAGE:
-    cloud deploy [OPTIONS]
-
-OPTIONS:
-        --buildinfo <BUILDINFO>
-            Build metadata to append to the bindle version
-
-    -d, --staging-dir <STAGING_DIR>
-            Path to assemble the bindle before pushing (defaults to a temporary directory)
-
-    -e, --deploy-existing-bindle
-            Deploy existing bindle if it already exists on bindle server
-
-        --environment-name <environment-name>
-            Deploy to the Fermyon instance saved under the specified name. If omitted, Spin deploys
-            to the default unnamed instance [env: FERMYON_DEPLOYMENT_ENVIRONMENT=]
-
-    -f, --from <APP_MANIFEST_FILE>
-            The application to deploy. This may be a manifest (spin.toml) file, or a directory
-            containing a spin.toml file. If omitted, it defaults to "spin.toml" [default: spin.toml]
-
-    -h, --help
-            Print help information
-
-        --key-value <KEY_VALUES>
-            Set a key/value pair (key=value) in the deployed application's default store. Any
-            existing value will be overwritten. Can be used multiple times
-
-        --no-buildinfo
-            Disable attaching buildinfo [env: SPIN_DEPLOY_NO_BUILDINFO=]
-
-        --readiness-timeout <READINESS_TIMEOUT_SECS>
-            How long in seconds to wait for a deployed HTTP application to become ready. The default
-            is 60 seconds. Set it to 0 to skip waiting for readiness [default: 60]
-
-    -V, --version
-            Print version information
-```
-
-{{ blockEnd }}
 
 {{ startTab "v0.1.1"}}
 
@@ -195,53 +116,6 @@ OPTIONS:
 ## Login
 
 {{ tabs "cloud-plugin-version" }}
-
-{{ startTab "v0.1.0"}}
-
-Spin compatibility: `>= v1.3`
-
-<!-- @selectiveCpy -->
-```console
-$ spin cloud login --help
-
-cloud-login 0.1.0
-Login to Fermyon Cloud
-
-USAGE:
-    cloud login [OPTIONS]
-
-OPTIONS:
-        --auth-method <auth-method>
-            [env: AUTH_METHOD=] [possible values: github, token]
-
-        --environment-name <environment-name>
-            Save the login details under the specified name instead of making them the default. Use
-            named environments with `spin deploy --environment-name <name>` [env:
-            FERMYON_DEPLOYMENT_ENVIRONMENT=]
-
-    -h, --help
-            Print help information
-
-    -k, --insecure
-            Ignore server certificate errors
-
-        --list
-            List saved logins
-
-        --status
-            Display login status
-
-        --token <TOKEN>
-            Auth Token [env: SPIN_AUTH_TOKEN=]
-
-        --url <CLOUD_SERVER_URL>
-            URL of Fermyon Cloud Instance [env: CLOUD_URL=] [default: https://cloud.fermyon.com/]
-
-    -V, --version
-            Print version information
-```
-
-{{ blockEnd }}
 
 {{ startTab "v0.1.1"}}
 
@@ -335,18 +209,6 @@ CLI commands have four phases that indicate levels of stability:
 - `Deprecated`: Support for these commands will be removed in a future release.
 
 {{ tabs "command-version" }}
-
-{{ startTab "v0.1.0"}}
-
-Spin compatibility: `>= v1.3`
-
-| Command                                                    | Stability   |
-| ---------------------------------------------------------- | ----------- |
-| <code>cloud deploy</code>                                                 | Stabilizing      |
-| <code>cloud login</code>                                               | Stabilizing      |
-| <code>cloud variables</code>                                                 | Stabilizing      |
-
-{{ blockEnd }}
 
 {{ startTab "v0.1.1"}}
 

--- a/content/cloud/cloud-plugin.md
+++ b/content/cloud/cloud-plugin.md
@@ -21,7 +21,9 @@ Fermyon provides a `cloud` plugin for the Spin CLI for you to manage Spin applic
 
 {{ tabs "cloud-plugin-version" }}
 
-{{ startTab "v0.1.0 (Spin >= v1.3)"}}
+{{ startTab "v0.1.0"}}
+
+Spin compatibility: `>= v1.3`
 
 <!-- @selectiveCpy -->
 
@@ -29,6 +31,33 @@ Fermyon provides a `cloud` plugin for the Spin CLI for you to manage Spin applic
 $ spin cloud --help
 
 cloud-plugin 0.1.0
+Fermyon Engineering <engineering@fermyon.com>
+
+USAGE:
+    cloud <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+SUBCOMMANDS:
+    deploy       Package and upload an application to the Fermyon Cloud
+    help         Print this message or the help of the given subcommand(s)
+    login        Login to Fermyon Cloud
+```
+
+{{ blockEnd }}
+
+{{ startTab "v0.1.1"}}
+
+Spin compatibility: `>= v1.3`
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin cloud --help
+
+cloud-plugin 0.1.1
 Fermyon Engineering <engineering@fermyon.com>
 
 USAGE:
@@ -53,13 +82,67 @@ SUBCOMMANDS:
 
 {{ tabs "cloud-plugin-version" }}
 
-{{ startTab "v0.1.0 (Spin >= v1.3)"}}
+{{ startTab "v0.1.0"}}
+
+Spin compatibility: `>= v1.3`
 
 <!-- @selectiveCpy -->
 ```console
 $ spin cloud deploy --help
 
 cloud-deploy 0.1.0
+Package and upload an application to the Fermyon Cloud
+
+USAGE:
+    cloud deploy [OPTIONS]
+
+OPTIONS:
+        --buildinfo <BUILDINFO>
+            Build metadata to append to the bindle version
+
+    -d, --staging-dir <STAGING_DIR>
+            Path to assemble the bindle before pushing (defaults to a temporary directory)
+
+    -e, --deploy-existing-bindle
+            Deploy existing bindle if it already exists on bindle server
+
+        --environment-name <environment-name>
+            Deploy to the Fermyon instance saved under the specified name. If omitted, Spin deploys
+            to the default unnamed instance [env: FERMYON_DEPLOYMENT_ENVIRONMENT=]
+
+    -f, --from <APP_MANIFEST_FILE>
+            The application to deploy. This may be a manifest (spin.toml) file, or a directory
+            containing a spin.toml file. If omitted, it defaults to "spin.toml" [default: spin.toml]
+
+    -h, --help
+            Print help information
+
+        --key-value <KEY_VALUES>
+            Set a key/value pair (key=value) in the deployed application's default store. Any
+            existing value will be overwritten. Can be used multiple times
+
+        --no-buildinfo
+            Disable attaching buildinfo [env: SPIN_DEPLOY_NO_BUILDINFO=]
+
+        --readiness-timeout <READINESS_TIMEOUT_SECS>
+            How long in seconds to wait for a deployed HTTP application to become ready. The default
+            is 60 seconds. Set it to 0 to skip waiting for readiness [default: 60]
+
+    -V, --version
+            Print version information
+```
+
+{{ blockEnd }}
+
+{{ startTab "v0.1.1"}}
+
+Spin compatibility: `>= v1.3`
+
+<!-- @selectiveCpy -->
+```console
+$ spin cloud deploy --help
+
+cloud-deploy 0.1.1
 Package and upload an application to the Fermyon Cloud
 
 USAGE:
@@ -113,7 +196,9 @@ OPTIONS:
 
 {{ tabs "cloud-plugin-version" }}
 
-{{ startTab "v0.1.0 (Spin >= v1.3)"}}
+{{ startTab "v0.1.0"}}
+
+Spin compatibility: `>= v1.3`
 
 <!-- @selectiveCpy -->
 ```console
@@ -158,19 +243,68 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v0.1.1"}}
+
+Spin compatibility: `>= v1.3`
+
+<!-- @selectiveCpy -->
+```console
+$ spin cloud login --help
+
+cloud-login 0.1.1
+Login to Fermyon Cloud
+
+USAGE:
+    cloud login [OPTIONS]
+
+OPTIONS:
+        --auth-method <auth-method>
+            [env: AUTH_METHOD=] [possible values: github, token]
+
+        --environment-name <environment-name>
+            Save the login details under the specified name instead of making them the default. Use
+            named environments with `spin deploy --environment-name <name>` [env:
+            FERMYON_DEPLOYMENT_ENVIRONMENT=]
+
+    -h, --help
+            Print help information
+
+    -k, --insecure
+            Ignore server certificate errors
+
+        --list
+            List saved logins
+
+        --status
+            Display login status
+
+        --token <TOKEN>
+            Auth Token [env: SPIN_AUTH_TOKEN=]
+
+        --url <CLOUD_SERVER_URL>
+            URL of Fermyon Cloud Instance [env: CLOUD_URL=] [default: https://cloud.fermyon.com/]
+
+    -V, --version
+            Print version information
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 ### Variables
 
 {{ tabs "cloud-plugin-version" }} 
 
-{{ startTab "v0.1.0 (Spin >= v1.3)"}}
+{{ startTab "v0.1.1"}}
+
+Spin compatibility: `>= v1.3`
 
 <!-- @selectiveCpy -->
 ```console
 $ spin cloud variables --help
 
-cloud-variables 0.1.0
+cloud-variables 0.1.1
 Manage Spin application variables
 
 USAGE:
@@ -202,7 +336,21 @@ CLI commands have four phases that indicate levels of stability:
 
 {{ tabs "command-version" }}
 
-{{ startTab "v0.1.0 (Spin >= v1.3)"}}
+{{ startTab "v0.1.0"}}
+
+Spin compatibility: `>= v1.3`
+
+| Command                                                    | Stability   |
+| ---------------------------------------------------------- | ----------- |
+| <code>cloud deploy</code>                                                 | Stabilizing      |
+| <code>cloud login</code>                                               | Stabilizing      |
+| <code>cloud variables</code>                                                 | Stabilizing      |
+
+{{ blockEnd }}
+
+{{ startTab "v0.1.1"}}
+
+Spin compatibility: `>= v1.3`
 
 | Command                                                    | Stability   |
 | ---------------------------------------------------------- | ----------- |

--- a/content/cloud/cloud-plugin.md
+++ b/content/cloud/cloud-plugin.md
@@ -1,0 +1,346 @@
+title = "Cloud Command Reference"
+date = "2023-06-07T22:41:02.478752Z"
+template = "cloud_main"
+enable_shortcodes = true
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/cloud/cloud-plugin.md"
+
+---
+- [Spin Cloud Command](#cloud)
+  - [Deploy](#deploy)
+  - [Login](#login)
+  - [Variables](#cloud)
+    - [Set (Variables)](#set-variables)
+    - [Delete (Variables)](#delete-variables)
+    - [List (Variables)](#list-variables)
+  - [Subcommands Stability Table](#subcommands-stability-table)
+
+## Spin Cloud Command
+Fermyon provides a `cloud` plugin for the Spin CLI for you to manage Spin applications in Fermyon Cloud. This page documents the `spin cloud` command. Specifically, all of the available options and subcommands. For more information on subcommand stability, see the [subcommands stability table](#subcommand-stability-table). You can reproduce the Spin Cloud command documentation on your machine by using the --help flag. For example:
+
+{{ tabs "cloud-plugin-version" }}
+
+{{ startTab "v0.1.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin cloud --help
+
+cloud-plugin 0.1.0
+Fermyon Engineering <engineering@fermyon.com>
+
+USAGE:
+    cloud <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+SUBCOMMANDS:
+    deploy    Package and upload an application to the Fermyon Cloud
+    help      Print this message or the help of the given subcommand(s)
+    login     Login to Fermyon Cloud
+```
+
+{{ blockEnd }}
+
+{{ startTab "v0.1.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin cloud --help
+
+cloud-plugin 0.1.1
+Fermyon Engineering <engineering@fermyon.com>
+
+USAGE:
+    cloud <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+SUBCOMMANDS:
+    deploy       Package and upload an application to the Fermyon Cloud
+    help         Print this message or the help of the given subcommand(s)
+    login        Login to Fermyon Cloud
+    variables    Manage Spin application variables
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+
+### Deploy
+
+{{ tabs "cloud-plugin-version" }}
+
+{{ startTab "v.1.0"}}
+
+<!-- @selectiveCpy -->
+```console
+$ spin cloud deploy --help
+
+cloud-deploy 0.1.0
+Package and upload an application to the Fermyon Cloud
+
+USAGE:
+    cloud deploy [OPTIONS]
+
+OPTIONS:
+        --buildinfo <BUILDINFO>
+            Build metadata to append to the bindle version
+
+    -d, --staging-dir <STAGING_DIR>
+            Path to assemble the bindle before pushing (defaults to a temporary directory)
+
+    -e, --deploy-existing-bindle
+            Deploy existing bindle if it already exists on bindle server
+
+        --environment-name <environment-name>
+            Deploy to the Fermyon instance saved under the specified name. If omitted, Spin deploys
+            to the default unnamed instance [env: FERMYON_DEPLOYMENT_ENVIRONMENT=]
+
+    -f, --from <APP_MANIFEST_FILE>
+            The application to deploy. This may be a manifest (spin.toml) file, or a directory
+            containing a spin.toml file. If omitted, it defaults to "spin.toml" [default: spin.toml]
+
+    -h, --help
+            Print help information
+
+        --key-value <KEY_VALUES>
+            Set a key/value pair (key=value) in the deployed application's default store. Any
+            existing value will be overwritten. Can be used multiple times
+
+        --no-buildinfo
+            Disable attaching buildinfo [env: SPIN_DEPLOY_NO_BUILDINFO=]
+
+        --readiness-timeout <READINESS_TIMEOUT_SECS>
+            How long in seconds to wait for a deployed HTTP application to become ready. The default
+            is 60 seconds. Set it to 0 to skip waiting for readiness [default: 60]
+
+    -V, --version
+            Print version information
+```
+
+{{ blockEnd }}
+
+{{ startTab "v0.1.1"}}
+
+<!-- @selectiveCpy -->
+```console
+$ spin cloud deploy --help
+
+cloud-deploy 0.1.1
+Package and upload an application to the Fermyon Cloud
+
+USAGE:
+    cloud deploy [OPTIONS]
+
+OPTIONS:
+        --buildinfo <BUILDINFO>
+            Build metadata to append to the bindle version
+
+    -d, --staging-dir <STAGING_DIR>
+            Path to assemble the bindle before pushing (defaults to a temporary directory)
+
+    -e, --deploy-existing-bindle
+            Deploy existing bindle if it already exists on bindle server
+
+        --environment-name <environment-name>
+            Deploy to the Fermyon instance saved under the specified name. If omitted, Spin deploys
+            to the default unnamed instance [env: FERMYON_DEPLOYMENT_ENVIRONMENT=]
+
+    -f, --from <APP_MANIFEST_FILE>
+            The application to deploy. This may be a manifest (spin.toml) file, or a directory
+            containing a spin.toml file. If omitted, it defaults to "spin.toml" [default: spin.toml]
+
+    -h, --help
+            Print help information
+
+        --key-value <KEY_VALUES>
+            Set a key/value pair (key=value) in the deployed application's default store. Any
+            existing value will be overwritten. Can be used multiple times
+
+        --no-buildinfo
+            Disable attaching buildinfo [env: SPIN_DEPLOY_NO_BUILDINFO=]
+
+        --readiness-timeout <READINESS_TIMEOUT_SECS>
+            How long in seconds to wait for a deployed HTTP application to become ready. The default
+            is 60 seconds. Set it to 0 to skip waiting for readiness [default: 60]
+
+    -V, --version
+            Print version information
+
+        --variable <VARIABLES>
+            Set a variable pair (variable=value) in the deployed application. Any existing value
+            will be overwritten. Can be used multiple times
+```
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+
+## Login
+
+
+{{ tabs "cloud-plugin-version" }}
+
+{{ startTab "v0.1.0"}}
+
+<!-- @selectiveCpy -->
+```console
+$ spin cloud login --help
+
+cloud-login 0.1.0
+Login to Fermyon Cloud
+
+USAGE:
+    cloud login [OPTIONS]
+
+OPTIONS:
+        --auth-method <auth-method>
+            [env: AUTH_METHOD=] [possible values: github, token]
+
+        --environment-name <environment-name>
+            Save the login details under the specified name instead of making them the default. Use
+            named environments with `spin deploy --environment-name <name>` [env:
+            FERMYON_DEPLOYMENT_ENVIRONMENT=]
+
+    -h, --help
+            Print help information
+
+    -k, --insecure
+            Ignore server certificate errors
+
+        --list
+            List saved logins
+
+        --status
+            Display login status
+
+        --token <TOKEN>
+            Auth Token [env: SPIN_AUTH_TOKEN=]
+
+        --url <CLOUD_SERVER_URL>
+            URL of Fermyon Cloud Instance [env: CLOUD_URL=] [default: https://cloud.fermyon.com/]
+
+    -V, --version
+            Print version information
+```
+
+{{ blockEnd }}
+
+{{ startTab "v0.1.1"}}
+
+<!-- @selectiveCpy -->
+```console
+$ spin cloud login --help
+
+cloud-login 0.1.1
+Login to Fermyon Cloud
+
+USAGE:
+    cloud login [OPTIONS]
+
+OPTIONS:
+        --auth-method <auth-method>
+            [env: AUTH_METHOD=] [possible values: github, token]
+
+        --environment-name <environment-name>
+            Save the login details under the specified name instead of making them the default. Use
+            named environments with `spin deploy --environment-name <name>` [env:
+            FERMYON_DEPLOYMENT_ENVIRONMENT=]
+
+    -h, --help
+            Print help information
+
+    -k, --insecure
+            Ignore server certificate errors
+
+        --list
+            List saved logins
+
+        --status
+            Display login status
+
+        --token <TOKEN>
+            Auth Token [env: SPIN_AUTH_TOKEN=]
+
+        --url <CLOUD_SERVER_URL>
+            URL of Fermyon Cloud Instance [env: CLOUD_URL=] [default: https://cloud.fermyon.com/]
+
+    -V, --version
+            Print version information
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+### Variables
+
+{{ tabs "cloud-plugin-version" }} 
+
+{{ startTab "v0.1.1"}}
+
+<!-- @selectiveCpy -->
+```console
+$ spin cloud variables --help
+
+cloud-variables 0.1.1
+Manage Spin application variables
+
+USAGE:
+    cloud variables <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+SUBCOMMANDS:
+    delete    Delete variable pairs
+    help      Print this message or the help of the given subcommand(s)
+    list      List all variables of an application
+    set       Set variable pairs
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+### Subcommand Stability Table
+
+CLI commands have four phases that indicate levels of stability:
+
+- `Experimental`: These commands are experiments and may or may not be available in later versions of the CLI.
+- `Stabilizing`: These commands have moved out of the `experimental` phase and we are now in the active process of stabilizing them. This includes updating flags, command output, errors, and more.
+- `Stable`: These commands have moved out of the `stablizing` phase and will not change in backwards incompatible ways until the next major version release.
+- `Deprecated`: Support for these commands will be removed in a future release.
+
+{{ tabs "command-version" }}
+
+{{ startTab "v0.1.0"}}
+
+| Command                                                    | Stability   |
+| ---------------------------------------------------------- | ----------- |
+| <code>cloud deploy</code>                                                 | Stabilizing      |
+| <code>cloud login</code>                                               | Stabilizing      |
+| <code>cloud variables</code>                                                 | Stabilizing      |
+
+{{ blockEnd }}
+
+{{ startTab "v0.1.1"}}
+
+| Command                                                    | Stability   |
+| ---------------------------------------------------------- | ----------- |
+| <code>cloud deploy</code>                                                 | Stabilizing      |
+| <code>cloud login</code>                                               | Stabilizing      |
+| <code>cloud variables</code>                                                 | Stabilizing      |
+
+{{ blockEnd }}
+
+{{ blockEnd }}

--- a/content/cloud/cloud-plugin.md
+++ b/content/cloud/cloud-plugin.md
@@ -9,7 +9,7 @@ url = "https://github.com/fermyon/developer/blob/main/content/cloud/cloud-plugin
 - [Spin Cloud Command](#cloud)
   - [Deploy](#deploy)
   - [Login](#login)
-  - [Variables](#cloud)
+  - [Variables](#variables)
     - [Set (Variables)](#set-variables)
     - [Delete (Variables)](#delete-variables)
     - [List (Variables)](#list-variables)

--- a/content/spin/contributing-docs.md
+++ b/content/spin/contributing-docs.md
@@ -237,8 +237,7 @@ test.sh
 - `v1.0.0`
 - `v1.1.0`
 - `v1.2.0`
-- `v0.1.0`
-- `v0.1.1`
+- `v0.1.0 (Spin >= v1.3)`
 - `Windows`
 
 The next section covers the highly recommended use of ToCs.

--- a/content/spin/contributing-docs.md
+++ b/content/spin/contributing-docs.md
@@ -237,7 +237,8 @@ test.sh
 - `v1.0.0`
 - `v1.1.0`
 - `v1.2.0`
-- `v0.1.0 (Spin >= v1.3)`
+- `v0.1.0`
+- `v0.1.1`
 - `Windows`
 
 The next section covers the highly recommended use of ToCs.

--- a/content/spin/contributing-docs.md
+++ b/content/spin/contributing-docs.md
@@ -216,6 +216,7 @@ test.sh
 - `platforms`
 - `sdk-type`
 - `spin-version`
+- `cloud-plugin-version`
 
 **startTab**
 - `Azure AKS`
@@ -236,6 +237,8 @@ test.sh
 - `v1.0.0`
 - `v1.1.0`
 - `v1.2.0`
+- `v0.1.0`
+- `v0.1.1`
 - `Windows`
 
 The next section covers the highly recommended use of ToCs.

--- a/templates/cloud_sidebar.hbs
+++ b/templates/cloud_sidebar.hbs
@@ -75,8 +75,8 @@
                 <ul class="menu-list accordion-menu-item-content">
                     <li><a {{#if (active_content request.spin-path-info "/cloud/rest-api" )}} class="active" {{/if}}
                             href="{{site.info.base_url}}/cloud/rest-api">REST API</a></li>
-                    <li><a {{#if (active_content request.spin-path-info "/common/cli-reference" )}} class="active"
-                            {{/if}} href="{{site.info.base_url}}/common/cli-reference">Spin CLI Reference</a></li>
+                    <li><a {{#if (active_content request.spin-path-info "/cloud/cli-reference" )}} class="active"
+                            {{/if}} href="{{site.info.base_url}}/cloud/cli-reference">Spin CLI Reference</a></li>
                     <li><a {{#if (active_content request.spin-path-info "/cloud/cloud-plugin" )}} class="active"
                             {{/if}} href="{{site.info.base_url}}/cloud/cloud-plugin">Cloud Command Reference</a></li>
                     <li><a {{#if (active_content request.spin-path-info "/cloud/changelog" )}} class="active"

--- a/templates/cloud_sidebar.hbs
+++ b/templates/cloud_sidebar.hbs
@@ -75,8 +75,10 @@
                 <ul class="menu-list accordion-menu-item-content">
                     <li><a {{#if (active_content request.spin-path-info "/cloud/rest-api" )}} class="active" {{/if}}
                             href="{{site.info.base_url}}/cloud/rest-api">REST API</a></li>
-                    <li><a {{#if (active_content request.spin-path-info "/cloud/cli-reference" )}} class="active"
-                            {{/if}} href="{{site.info.base_url}}/cloud/cli-reference">CLI Reference</a></li>
+                    <li><a {{#if (active_content request.spin-path-info "/common/cli-reference" )}} class="active"
+                            {{/if}} href="{{site.info.base_url}}/common/cli-reference">Spin CLI Reference</a></li>
+                    <li><a {{#if (active_content request.spin-path-info "/cloud/cloud-plugin" )}} class="active"
+                            {{/if}} href="{{site.info.base_url}}/cloud/cloud-plugin">Cloud Command Reference</a></li>
                     <li><a {{#if (active_content request.spin-path-info "/cloud/changelog" )}} class="active"
                             {{/if}} href="{{site.info.base_url}}/cloud/changelog">Changelog</a></li>
                 </ul>


### PR DESCRIPTION
Cloud commands

We will likely want to link to the cloud plugin blog from here. 

~Draft PR to see what folks think about having this added page in cloud to describe the `spin cloud` subcommands.~

~For some reason, the tabs are not rendering correctly :/~

~Note: Made up the existence of a cloud plugin `v0.1.1` that has an unhidden variables command. Likely we will actually replace this version~ removed

~TODO: add definition of what supported spin version for each cloud plugin version~


Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors
- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
