### PR TITLE
fix(cloud): add variables subcommands to cloud command reference

### DIFF
--- a/content/cloud/cloud-plugin.md
+++ b/content/cloud/cloud-plugin.md
@@ -10,9 +10,9 @@ url = "https://github.com/fermyon/developer/blob/main/content/cloud/cloud-plugin
   - [Deploy](#deploy)
   - [Login](#login)
   - [Variables](#variables)
-    - [Set (Variables)](#set-variables)
-    - [Delete (Variables)](#delete-variables)
-    - [List (Variables)](#list-variables)
+    - [Set (Variables)](#variables-set)
+    - [Delete (Variables)](#variables-delete)
+    - [List (Variables)](#variables-list)
   - [Subcommands Stability Table](#subcommands-stability-table)
 
 ## Spin Cloud Command
@@ -113,7 +113,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-## Login
+### Login
 
 {{ tabs "cloud-plugin-version" }}
 
@@ -193,6 +193,123 @@ SUBCOMMANDS:
     help      Print this message or the help of the given subcommand(s)
     list      List all variables of an application
     set       Set variable pairs
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+#### Variables (Set)
+
+{{ tabs "cloud-plugin-version" }} 
+
+{{ startTab "v0.1.1"}}
+
+Spin compatibility: `>= v1.3`
+
+<!-- @selectiveCpy -->
+```console
+$ spin cloud variables set --help
+
+cloud-variables-set 0.1.1
+Set variables
+
+USAGE:
+    cloud variables set [OPTIONS] --app <app> [VARIABLES_TO_SET]...
+
+ARGS:
+    <VARIABLES_TO_SET>...    Variable pair to set
+
+OPTIONS:
+        --app <app>
+            Name of Spin app
+
+        --environment-name <environment-name>
+            Deploy to the Fermyon instance saved under the specified name. If omitted, Spin deploys
+            to the default unnamed instance [env: FERMYON_DEPLOYMENT_ENVIRONMENT=]
+
+    -h, --help
+            Print help information
+
+    -V, --version
+            Print version information
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+#### Variables (Delete)
+
+{{ tabs "cloud-plugin-version" }} 
+
+{{ startTab "v0.1.1"}}
+
+Spin compatibility: `>= v1.3`
+
+<!-- @selectiveCpy -->
+```console
+$ spin cloud variables delete --help
+
+cloud-variables-delete 0.1.1
+Delete variables
+
+USAGE:
+    cloud variables delete [OPTIONS] --app <app> [VARIABLES_TO_DELETE]...
+
+ARGS:
+    <VARIABLES_TO_DELETE>...    Variable pair to set
+
+OPTIONS:
+        --app <app>
+            Name of Spin app
+
+        --environment-name <environment-name>
+            Deploy to the Fermyon instance saved under the specified name. If omitted, Spin deploys
+            to the default unnamed instance [env: FERMYON_DEPLOYMENT_ENVIRONMENT=]
+
+    -h, --help
+            Print help information
+
+    -V, --version
+            Print version information
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+#### Variables (List)
+
+{{ tabs "cloud-plugin-version" }} 
+
+{{ startTab "v0.1.1"}}
+
+Spin compatibility: `>= v1.3`
+
+<!-- @selectiveCpy -->
+```console
+$ spin cloud variables list --help
+
+cloud-variables-list 0.1.1
+List all variables of an application
+
+USAGE:
+    cloud variables list [OPTIONS] --app <app>
+
+OPTIONS:
+        --app <app>
+            Name of Spin app
+
+        --environment-name <environment-name>
+            Deploy to the Fermyon instance saved under the specified name. If omitted, Spin deploys
+            to the default unnamed instance [env: FERMYON_DEPLOYMENT_ENVIRONMENT=]
+
+    -h, --help
+            Print help information
+
+    -V, --version
+            Print version information
 ```
 
 {{ blockEnd }}

--- a/content/cloud/cloud-plugin.md
+++ b/content/cloud/cloud-plugin.md
@@ -6,14 +6,14 @@ enable_shortcodes = true
 url = "https://github.com/fermyon/developer/blob/main/content/cloud/cloud-plugin.md"
 
 ---
-- [Spin Cloud Command](#cloud)
+- [Spin Cloud Command](#spin-cloud-command)
   - [Deploy](#deploy)
   - [Login](#login)
   - [Variables](#variables)
-    - [Set (Variables)](#variables-set)
-    - [Delete (Variables)](#variables-delete)
-    - [List (Variables)](#variables-list)
-  - [Subcommands Stability Table](#subcommands-stability-table)
+    - [Set (Variables)](#set-variables)
+    - [Delete (Variables)](#delete-variables)
+    - [List (Variables)](#list-variables)
+  - [Subcommand Stability Table](#subcommand-stability-table)
 
 ## Spin Cloud Command
 
@@ -199,7 +199,7 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
-#### Variables (Set)
+#### Set (Variables)
 
 {{ tabs "cloud-plugin-version" }} 
 
@@ -239,7 +239,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-#### Variables (Delete)
+#### Delete (Variables)
 
 {{ tabs "cloud-plugin-version" }} 
 
@@ -279,7 +279,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-#### Variables (List)
+#### List (Variables)
 
 {{ tabs "cloud-plugin-version" }} 
 


### PR DESCRIPTION
I indexed but did not add the variables subcommands. this adds them

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors
- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
