### PR TITLE
Consistently link Go Packages for API docs, but do not use badge

### DIFF
--- a/content/spin/http-outbound.md
+++ b/content/spin/http-outbound.md
@@ -108,7 +108,7 @@ You can find a complete example for using outbound HTTP in the [Python SDK repos
 
 {{ startTab "TinyGo"}}
 
-HTTP functions are available in the `github.com/fermyon/spin/sdk/go/http` package. The general function is named `Send`, but the Go SDK also surfaces individual functions, with request-specific parameters, for the `Get` and `Post` operations. For example:
+HTTP functions are available in the `github.com/fermyon/spin/sdk/go/http` package. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/http). The general function is named `Send`, but the Go SDK also surfaces individual functions, with request-specific parameters, for the `Get` and `Post` operations. For example:
 
 ```go
 import (

--- a/content/spin/kv-store-api-guide.md
+++ b/content/spin/kv-store-api-guide.md
@@ -129,7 +129,7 @@ def handle_request(request):
 
 {{ startTab "TinyGo"}}
 
-Key value functions are provided by the `github.com/fermyon/spin/sdk/go/key_value` module. Here is the reference [![Go Reference](https://pkg.go.dev/badge/github.com/fermyon/spin/sdk/go/key_value.svg)](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/key_value). For example: 
+Key value functions are provided by the `github.com/fermyon/spin/sdk/go/key_value` module. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/key_value). For example: 
 
 ```go
 import "github.com/fermyon/spin/sdk/go/key_value"

--- a/content/spin/redis-outbound.md
+++ b/content/spin/redis-outbound.md
@@ -117,7 +117,7 @@ You can find a complete example for using outbound Redis from an HTTP component 
 
 {{ startTab "TinyGo"}}
 
-Redis functions are available in the `github.com/fermyon/spin/sdk/go/redis` package. The function names are TitleCased. For example:
+Redis functions are available in the `github.com/fermyon/spin/sdk/go/redis` package. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/redis). The function names are TitleCased. For example:
 
 ```go
 import (


### PR DESCRIPTION
Fixes #679.

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
