### PR TITLE
Add an API Guide for Configuration Variables

### DIFF
--- a/content/cloud/faq.md
+++ b/content/cloud/faq.md
@@ -46,6 +46,7 @@ Fermyon Cloud supports Spin CLI v0.6.0 or newer. That being said, there are cert
 | [Redis](/spin/redis-trigger) | Not supported |
 | **APIs** |
 | [Outbound HTTP](/spin/rust-components.md#sending-outbound-http-requests) | Supported |
+| [Configuration Variables](/spin/variables) | Supported |
 | [Key Value Storage](/spin/kv-store-api-guide) | Supported (only default store) |
 | [MySQL](/spin/rdbms-storage#using-mysql-and-postgresql-from-applications) | Supported |
 | [PostgreSQL](/spin/rdbms-storage#using-mysql-and-postgresql-from-applications) | Supported |

--- a/content/cloud/variables.md
+++ b/content/cloud/variables.md
@@ -134,8 +134,6 @@ def handle_request(request):
     return Response(200,
                     {"content-type": "application/json"},
                     bytes(response, "utf-8"))
-
-
 ```
 
 Build and run the application locally to test it out. We will use the [environment variable provider](/spin/dynamic-configuration.md#environment-variable-provider) to set the variable values locally. The provider gets the variable values from the `spin` process's environment, searching for environment variables prefixed with `SPIN_CONFIG_`.

--- a/content/spin/api-guides-overview.md
+++ b/content/spin/api-guides-overview.md
@@ -14,7 +14,8 @@ The following table shows the status of the interfaces Spin provides to applicat
 | [Redis Trigger](/spin/redis-trigger)                         | Stable   | No  |
 | [Outbound HTTP](/spin/http-outbound)                          | Stable   | Yes   |
 | [Outbound Redis](/spin/redis-outbound)                         | Stable  | Yes   |
-| [Dynamic Configuration](/spin/dynamic-configuration)                         | Experimental | No |
+| [Configuration Variables](/spin/variables)                      | Stable | Yes |
+| [Runtime Configuration](/spin/dynamic-configuration#runtime-configuration)  | Experimental | No |
 | [PostgreSQL](/spin/rdbms-storage)                             | Experimental | Yes |
 | [MySQL](/spin/rdbms-storage)                                  | Experimental | Yes |
 | [Key-value Storage](/spin/kv-store-api-guide)                      | Stabilizing | Yes |

--- a/content/spin/api-guides-overview.md
+++ b/content/spin/api-guides-overview.md
@@ -15,7 +15,6 @@ The following table shows the status of the interfaces Spin provides to applicat
 | [Outbound HTTP](/spin/http-outbound)                          | Stable   | Yes   |
 | [Outbound Redis](/spin/redis-outbound)                         | Stable  | Yes   |
 | [Configuration Variables](/spin/variables)                      | Stable | Yes |
-| [Runtime Configuration](/spin/dynamic-configuration#runtime-configuration)  | Experimental | No |
 | [PostgreSQL](/spin/rdbms-storage)                             | Experimental | Yes |
 | [MySQL](/spin/rdbms-storage)                                  | Experimental | Yes |
 | [Key-value Storage](/spin/kv-store-api-guide)                      | Stabilizing | Yes |

--- a/content/spin/language-support-overview.md
+++ b/content/spin/language-support-overview.md
@@ -20,6 +20,7 @@ This page contains information about language support for Spin features:
 | [Redis](/spin/redis-trigger) | Supported |
 | **APIs** |
 | [Outbound HTTP](/spin/rust-components.md#sending-outbound-http-requests) | Supported |
+| [Configuration Variables](/spin/variables) | Supported |
 | [Key Value Storage](/spin/kv-store-api-guide) | Supported |
 | [MySQL](/spin/rdbms-storage#using-mysql-and-postgresql-from-applications) | Supported |
 | [PostgreSQL](/spin/rdbms-storage#using-mysql-and-postgresql-from-applications) | Supported |
@@ -38,6 +39,7 @@ This page contains information about language support for Spin features:
 | Redis | Not Supported |
 | **APIs** |
 | [Outbound HTTP](/spin/javascript-components#sending-outbound-http-requests) | Supported |
+| [Configuration Variables](/spin/dynamic-configuration#custom-config-variables) | Supported |
 | [Key Value Storage](/spin/kv-store-api-guide) | Supported |
 | MySQL | Not Supported |
 | PostgreSQL| Not Supported |
@@ -56,6 +58,7 @@ This page contains information about language support for Spin features:
 | Redis | Not Supported |
 | **APIs** |
 | [Outbound HTTP](/spin/python-components#an-outbound-http-example) | Supported |
+| [Configuration Variables](/spin/dynamic-configuration#custom-config-variables) | Supported |
 | [Key Value Storage](/spin/kv-store-api-guide) | Supported |
 | MySQL | Not Supported |
 | PostgreSQL | Not Supported |
@@ -74,6 +77,7 @@ This page contains information about language support for Spin features:
 | [Redis](/spin/go-components#redis-components) | Supported |
 | **APIs** |
 | [Outbound HTTP](/spin/go-components#sending-outbound-http-requests) | Supported |
+| [Configuration Variables](/spin/dynamic-configuration#custom-config-variables) | Supported |
 | [Key Value Storage](/spin/kv-store-api-guide) | Supported |
 | MySQL | Not Supported |
 | PostgreSQL | Not Supported |
@@ -92,6 +96,7 @@ This page contains information about language support for Spin features:
 | Redis | Not Supported |
 | **APIs** |
 | [Outbound HTTP](https://github.com/fermyon/spin-dotnet-sdk#making-outbound-http-requests) | Supported |
+| [Configuration Variables](/spin/dynamic-configuration#custom-config-variables) | Supported |
 | Key Value Storage | Not Supported |
 | MySQL | Not Supported |
 | [PostgreSQL](https://github.com/fermyon/spin-dotnet-sdk#working-with-postgres) | Supported |

--- a/content/spin/variables.md
+++ b/content/spin/variables.md
@@ -1,0 +1,205 @@
+title = "Configuration Variables"
+template = "spin_main"
+date = "2022-06-14T00:22:56Z"
+enable_shortcodes = true
+[extra]
+url = "https://github.com/fermyon/developer/blob/main//content/spin/variables.md"
+
+---
+- [Using the Config SDK to Get Variables](#using-the-config-sdk-to-get-variables)
+
+Spin supports dynamic application variables. Instead of being static, their values can be updated without modifying the application, creating a simpler experience for rotating secrets, updating API endpoints, and more. 
+
+These variables are defined in a Spin application manifest (in the `[variables]` section) and are provided by a [configuration provider](/spin/dynamic-configuration.md#custom-config-providers). When running Spin locally, the configuration provider can be Vault for secrets or host environment variables. Refer to the [dynamic configuration documentation](/spin/dynamic-configuration.md) to learn how to configure variables locally.
+
+## Using the Config SDK to Get Variables
+
+The Spin SDK surfaces the Spin Config interface to your language. The [interface](https://github.com/fermyon/spin/blob/main/wit/ephemeral/spin-config.wit) consists of one operation:
+
+| Operation  | Parameters                          | Returns             | Behavior |
+|------------|-------------------------------------|---------------------|----------|
+| `get-config`    | Variable name  | Variable value    | Gets the value of the variable from the configured provider |
+
+In order to get a variable, it must be declared in an application's manifest (`spin.toml`). For example, say an application needs to access a secret. A variable named `password` could be added to the manifest and set as required with `required = true` since there is no reasonable default value for a secret. To do this, add a top-level `[variables]` section to the application manifest (`spin.toml`) and declare the variable within it.
+
+<!-- @selectiveCpy -->
+```toml
+# Add this above the [component] section
+[variables]
+password = { required = true }
+```
+
+To surface the variable to a component, add a `[component.config]` section in the component and specify the variable within it. Instead of statically assigning the value of the config variable, dynamically reference the variable with [mustache](https://mustache.github.io/)-inspired string templates. Only components that explicitly use the variables in their configuration section will get access to them. This enables only exposing variables and secrets to the desired components of an application.
+
+```toml
+# Add this below the [component.build] section
+[component.config]
+password = "\{{ password }}"
+```
+
+The resulting application manifest should look similar to the following, with the `[component.build]` section varying depending on the language used to build the `password_checker` component:
+
+<!-- @selectiveCpy -->
+```toml
+spin_manifest_version = "1"
+description = "A Spin app with a dynamically updatable variable"
+name = "password_checker"
+trigger = { type = "http", base = "/" }
+version = "0.1.0"
+
+[variables]
+password = { required = true }
+
+[[component]]
+id = "password_checker"
+source = "app.wasm"
+[component.trigger]
+route = "/..."
+[component.build]
+command = "spin py2wasm app -o app.wasm"
+[component.config]
+password = "\{{ password }}"
+```
+
+To illustrate the config API, each of the following examples receives a password via the HTTP request body, compares it to an expected password, and returns a JSON response indicating whether the submitted password matched or not. To use the [environment variable provider](/spin/dynamic-configuration.md#environment-variable-provider) to set the variable values locally, set the `password` variable's value in an environment variable prefixed with `SPIN_CONFIG_`. The provider gets the variable values from the `spin` process's environment:
+
+<!-- @selectiveCpy -->
+```bash
+$ SPIN_CONFIG_PASSWORD="123" spin build --up
+
+Serving http://127.0.0.1:3000
+Available Routes:
+  password-checker: http://127.0.0.1:3000 (wildcard)
+```
+
+Send a request to the application with the correct password in the body to authenticate successfully.
+
+<!-- @selectiveCpy -->
+```bash
+$ curl -d "123" http://127.0.0.1:3000
+{"authentication": "accepted"}
+```
+
+The exact details of calling the config SDK from a Spin application depends on the language:
+
+{{ tabs "sdk-type" }}
+
+{{ startTab "Rust"}}
+
+The config function is available in the `spin_sdk::config` module.
+
+```rust
+use anyhow::Result;
+use spin_sdk::{
+    config,
+    http::{Request, Response},
+    http_component,
+};
+
+#[http_component]
+fn handle_spin_example(req: Request) -> Result<Response> {
+    let password = std::str::from_utf8(req.body().as_ref().unwrap()).unwrap();
+    let expected = config::get("password").expect("could not get variable");
+    let response = if expected == password {
+        "accepted"
+    } else {
+        "denied"
+    };
+    let response_json = format!("\{{\"authentication\": \"{}\"}}", response);
+    Ok(http::Response::builder()
+        .status(200)
+        .header("Content-Type", "application/json")
+        .body(Some(response_json.into()))?)
+}
+
+```
+
+{{ blockEnd }}
+
+{{ startTab "TypeScript"}}
+
+The config function is available in the `spinSdk.config` package.
+
+```ts
+import { HandleRequest, HttpRequest, HttpResponse } from "@fermyon/spin-sdk"
+
+const decoder = new TextDecoder("utf-8")
+
+export const handleRequest: HandleRequest = async function (request: HttpRequest): Promise<HttpResponse> {
+  const expected = decoder.decode(request.body)
+  let password = spinSdk.config.get("openai_key")
+  let access = "denied"
+  if (expected === password) {
+      access = "accepted"
+  }
+  let responseJson = `{\"authentication\": \"${access}\"}`;
+
+  return {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    body: responseJson
+  }
+}
+
+```
+
+{{ blockEnd }}
+
+{{ startTab "Python"}}
+
+The config function is available in the `spin_config` package.
+
+```py
+from spin_http import Response
+from spin_config import config_get
+
+def handle_request(request):
+    password = request.body.decode("utf-8")
+    expected = config_get("password")
+    access = "denied"
+    if expected == password:
+        access = "accepted"
+    response = f'\{{"authentication": "{access}"}}'
+    return Response(200,
+                    {"content-type": "application/json"},
+                    bytes(response, "utf-8"))
+```
+
+{{ blockEnd }}
+
+{{ startTab "TinyGo"}}
+
+The config function is available in the `github.com/fermyon/spin/sdk/go/config` package. See [Go package](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/config) for reference documentation.
+
+```go
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	spinconfig "github.com/fermyon/spin/sdk/go/config"
+	spinhttp "github.com/fermyon/spin/sdk/go/http"
+)
+
+spinhttp.Handle(func(w http.ResponseWriter, r *http.Request) {
+    access := "denied"
+    password, err := io.ReadAll(r.Body)
+    if err == nil {
+        expected, err := spinconfig.Get("password")
+        if err != nil {
+            http.Error(w, err.Error(), http.StatusInternalServerError)
+            return
+        }
+        if expected == string(password) {
+            access = "accepted"
+        }
+    }
+    response := fmt.Sprintf("{\"authentication\": \"%s\"}", access)
+    w.Header().Set("Content-Type", "application/json")
+    fmt.Fprintln(w, response)
+})
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}

--- a/templates/spin_sidebar.hbs
+++ b/templates/spin_sidebar.hbs
@@ -87,6 +87,8 @@
                             href="{{site.info.base_url}}/spin/rdbms-storage">Relational Database Storage</a></li>
                     <li><a {{#if (active_content request.spin-path-info "/spin/kv-store-api-guide" )}} class="active"
                             {{/if}} href="{{site.info.base_url}}/spin/kv-store-api-guide">Key Value Store</a></li>
+                    <li><a {{#if (active_content request.spin-path-info "/spin/variables" )}} class="active"
+                            {{/if}} href="{{site.info.base_url}}/spin/variables">Configuration Variables</a></li>
                 </ul>
             </div>
             <div class="accordion-menu-item">

--- a/templates/spin_sidebar.hbs
+++ b/templates/spin_sidebar.hbs
@@ -88,7 +88,7 @@
                     <li><a {{#if (active_content request.spin-path-info "/spin/kv-store-api-guide" )}} class="active"
                             {{/if}} href="{{site.info.base_url}}/spin/kv-store-api-guide">Key Value Store</a></li>
                     <li><a {{#if (active_content request.spin-path-info "/spin/variables" )}} class="active"
-                            {{/if}} href="{{site.info.base_url}}/spin/variables">Configuration Variables</a></li>
+                            {{/if}} href="{{site.info.base_url}}/spin/variables">Application Variables</a></li>
                 </ul>
             </div>
             <div class="accordion-menu-item">


### PR DESCRIPTION
We have been missing an API for Config Variables. I added one and reference it from the FAQ page.

The examples in the guide are more verbose than other guides. Let me know it they are not minimal enough. I like the idea of having working handles. 

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
