### PR TITLE
Adding 1.3 to the cli reference

### DIFF
--- a/content/spin/cli-reference.md
+++ b/content/spin/cli-reference.md
@@ -6,170 +6,43 @@ enable_shortcodes = true
 url = "https://github.com/fermyon/developer/blob/main/content/spin/cli-reference.md"
 
 ---
-- [Spin](#spin)
-  - [Add](#add)
-  - [Build](#build)
-  - [Cloud](#cloud)
-    - [Deploy (Cloud)](#deploy-cloud)
-    - [Login (Cloud)](#login-cloud)
-  - [Deploy](#deploy)
-  - [Help](#help)
-  - [Login](#login)
-  - [New](#new)
-  - [Plugins](#plugins)
-    - [Install (Plugins)](#install-plugins)
-    - [List (Plugins)](#list-plugins)
-    - [Uninstall (Plugins)](#uninstall-plugins)
-    - [Update (Plugins)](#update-plugins)
-    - [Upgrade (Plugins)](#upgrade-plugins)
-  - [OCI Registry](#oci-registry)
-    - [Login (OCI Registry)](#login-oci-registry)
-    - [Pull (OCI Registry)](#pull-oci-registry)
-    - [Push (OCI Registry)](#push-oci-registry)
-  - [Templates](#templates)
-    - [Install (Templates)](#install-templates)
-    - [List (Templates)](#list-templates)
-    - [Uninstall (Templates)](#uninstall-templates)
-    - [Upgrade (Templates)](#upgrade-templates)
-  - [Up](#up)
-    - [Trigger Options](#trigger-options)
-      - [Redis Request Handler](#redis-request-handler)
-      - [HTTP Request Handler](#http-request-handler)
-  - [Watch](#watch)
-  - [CLI Stability Table](#cli-stability-table)
+- [add](#add)
+- [build](#build)
+- [cloud](#cloud)
+- [deploy](#deploy)
+- [cloud deploy](#cloud-deploy)
+- [login](#login)
+- [cloud login](#cloud-login)
+- [cloud variables](#cloud-variables)
+- [help](#help)
+- [new](#new)
+- [plugin](#plugin)
+- [plugins](#plugins)
+- [plugins install](#plugins-install)
+- [plugins list](#plugins-list)
+- [plugins uninstall](#plugins-uninstall)
+- [plugins update](#plugins-update)
+- [plugins upgrade](#plugins-upgrade)
+- [oci](#oci)
+- [registry](#registry)
+- [registry login](#registry-login)
+- [registry pull](#registry-pull)
+- [registry push](#registry-push)
+- [template](#template)
+- [templates](#templates)
+- [templates install](#templates-install)
+- [templates list](#templates-list)
+- [templates uninstall](#templates-uninstall)
+- [templates upgrade](#templates-upgrade)
+- [up](#up)
+- [watch](#watch)
+- [CLI Stability Table](#cli-stability-table)
 
-## Spin
+This page documents the Spin Command Line Interface (CLI).
 
-This page documents the Spin Command Line Interface (CLI). Specifically, all of the available Spin Options and Subcommands. For more information on command stability, see the [CLI stability table](#cli-stability-table). You can reproduce the Spin CLI documentation on your machine by using the `--help` flag. For example:
+For information on command stability, see the [CLI stability table](#cli-stability-table).
 
-{{ tabs "spin-version" }}
-
-{{ startTab "v1.0.0"}}
-
-<!-- @selectiveCpy -->
-
-```console
-$ spin --help
-
-USAGE:
-    spin <SUBCOMMAND>
-
-OPTIONS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-
-SUBCOMMANDS:
-    add          Scaffold a new component into an existing application
-    build        Build the Spin application
-    cloud        Commands for publishing applications to the Fermyon Platform
-    deploy       Package and upload an application to the Fermyon Platform
-    help         Print this message or the help of the given subcommand(s)
-    login        Log into the Fermyon Platform
-    new          Scaffold a new application based on a template
-    plugins      Install/uninstall Spin plugins
-    registry     Commands for working with OCI registries to distribute applications
-    templates    Commands for working with WebAssembly component templates
-    up           Start the Spin application
-```
-
-{{ blockEnd }}
-
-{{ startTab "v1.1.0"}}
-
-<!-- @selectiveCpy -->
-
-```console
-$ spin --help
-
-USAGE:
-    spin <SUBCOMMAND>
-
-OPTIONS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-
-SUBCOMMANDS:
-    add          Scaffold a new component into an existing application
-    build        Build the Spin application
-    cloud        Commands for publishing applications to the Fermyon Platform
-    deploy       Package and upload an application to the Fermyon Platform
-    help         Print this message or the help of the given subcommand(s)
-    login        Log into the Fermyon Platform
-    new          Scaffold a new application based on a template
-    plugins      Install/uninstall Spin plugins
-    registry     Commands for working with OCI registries to distribute applications
-    templates    Commands for working with WebAssembly component templates
-    up           Start the Spin application
-    watch        Rebuild and restart the Spin application when files changes
-```
-
-{{ blockEnd }}
-
-{{ startTab "v1.2.0"}}
-
-<!-- @selectiveCpy -->
-
-```console
-$ spin --help
-
-USAGE:
-    spin <SUBCOMMAND>
-
-OPTIONS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-
-SUBCOMMANDS:
-    add          Scaffold a new component into an existing application
-    build        Build the Spin application
-    cloud        Commands for publishing applications to the Fermyon Platform
-    deploy       Package and upload an application to the Fermyon Platform
-    help         Print this message or the help of the given subcommand(s)
-    login        Log into the Fermyon Platform
-    new          Scaffold a new application based on a template
-    plugins      Install/uninstall Spin plugins
-    registry     Commands for working with OCI registries to distribute applications
-    templates    Commands for working with WebAssembly component templates
-    up           Start the Spin application
-    watch        Build and run the Spin application, rebuilding and restarting it when files
-```
-
-{{ blockEnd }}
-
-{{ startTab "v1.3.0"}}
-
-<!-- @selectiveCpy -->
-
-```console
-$ spin --help
-
-USAGE:
-    spin <SUBCOMMAND>
-
-OPTIONS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-
-SUBCOMMANDS:
-    add          Scaffold a new component into an existing application
-    build        Build the Spin application
-    cloud        Commands for publishing applications to the Fermyon Platform
-    deploy       Package and upload an application to the Fermyon Platform
-    help         Print this message or the help of the given subcommand(s)
-    login        Log into the Fermyon Platform
-    new          Scaffold a new application based on a template
-    plugins      Install/uninstall Spin plugins
-    registry     Commands for working with OCI registries to distribute applications
-    templates    Commands for working with WebAssembly component templates
-    up           Start the Spin application
-    watch        Build and run the Spin application, rebuilding and restarting it when files
-```
-
-{{ blockEnd }}
-
-{{ blockEnd }}
-
-### Add
+### add
 
 Adding a subcommand (and again issuing the `--help` command) will provide information specific to that particular subcommand. For example:
 
@@ -247,7 +120,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -321,7 +194,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-### Build
+### build
 
 {{ tabs "spin-version" }}
 
@@ -373,7 +246,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -432,7 +305,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-### Cloud
+### cloud
 
 {{ tabs "spin-version" }}
 
@@ -484,7 +357,7 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -510,6 +383,8 @@ SUBCOMMANDS:
 
 {{ startTab "v1.3.0"}}
 
+The `cloud` command is implemented by the [cloud-plugin](https://github.com/fermyon/cloud-plugin).
+
 <!-- @selectiveCpy -->
 
 ```console
@@ -530,12 +405,17 @@ SUBCOMMANDS:
     help         Print this message or the help of the given subcommand(s)
     login        Login to Fermyon Cloud
     variables    Manage Spin application variables
+```
 
 {{ blockEnd }}
 
 {{ blockEnd }}
 
-#### Deploy (Cloud)
+### deploy
+
+`spin deploy` is a shotcurt to [`spin cloud deploy`](#cloud-deploy).
+
+### cloud deploy
 
 {{ tabs "spin-version" }}
 
@@ -633,7 +513,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -682,6 +562,8 @@ OPTIONS:
 {{ blockEnd }}
 
 {{ startTab "v1.3.0"}}
+
+The `cloud deploy` command is implemented by the [cloud-plugin](https://github.com/fermyon/cloud-plugin).
 
 <!-- @selectiveCpy -->
 
@@ -738,9 +620,13 @@ OPTIONS:
 
 {{ blockEnd }}
 
-#### Login (Cloud)
+### login
 
-Please note: the previous `spin login` command (from versions before Spin v0.9.0) has been kept to ensure backward compatibility. In the Spin v0.9.0 release, both the `spin login --help` and `spin cloud login --help` commands will produce the same output, which is as follows:
+Please note: the previous `spin login` command (from versions before Spin v0.9.0) has been kept to ensure backward compatibility. In the Spin v0.9.0 release, both the `spin login --help` and [`spin cloud login --help`](#cloud-login) commands will produce the same output.
+
+`spin login` is a shotcurt to [`spin cloud login`](#cloud-login).
+
+### cloud login
 
 {{ tabs "spin-version" }}
 
@@ -860,7 +746,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -919,6 +805,8 @@ OPTIONS:
 {{ blockEnd }}
 
 {{ startTab "v1.3.0"}}
+
+The `cloud login` command is implemented by the [cloud-plugin](https://github.com/fermyon/cloud-plugin).
 
 <!-- @selectiveCpy -->
 
@@ -966,11 +854,13 @@ OPTIONS:
 
 {{ blockEnd }}
 
-#### Variables (Cloud)
+### cloud variables
 
 {{ tabs "spin-version" }}
 
 {{ startTab "v1.3.0"}}
+
+The `variables` command is implemented by the [cloud-plugin](https://github.com/fermyon/cloud-plugin).
 
 <!-- @selectiveCpy -->
 
@@ -999,206 +889,7 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
-### Deploy
-
-{{ tabs "spin-version" }}
-
-{{ startTab "v1.0.0"}}
-
-<!-- @selectiveCpy -->
-```console
-$ spin deploy --help
-
-spin-deploy 
-Package and upload an application to the Fermyon Platform
-
-USAGE:
-    spin deploy [OPTIONS]
-
-OPTIONS:
-        --buildinfo <BUILDINFO>
-            Build metadata to append to the bindle version
-
-    -d, --staging-dir <STAGING_DIR>
-            Path to assemble the bindle before pushing (defaults to a temporary directory)
-
-    -e, --deploy-existing-bindle
-            Deploy existing bindle if it already exists on bindle server
-
-        --environment-name <environment-name>
-            Deploy to the Fermyon instance saved under the specified name. If omitted, Spin deploys
-            to the default unnamed instance [env: FERMYON_DEPLOYMENT_ENVIRONMENT=]
-
-    -f, --file <APP_MANIFEST_FILE>
-            Path to spin.toml [default: spin.toml]
-
-    -h, --help
-            Print help information
-
-        --key-value <KEY_VALUES>
-            Pass a key/value (key=value) to all components of the application. Can be used multiple
-            times
-
-        --no-buildinfo
-            Disable attaching buildinfo [env: SPIN_DEPLOY_NO_BUILDINFO=]
-
-        --readiness-timeout <READINESS_TIMEOUT_SECS>
-            How long in seconds to wait for a deployed HTTP application to become ready. The default
-            is 60 seconds. Set it to 0 to skip waiting for readiness [default: 60]
-```
-
-{{ blockEnd }}
-
-{{ startTab "v1.1.0"}}
-
-<!-- @selectiveCpy -->
-```console
-$ spin deploy --help
-
-spin-deploy 
-Package and upload an application to the Fermyon Platform
-
-USAGE:
-    spin deploy [OPTIONS]
-
-OPTIONS:
-        --buildinfo <BUILDINFO>
-            Build metadata to append to the bindle version
-
-    -d, --staging-dir <STAGING_DIR>
-            Path to assemble the bindle before pushing (defaults to a temporary directory)
-
-    -e, --deploy-existing-bindle
-            Deploy existing bindle if it already exists on bindle server
-
-        --environment-name <environment-name>
-            Deploy to the Fermyon instance saved under the specified name. If omitted, Spin deploys
-            to the default unnamed instance [env: FERMYON_DEPLOYMENT_ENVIRONMENT=]
-
-    -f, --file <APP_MANIFEST_FILE>
-            Path to spin.toml [default: spin.toml]
-
-    -h, --help
-            Print help information
-
-        --key-value <KEY_VALUES>
-            Pass a key/value (key=value) to all components of the application. Can be used multiple
-            times
-
-        --no-buildinfo
-            Disable attaching buildinfo [env: SPIN_DEPLOY_NO_BUILDINFO=]
-
-        --readiness-timeout <READINESS_TIMEOUT_SECS>
-            How long in seconds to wait for a deployed HTTP application to become ready. The default
-            is 60 seconds. Set it to 0 to skip waiting for readiness [default: 60]
-```
-
-{{ blockEnd }}
-
-{{ startTab "v1.2.0"}}
-
-<!-- @selectiveCpy -->
-```console
-$ spin deploy --help
-
-spin-deploy 
-Package and upload an application to the Fermyon Platform
-
-USAGE:
-    spin deploy [OPTIONS]
-
-OPTIONS:
-        --buildinfo <BUILDINFO>
-            Build metadata to append to the bindle version
-
-    -d, --staging-dir <STAGING_DIR>
-            Path to assemble the bindle before pushing (defaults to a temporary directory)
-
-    -e, --deploy-existing-bindle
-            Deploy existing bindle if it already exists on bindle server
-
-        --environment-name <environment-name>
-            Deploy to the Fermyon instance saved under the specified name. If omitted, Spin deploys
-            to the default unnamed instance [env: FERMYON_DEPLOYMENT_ENVIRONMENT=]
-
-    -f, --from <APP_MANIFEST_FILE>
-            The application to deploy. This may be a manifest (spin.toml) file, or a directory
-            containing a spin.toml file. If omitted, it defaults to "spin.toml" [default: spin.toml]
-
-    -h, --help
-            Print help information
-
-        --key-value <KEY_VALUES>
-            Set a key/value pair (key=value) in the deployed application's default store. Any
-            existing value will be overwritten. Can be used multiple times
-
-        --no-buildinfo
-            Disable attaching buildinfo [env: SPIN_DEPLOY_NO_BUILDINFO=]
-
-        --readiness-timeout <READINESS_TIMEOUT_SECS>
-            How long in seconds to wait for a deployed HTTP application to become ready. The default
-            is 60 seconds. Set it to 0 to skip waiting for readiness [default: 60]
-```
-
-{{ blockEnd }}
-
-{{ startTab "v1.3.0"}}
-
-<!-- @selectiveCpy -->
-```console
-$ spin deploy --help
-
-cloud-deploy 0.1.1
-Package and upload an application to the Fermyon Cloud
-
-USAGE:
-    cloud deploy [OPTIONS]
-
-OPTIONS:
-        --buildinfo <BUILDINFO>
-            Build metadata to append to the bindle version
-
-    -d, --staging-dir <STAGING_DIR>
-            Path to assemble the bindle before pushing (defaults to a temporary directory)
-
-    -e, --deploy-existing-bindle
-            Deploy existing bindle if it already exists on bindle server
-
-        --environment-name <environment-name>
-            Deploy to the Fermyon instance saved under the specified name. If omitted, Spin deploys
-            to the default unnamed instance [env: FERMYON_DEPLOYMENT_ENVIRONMENT=]
-
-    -f, --from <APP_MANIFEST_FILE>
-            The application to deploy. This may be a manifest (spin.toml) file, or a directory
-            containing a spin.toml file. If omitted, it defaults to "spin.toml" [default: spin.toml]
-
-    -h, --help
-            Print help information
-
-        --key-value <KEY_VALUES>
-            Set a key/value pair (key=value) in the deployed application's default store. Any
-            existing value will be overwritten. Can be used multiple times
-
-        --no-buildinfo
-            Disable attaching buildinfo [env: SPIN_DEPLOY_NO_BUILDINFO=]
-
-        --readiness-timeout <READINESS_TIMEOUT_SECS>
-            How long in seconds to wait for a deployed HTTP application to become ready. The default
-            is 60 seconds. Set it to 0 to skip waiting for readiness [default: 60]
-
-    -V, --version
-            Print version information
-
-        --variable <VARIABLES>
-            Set a variable (variable=value) in the deployed application. Any existing value will be
-            overwritten. Can be used multiple times
-```
-
-{{ blockEnd }}
-
-{{ blockEnd }}
-
-### Help
+### help
 
 {{ tabs "spin-version" }}
 
@@ -1266,14 +957,14 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
 
 <!-- @selectiveCpy -->
 
 ```console
 $ spin help      
 
-spin 1.2.0 
+spin 1.2.0/1.2.1 
 The Spin CLI
 
 USAGE:
@@ -1341,233 +1032,7 @@ SUBCOMMANDS:
 
 > Please note: Spin `help` is a convenient way to access help using a subcommand, instead of using the `--help` option. For example, `spin help cloud` will give you the same output as `spin cloud --help`. Similarly, `spin help build` will give you the same output as `spin build --help` and so forth.
 
-### Login
-
-{{ tabs "spin-version" }}
-
-{{ startTab "v1.0.0"}}
-
-<!-- @selectiveCpy -->
-
-```console
-$ spin login --help
-
-spin-login 
-Log into the Fermyon Platform
-
-USAGE:
-    spin login [OPTIONS]
-
-OPTIONS:
-        --auth-method <auth-method>
-            [env: AUTH_METHOD=] [possible values: github, username, token]
-
-        --bindle-password <BINDLE_PASSWORD>
-            Basic http auth password for the bindle server [env: BINDLE_PASSWORD=]
-
-        --bindle-server <BINDLE_SERVER_URL>
-            URL of bindle server [env: BINDLE_URL=]
-
-        --bindle-username <BINDLE_USERNAME>
-            Basic http auth username for the bindle server [env: BINDLE_USERNAME=]
-
-        --environment-name <environment-name>
-            Save the login details under the specified name instead of making them the default. Use
-            named environments with `spin deploy --environment-name <name>` [env:
-            FERMYON_DEPLOYMENT_ENVIRONMENT=]
-
-    -h, --help
-            Print help information
-
-    -k, --insecure
-            Ignore server certificate errors from bindle and hippo
-
-        --list
-            List saved logins
-
-        --password <HIPPO_PASSWORD>
-            Hippo password [env: HIPPO_PASSWORD=]
-
-        --status
-            Display login status
-
-        --token <TOKEN>
-            Auth Token [env: SPIN_AUTH_TOKEN=]
-
-        --url <HIPPO_SERVER_URL>
-            URL of hippo server [env: HIPPO_URL=] [default: https://cloud.fermyon.com/]
-
-        --username <HIPPO_USERNAME>
-            Hippo username [env: HIPPO_USERNAME=]
-```
-
-{{ blockEnd }}
-
-{{ startTab "v1.1.0"}}
-
-<!-- @selectiveCpy -->
-
-```console
-$ spin login --help
-
-spin-login 
-Log into the Fermyon Platform
-
-USAGE:
-    spin login [OPTIONS]
-
-OPTIONS:
-        --auth-method <auth-method>
-            [env: AUTH_METHOD=] [possible values: github, username, token]
-
-        --bindle-password <BINDLE_PASSWORD>
-            Basic http auth password for the bindle server [env: BINDLE_PASSWORD=]
-
-        --bindle-server <BINDLE_SERVER_URL>
-            URL of bindle server [env: BINDLE_URL=]
-
-        --bindle-username <BINDLE_USERNAME>
-            Basic http auth username for the bindle server [env: BINDLE_USERNAME=]
-
-        --environment-name <environment-name>
-            Save the login details under the specified name instead of making them the default. Use
-            named environments with `spin deploy --environment-name <name>` [env:
-            FERMYON_DEPLOYMENT_ENVIRONMENT=]
-
-    -h, --help
-            Print help information
-
-    -k, --insecure
-            Ignore server certificate errors from bindle and hippo
-
-        --list
-            List saved logins
-
-        --password <HIPPO_PASSWORD>
-            Hippo password [env: HIPPO_PASSWORD=]
-
-        --status
-            Display login status
-
-        --token <TOKEN>
-            Auth Token [env: SPIN_AUTH_TOKEN=]
-
-        --url <HIPPO_SERVER_URL>
-            URL of hippo server [env: HIPPO_URL=] [default: https://cloud.fermyon.com/]
-
-        --username <HIPPO_USERNAME>
-            Hippo username [env: HIPPO_USERNAME=]
-```
-
-{{ blockEnd }}
-
-{{ startTab "v1.2.0"}}
-
-<!-- @selectiveCpy -->
-
-```console
-$ spin login --help
-
-spin-login 
-Log into the Fermyon Platform
-
-USAGE:
-    spin login [OPTIONS]
-
-OPTIONS:
-        --auth-method <auth-method>
-            [env: AUTH_METHOD=] [possible values: github, username, token]
-
-        --bindle-password <BINDLE_PASSWORD>
-            Basic http auth password for the bindle server [env: BINDLE_PASSWORD=]
-
-        --bindle-server <BINDLE_SERVER_URL>
-            URL of bindle server [env: BINDLE_URL=]
-
-        --bindle-username <BINDLE_USERNAME>
-            Basic http auth username for the bindle server [env: BINDLE_USERNAME=]
-
-        --environment-name <environment-name>
-            Save the login details under the specified name instead of making them the default. Use
-            named environments with `spin deploy --environment-name <name>` [env:
-            FERMYON_DEPLOYMENT_ENVIRONMENT=]
-
-    -h, --help
-            Print help information
-
-    -k, --insecure
-            Ignore server certificate errors from bindle and hippo
-
-        --list
-            List saved logins
-
-        --password <HIPPO_PASSWORD>
-            Hippo password [env: HIPPO_PASSWORD=]
-
-        --status
-            Display login status
-
-        --token <TOKEN>
-            Auth Token [env: SPIN_AUTH_TOKEN=]
-
-        --url <HIPPO_SERVER_URL>
-            URL of hippo server [env: HIPPO_URL=] [default: https://cloud.fermyon.com/]
-
-        --username <HIPPO_USERNAME>
-            Hippo username [env: HIPPO_USERNAME=]
-```
-
-{{ blockEnd }}
-
-{{ startTab "v1.3.0"}}
-
-<!-- @selectiveCpy -->
-
-```console
-$ spin login --help
-
-cloud-login 0.1.1
-Login to Fermyon Cloud
-
-USAGE:
-    cloud login [OPTIONS]
-
-OPTIONS:
-        --auth-method <auth-method>
-            [env: AUTH_METHOD=] [possible values: github, token]
-
-        --environment-name <environment-name>
-            Save the login details under the specified name instead of making them the default. Use
-            named environments with `spin deploy --environment-name <name>` [env:
-            FERMYON_DEPLOYMENT_ENVIRONMENT=]
-
-    -h, --help
-            Print help information
-
-    -k, --insecure
-            Ignore server certificate errors
-
-        --list
-            List saved logins
-
-        --status
-            Display login status
-
-        --token <TOKEN>
-            Auth Token [env: SPIN_AUTH_TOKEN=]
-
-        --url <CLOUD_SERVER_URL>
-            URL of Fermyon Cloud Instance [env: CLOUD_URL=] [default: https://cloud.fermyon.com/]
-
-    -V, --version
-            Print version information
-```
-
-{{ blockEnd }}
-
-{{ blockEnd }}
-
-### New
+### new
 
 {{ tabs "spin-version" }}
 
@@ -1641,7 +1106,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -1718,7 +1183,11 @@ OPTIONS:
 * `spin new` creates a _new_ application - that is, a new directory with a new `spin.toml` file.
 * `spin add` _adds_ a component to an _existing_ application - that is, it modifies an existing `spin.toml` file.
 
-### Plugins
+### plugin
+
+`spin plugin` is an alias for [`spin plugins`](#plugins)
+
+### plugins
 
 {{ tabs "spin-version" }}
 
@@ -1776,7 +1245,7 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -1832,7 +1301,7 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
-#### Install (Plugins)
+### plugins install
 
 {{ tabs "spin-version" }}
 
@@ -1918,7 +1387,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -2002,7 +1471,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-#### List (Plugins)
+### plugins list
 
 {{ tabs "spin-version" }}
 
@@ -2046,7 +1515,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -2088,7 +1557,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-#### Uninstall (Plugins)
+### plugins uninstall
 
 {{ tabs "spin-version" }}
 
@@ -2136,7 +1605,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -2182,7 +1651,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-#### Update (Plugins)
+### plugins update
 
 {{ tabs "spin-version" }}
 
@@ -2224,7 +1693,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -2264,7 +1733,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-#### Upgrade (Plugins)
+### plugins upgrade
 
 {{ tabs "spin-version" }}
 
@@ -2356,7 +1825,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -2448,7 +1917,11 @@ OPTIONS:
 
 **Note:** For additional information, please see the [Managing Plugins](/spin/managing-plugins) and/or [Creating Plugins](/spin/plugin-authoring) sections of the documentation.
 
-### OCI Registry
+### oci
+
+`spin oci` is an alias for  [`spin registry`](#registry)
+
+### registry
 
 {{ tabs "spin-version" }}
 
@@ -2504,7 +1977,7 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -2556,7 +2029,7 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
-#### Login (OCI Registry)
+### registry login
 
 {{ tabs "spin-version" }}
 
@@ -2610,7 +2083,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -2662,7 +2135,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-#### Pull (OCI Registry)
+### registry pull
 
 {{ tabs "spin-version" }}
 
@@ -2712,7 +2185,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -2760,7 +2233,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-#### Push (OCI Registry)
+### registry push
 
 {{ tabs "spin-version" }}
 
@@ -2812,7 +2285,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -2840,7 +2313,11 @@ OPTIONS:
 
 {{ blockEnd }}
 
-### Templates
+### template
+
+`spin template` is an alias for [`spin templates'](#templates)
+
+### templates
 
 {{ tabs "spin-version" }}
 
@@ -2896,7 +2373,7 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -2950,7 +2427,7 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
     
-#### Install (Templates)
+### templates install
 
 {{ tabs "spin-version" }}
 
@@ -3026,7 +2503,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -3100,7 +2577,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-#### List (Templates)
+### templates list
 
 {{ tabs "spin-version" }}
 
@@ -3146,7 +2623,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -3190,7 +2667,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-#### Uninstall (Templates)
+### templates uninstall
 
 <!-- @selectiveCpy -->
 
@@ -3240,7 +2717,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -3286,7 +2763,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-#### Upgrade (Templates)
+### templates upgrade
 
 {{ tabs "spin-version" }}
 
@@ -3360,7 +2837,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -3434,9 +2911,11 @@ OPTIONS:
 
 **Note:** For additional information, please see the [Managing Templates](/spin/managing-templates) and/or [Creating Templates](/spin/template-authoring) sections of the documentation.
 
-### Up
+### up
 
-The following options are available in relation to running your Spin application. Additionally, depending on the type of trigger that your application uses (i.e. HTTP or Redis trigger), there are trigger-specific options available. Details of the trigger options can be found in the next section (below).
+The following options are available in relation to running your Spin application.
+
+Note: There are three trigger options which only applies to the HTTP trigger (`--listen`, `--tls-cert` and `--tls-key`).
 
 {{ tabs "spin-version" }}
 
@@ -3484,6 +2963,12 @@ TRIGGER OPTIONS:
     -L, --log-dir <APP_LOG_DIR>
             Log directory for the stdout and stderr of components
 
+        --listen <ADDRESS>
+            IP address and port to listen on
+            
+            [default: 127.0.0.1:3000]
+            Only appplies to HTTP triggers            
+
     -q, --quiet
             Silence all component output to stdout/stderr
 
@@ -3492,6 +2977,19 @@ TRIGGER OPTIONS:
             
             [env: RUNTIME_CONFIG_FILE=]
 
+        --tls-cert <TLS_CERT>
+            The path to the certificate to use for https, if this is not set, normal http will be
+            used. The cert should be in PEM format
+            
+            [env: SPIN_TLS_CERT=]
+            Only appplies to HTTP triggers
+
+        --tls-key <TLS_KEY>
+            The path to the certificate key to use for https, if this is not set, normal http will
+            be used. The key should be in PKCS#8 format
+            
+            [env: SPIN_TLS_KEY=]
+            Only appplies to HTTP triggers
 ```
 
 {{ blockEnd }}
@@ -3540,6 +3038,12 @@ TRIGGER OPTIONS:
     -L, --log-dir <APP_LOG_DIR>
             Log directory for the stdout and stderr of components
 
+        --listen <ADDRESS>
+            IP address and port to listen on
+            
+            [default: 127.0.0.1:3000]
+            Only appplies to HTTP triggers
+
     -q, --quiet
             Silence all component output to stdout/stderr
 
@@ -3548,11 +3052,24 @@ TRIGGER OPTIONS:
             
             [env: RUNTIME_CONFIG_FILE=]
 
+        --tls-cert <TLS_CERT>
+            The path to the certificate to use for https, if this is not set, normal http will be
+            used. The cert should be in PEM format
+            
+            [env: SPIN_TLS_CERT=]
+            Only appplies to HTTP triggers
+
+        --tls-key <TLS_KEY>
+            The path to the certificate key to use for https, if this is not set, normal http will
+            be used. The key should be in PKCS#8 format
+            
+            [env: SPIN_TLS_KEY=]
+            Only appplies to HTTP triggers
 ```
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -3601,6 +3118,12 @@ TRIGGER OPTIONS:
     -L, --log-dir <APP_LOG_DIR>
             Log directory for the stdout and stderr of components
 
+        --listen <ADDRESS>
+            IP address and port to listen on
+            
+            [default: 127.0.0.1:3000]
+            Only appplies to HTTP triggers
+
     -q, --quiet
             Silence all component output to stdout/stderr
 
@@ -3615,7 +3138,20 @@ TRIGGER OPTIONS:
             
             For local apps, this defaults to `.spin/` relative to the `spin.toml` file. For remote
             apps, this has no default (unset). Passing an empty value forces the value to be unset.
+        
+        --tls-cert <TLS_CERT>
+            The path to the certificate to use for https, if this is not set, normal http will be
+            used. The cert should be in PEM format
+            
+            [env: SPIN_TLS_CERT=]
+            Only appplies to HTTP triggers
 
+        --tls-key <TLS_KEY>
+            The path to the certificate key to use for https, if this is not set, normal http will
+            be used. The key should be in PKCS#8 format
+            
+            [env: SPIN_TLS_KEY=]
+            Only appplies to HTTP triggers
 ```
 
 {{ blockEnd }}
@@ -3673,6 +3209,7 @@ TRIGGER OPTIONS:
             IP address and port to listen on
             
             [default: 127.0.0.1:3000]
+            Only appplies to HTTP triggers
 
     -q, --quiet
             Silence all component output to stdout/stderr
@@ -3694,12 +3231,14 @@ TRIGGER OPTIONS:
             used. The cert should be in PEM format
             
             [env: SPIN_TLS_CERT=]
+            Only appplies to HTTP triggers
 
         --tls-key <TLS_KEY>
             The path to the certificate key to use for https, if this is not set, normal http will
             be used. The key should be in PKCS#8 format
             
             [env: SPIN_TLS_KEY=]
+            Only appplies to HTTP triggers
 
 ```
 
@@ -3709,450 +3248,7 @@ TRIGGER OPTIONS:
 
 > **Please note:** If the `-f` or `--from` options do not accurately infer the intended registry or `.toml` file for your application, then you can explicitly specify either the `--from-registry` or  `--from-file` options to clarify this.
 
-#### Trigger Options
-
-##### Redis Request Handler
-
-Below, please see the available trigger options for the Redis request handler.
-
-{{ tabs "spin-version" }}
-
-{{ startTab "v1.0.0"}}
-
-<!-- @selectiveCpy -->
-
-```console
-$ spin up --help
-
-spin-up 
-Start the Spin application
-
-OPTIONS:
-        --direct-mounts         For local apps with directory mounts and no excluded files, mount
-                                them directly instead of using a temporary directory
-    -e, --env <ENV>             Pass an environment variable (key=value) to all components of the
-                                application
-    -f, --from <APPLICATION>    The application to run. This may be a manifest (spin.toml) file, a
-                                directory containing a spin.toml file, or a remote registry
-                                reference. If omitted, it defaults to "spin.toml"
-    -h, --help                  
-    -k, --insecure              Ignore server certificate errors from bindle server or registry
-        --temp <TMP>            Temporary directory for the static assets of the components
-
-TRIGGER OPTIONS:
-        --allow-transient-write
-            Set the static assets of the components in the temporary directory as writable
-
-        --cache <WASMTIME_CACHE_FILE>
-            Wasmtime cache configuration file
-            
-            [env: WASMTIME_CACHE_FILE=]
-
-        --disable-cache
-            Disable Wasmtime cache
-            
-            [env: DISABLE_WASMTIME_CACHE=]
-
-        --follow <FOLLOW_ID>
-            Print output to stdout/stderr only for given component(s)
-
-    -L, --log-dir <APP_LOG_DIR>
-            Log directory for the stdout and stderr of components
-
-    -q, --quiet
-            Silence all component output to stdout/stderr
-
-        --runtime-config-file <RUNTIME_CONFIG_FILE>
-            Configuration file for config providers and wasmtime config
-            
-            [env: RUNTIME_CONFIG_FILE=]
-
-        --state-dir <STATE_DIR>
-            Set the application state directory path. This is used in the default locations for
-            logs, key value stores, etc.
-            
-            For local apps, this defaults to `.spin/` relative to the `spin.toml` file. For remote
-            apps, this has no default (unset). Passing an empty value forces the value to be unset.
-```
-
-{{ blockEnd }}
-
-{{ startTab "v1.1.0"}}
-
-<!-- @selectiveCpy -->
-
-```console
-$ spin up --help
-
-spin-up 
-Start the Spin application
-
-OPTIONS:
-        --direct-mounts         For local apps with directory mounts and no excluded files, mount
-                                them directly instead of using a temporary directory
-    -e, --env <ENV>             Pass an environment variable (key=value) to all components of the
-                                application
-    -f, --from <APPLICATION>    The application to run. This may be a manifest (spin.toml) file, a
-                                directory containing a spin.toml file, or a remote registry
-                                reference. If omitted, it defaults to "spin.toml"
-    -h, --help                  
-    -k, --insecure              Ignore server certificate errors from bindle server or registry
-        --temp <TMP>            Temporary directory for the static assets of the components
-
-TRIGGER OPTIONS:
-        --allow-transient-write
-            Set the static assets of the components in the temporary directory as writable
-
-        --cache <WASMTIME_CACHE_FILE>
-            Wasmtime cache configuration file
-            
-            [env: WASMTIME_CACHE_FILE=]
-
-        --disable-cache
-            Disable Wasmtime cache
-            
-            [env: DISABLE_WASMTIME_CACHE=]
-
-        --follow <FOLLOW_ID>
-            Print output to stdout/stderr only for given component(s)
-
-    -L, --log-dir <APP_LOG_DIR>
-            Log directory for the stdout and stderr of components
-
-    -q, --quiet
-            Silence all component output to stdout/stderr
-
-        --runtime-config-file <RUNTIME_CONFIG_FILE>
-            Configuration file for config providers and wasmtime config
-            
-            [env: RUNTIME_CONFIG_FILE=]
-
-        --state-dir <STATE_DIR>
-            Set the application state directory path. This is used in the default locations for
-            logs, key value stores, etc.
-            
-            For local apps, this defaults to `.spin/` relative to the `spin.toml` file. For remote
-            apps, this has no default (unset). Passing an empty value forces the value to be unset.
-```
-
-{{ blockEnd }}
-
-{{ startTab "v1.2.0"}}
-
-<!-- @selectiveCpy -->
-
-```console
-$ spin up --help
-
-spin-up 
-Start the Spin application
-
-USAGE:
-    spin up [OPTIONS]
-
-OPTIONS:
-        --direct-mounts         For local apps with directory mounts and no excluded files, mount
-                                them directly instead of using a temporary directory
-    -e, --env <ENV>             Pass an environment variable (key=value) to all components of the
-                                application
-    -f, --from <APPLICATION>    The application to run. This may be a manifest (spin.toml) file, a
-                                directory containing a spin.toml file, or a remote registry
-                                reference. If omitted, it defaults to "spin.toml"
-    -h, --help                  
-    -k, --insecure              Ignore server certificate errors from bindle server or registry
-        --temp <TMP>            Temporary directory for the static assets of the components
-
-TRIGGER OPTIONS:
-        --allow-transient-write
-            Set the static assets of the components in the temporary directory as writable
-
-        --cache <WASMTIME_CACHE_FILE>
-            Wasmtime cache configuration file
-            
-            [env: WASMTIME_CACHE_FILE=]
-
-        --disable-cache
-            Disable Wasmtime cache
-            
-            [env: DISABLE_WASMTIME_CACHE=]
-
-        --follow <FOLLOW_ID>
-            Print output to stdout/stderr only for given component(s)
-
-        --key-value <KEY_VALUES>
-            Set a key/value pair (key=value) in the application's default store. Any existing value
-            will be overwritten. Can be used multiple times
-
-    -L, --log-dir <APP_LOG_DIR>
-            Log directory for the stdout and stderr of components
-
-    -q, --quiet
-            Silence all component output to stdout/stderr
-
-        --runtime-config-file <RUNTIME_CONFIG_FILE>
-            Configuration file for config providers and wasmtime config
-            
-            [env: RUNTIME_CONFIG_FILE=]
-
-        --state-dir <STATE_DIR>
-            Set the application state directory path. This is used in the default locations for
-            logs, key value stores, etc.
-            
-            For local apps, this defaults to `.spin/` relative to the `spin.toml` file. For remote
-            apps, this has no default (unset). Passing an empty value forces the value to be unset.
-```
-
-{{ blockEnd }}
-
-{{ blockEnd }}
-
-##### HTTP Request Handler
-
-Below, please see the available trigger options for the HTTP request handler. Note the additional three trigger options that the HTTP request handler offers (`--listen`, `--tls-cert` and `--tls-key`).
-
-{{ tabs "spin-version" }}
-
-{{ startTab "v1.0.0"}}
-
-<!-- @selectiveCpy -->
-
-```console
-$ spin up --help
-
-spin-up 
-Start the Spin application
-
-OPTIONS:
-        --direct-mounts         For local apps with directory mounts and no excluded files, mount
-                                them directly instead of using a temporary directory
-    -e, --env <ENV>             Pass an environment variable (key=value) to all components of the
-                                application
-    -f, --from <APPLICATION>    The application to run. This may be a manifest (spin.toml) file, a
-                                directory containing a spin.toml file, or a remote registry
-                                reference. If omitted, it defaults to "spin.toml"
-    -h, --help                  
-    -k, --insecure              Ignore server certificate errors from bindle server or registry
-        --temp <TMP>            Temporary directory for the static assets of the components
-
-TRIGGER OPTIONS:
-        --allow-transient-write
-            Set the static assets of the components in the temporary directory as writable
-
-        --cache <WASMTIME_CACHE_FILE>
-            Wasmtime cache configuration file
-            
-            [env: WASMTIME_CACHE_FILE=]
-
-        --disable-cache
-            Disable Wasmtime cache
-            
-            [env: DISABLE_WASMTIME_CACHE=]
-
-        --follow <FOLLOW_ID>
-            Print output to stdout/stderr only for given component(s)
-
-    -L, --log-dir <APP_LOG_DIR>
-            Log directory for the stdout and stderr of components
-
-        --listen <ADDRESS>
-            IP address and port to listen on
-            
-            [default: 127.0.0.1:3000]
-
-    -q, --quiet
-            Silence all component output to stdout/stderr
-
-        --runtime-config-file <RUNTIME_CONFIG_FILE>
-            Configuration file for config providers and wasmtime config
-            
-            [env: RUNTIME_CONFIG_FILE=]
-
-        --state-dir <STATE_DIR>
-            Set the application state directory path. This is used in the default locations for
-            logs, key value stores, etc.
-            
-            For local apps, this defaults to `.spin/` relative to the `spin.toml` file. For remote
-            apps, this has no default (unset). Passing an empty value forces the value to be unset.
-
-        --tls-cert <TLS_CERT>
-            The path to the certificate to use for https, if this is not set, normal http will be
-            used. The cert should be in PEM format
-            
-            [env: SPIN_TLS_CERT=]
-
-        --tls-key <TLS_KEY>
-            The path to the certificate key to use for https, if this is not set, normal http will
-            be used. The key should be in PKCS#8 format
-            
-            [env: SPIN_TLS_KEY=]
-```
-
-{{ blockEnd }}
-
-{{ startTab "v1.1.0"}}
-
-<!-- @selectiveCpy -->
-
-```console
-$ spin up --help
-
-spin-up 
-Start the Spin application
-
-OPTIONS:
-        --direct-mounts         For local apps with directory mounts and no excluded files, mount
-                                them directly instead of using a temporary directory
-    -e, --env <ENV>             Pass an environment variable (key=value) to all components of the
-                                application
-    -f, --from <APPLICATION>    The application to run. This may be a manifest (spin.toml) file, a
-                                directory containing a spin.toml file, or a remote registry
-                                reference. If omitted, it defaults to "spin.toml"
-    -h, --help                  
-    -k, --insecure              Ignore server certificate errors from bindle server or registry
-        --temp <TMP>            Temporary directory for the static assets of the components
-
-TRIGGER OPTIONS:
-        --allow-transient-write
-            Set the static assets of the components in the temporary directory as writable
-
-        --cache <WASMTIME_CACHE_FILE>
-            Wasmtime cache configuration file
-            
-            [env: WASMTIME_CACHE_FILE=]
-
-        --disable-cache
-            Disable Wasmtime cache
-            
-            [env: DISABLE_WASMTIME_CACHE=]
-
-        --follow <FOLLOW_ID>
-            Print output to stdout/stderr only for given component(s)
-
-    -L, --log-dir <APP_LOG_DIR>
-            Log directory for the stdout and stderr of components
-
-        --listen <ADDRESS>
-            IP address and port to listen on
-            
-            [default: 127.0.0.1:3000]
-
-    -q, --quiet
-            Silence all component output to stdout/stderr
-
-        --runtime-config-file <RUNTIME_CONFIG_FILE>
-            Configuration file for config providers and wasmtime config
-            
-            [env: RUNTIME_CONFIG_FILE=]
-
-        --state-dir <STATE_DIR>
-            Set the application state directory path. This is used in the default locations for
-            logs, key value stores, etc.
-            
-            For local apps, this defaults to `.spin/` relative to the `spin.toml` file. For remote
-            apps, this has no default (unset). Passing an empty value forces the value to be unset.
-
-        --tls-cert <TLS_CERT>
-            The path to the certificate to use for https, if this is not set, normal http will be
-            used. The cert should be in PEM format
-            
-            [env: SPIN_TLS_CERT=]
-
-        --tls-key <TLS_KEY>
-            The path to the certificate key to use for https, if this is not set, normal http will
-            be used. The key should be in PKCS#8 format
-            
-            [env: SPIN_TLS_KEY=]
-```
-
-{{ blockEnd }}
-
-{{ startTab "v1.2.0"}}
-
-<!-- @selectiveCpy -->
-
-```console
-$ spin up --help
-
-spin-up 
-Start the Spin application
-
-USAGE:
-    spin up [OPTIONS]
-
-OPTIONS:
-        --direct-mounts         For local apps with directory mounts and no excluded files, mount
-                                them directly instead of using a temporary directory
-    -e, --env <ENV>             Pass an environment variable (key=value) to all components of the
-                                application
-    -f, --from <APPLICATION>    The application to run. This may be a manifest (spin.toml) file, a
-                                directory containing a spin.toml file, or a remote registry
-                                reference. If omitted, it defaults to "spin.toml"
-    -h, --help                  
-    -k, --insecure              Ignore server certificate errors from bindle server or registry
-        --temp <TMP>            Temporary directory for the static assets of the components
-
-TRIGGER OPTIONS:
-        --allow-transient-write
-            Set the static assets of the components in the temporary directory as writable
-
-        --cache <WASMTIME_CACHE_FILE>
-            Wasmtime cache configuration file
-            
-            [env: WASMTIME_CACHE_FILE=]
-
-        --disable-cache
-            Disable Wasmtime cache
-            
-            [env: DISABLE_WASMTIME_CACHE=]
-
-        --follow <FOLLOW_ID>
-            Print output to stdout/stderr only for given component(s)
-
-        --key-value <KEY_VALUES>
-            Set a key/value pair (key=value) in the application's default store. Any existing value
-            will be overwritten. Can be used multiple times
-
-    -L, --log-dir <APP_LOG_DIR>
-            Log directory for the stdout and stderr of components
-
-        --listen <ADDRESS>
-            IP address and port to listen on
-            
-            [default: 127.0.0.1:3000]
-
-    -q, --quiet
-            Silence all component output to stdout/stderr
-
-        --runtime-config-file <RUNTIME_CONFIG_FILE>
-            Configuration file for config providers and wasmtime config
-            
-            [env: RUNTIME_CONFIG_FILE=]
-
-        --state-dir <STATE_DIR>
-            Set the application state directory path. This is used in the default locations for
-            logs, key value stores, etc.
-            
-            For local apps, this defaults to `.spin/` relative to the `spin.toml` file. For remote
-            apps, this has no default (unset). Passing an empty value forces the value to be unset.
-
-        --tls-cert <TLS_CERT>
-            The path to the certificate to use for https, if this is not set, normal http will be
-            used. The cert should be in PEM format
-            
-            [env: SPIN_TLS_CERT=]
-
-        --tls-key <TLS_KEY>
-            The path to the certificate key to use for https, if this is not set, normal http will
-            be used. The key should be in PKCS#8 format
-            
-            [env: SPIN_TLS_KEY=]
-```
-
-{{ blockEnd }}
-
-{{ blockEnd }}
-
-### Watch
+### watch
 
 {{ tabs "spin-version" }}
 
@@ -4184,7 +3280,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -4245,23 +3341,6 @@ OPTIONS:
 {{ blockEnd }}
 
 {{ blockEnd }}
-
-`spin watch` relies on configuration in your application manifest to know what files it should watch. For each component you should set the `component.build.watch` parameter with a list of glob patterns that your source files will match:
-
-```toml
-[component.build]
-# Example watch configuration for a Rust application
-watch = ["src/**/*.rs", "Cargo.toml"]
-```
-
-The table below outlines exactly which files `spin watch` will monitor for changes depending on how you run the command. `spin watch` uses the configuration found on every component in your application.
-
-| Files                   | `spin watch` monitors for changes              | `spin watch --skip-build` monitors for changes |
-| ----------------------- | ---------------------------------------------- | ---------------------------------------------- |
-| Application manifest    | Yes                                            | Yes                                            |
-| `component.build.watch` | Yes                                            | No                                             |
-| `component.files`       | Yes                                            | Yes                                            |
-| `component.source`      | No (Yes if the component has no build command) | Yes                                            |
 
 ### CLI Stability Table
 
@@ -4302,12 +3381,12 @@ CLI commands have four phases that indicate levels of stability:
 | <code>spin up</code>                                                                  | Stable       |
 | <code>spin cloud <deploy&vert;login></code>                                           | Stabilizing  |
 | <code>spin registry</code>                                                            | Stabilizing  |
-| <code>spin watch</code>                                                               | Stabilizing |
+| <code>spin watch</code>                                                               | Experimental |
 | <code>spin bindle <prepare&vert;push></code>                                          | Deprecated   |
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
 
 | Command                                                                               | Stability    |
 | ------------------------------------------------------------------------------------- | ------------ |

--- a/content/spin/cli-reference.md
+++ b/content/spin/cli-reference.md
@@ -136,6 +136,37 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.3.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin --help
+
+USAGE:
+    spin <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+SUBCOMMANDS:
+    add          Scaffold a new component into an existing application
+    build        Build the Spin application
+    cloud        Commands for publishing applications to the Fermyon Platform
+    deploy       Package and upload an application to the Fermyon Platform
+    help         Print this message or the help of the given subcommand(s)
+    login        Log into the Fermyon Platform
+    new          Scaffold a new application based on a template
+    plugins      Install/uninstall Spin plugins
+    registry     Commands for working with OCI registries to distribute applications
+    templates    Commands for working with WebAssembly component templates
+    up           Start the Spin application
+    watch        Build and run the Spin application, rebuilding and restarting it when files
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 ### Add
@@ -252,6 +283,42 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.3.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin add --help
+
+spin-add 
+Scaffold a new component into an existing application
+
+USAGE:
+    spin add [OPTIONS] [ARGS]
+
+ARGS:
+    <TEMPLATE_ID>    The template from which to create the new application or component. Run
+                     `spin templates list` to see available options
+    <NAME>           The name of the new application or component
+
+OPTIONS:
+    -a, --accept-defaults              An optional argument that allows to skip prompts for the
+                                       manifest file by accepting the defaults if available on the
+                                       template
+    -f, --file <APP_MANIFEST_FILE>     Path to spin.toml
+    -h, --help                         Print help information
+    -o, --output <OUTPUT_PATH>         The directory in which to create the new application or
+                                       component. The default is the name argument
+        --tag <TAGS>                   Filter templates to select by tags
+    -v, --value <VALUES>               Parameter values to be passed to the template (in name=value
+                                       format)
+        --values-file <VALUES_FILE>    A TOML file which contains parameter values in name = "value"
+                                       format. Parameters passed as CLI option overwrite parameters
+                                       specified in the file
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 ### Build
@@ -332,6 +399,37 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.3.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin build --help
+
+spin-build 
+Build the Spin application
+
+USAGE:
+    spin build [OPTIONS] [UP_ARGS]...
+
+ARGS:
+    <UP_ARGS>...    
+
+OPTIONS:
+    -c, --component-id <COMPONENT_ID>...
+            Component ID to build. This can be specified multiple times. The default is all
+            components
+    -f, --from <APP_MANIFEST_FILE>
+            The application to build. This may be a manifest (spin.toml) file, or a directory
+            containing a spin.toml file. If omitted, it defaults to "spin.toml" [default: spin.toml]
+    -h, --help
+            Print help information
+    -u, --up
+            Run the application after building
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 ### Cloud
@@ -407,6 +505,31 @@ SUBCOMMANDS:
     help      Print this message or the help of the given subcommand(s)
     login     Log into the Fermyon Platform
 ```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin cloud --help
+
+cloud-plugin 0.1.1
+Fermyon Engineering <engineering@fermyon.com>
+
+USAGE:
+    cloud <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+SUBCOMMANDS:
+    deploy       Package and upload an application to the Fermyon Cloud
+    help         Print this message or the help of the given subcommand(s)
+    login        Login to Fermyon Cloud
+    variables    Manage Spin application variables
 
 {{ blockEnd }}
 
@@ -554,6 +677,61 @@ OPTIONS:
         --readiness-timeout <READINESS_TIMEOUT_SECS>
             How long in seconds to wait for a deployed HTTP application to become ready. The default
             is 60 seconds. Set it to 0 to skip waiting for readiness [default: 60]
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin cloud deploy --help
+
+cloud-deploy 0.1.1
+Package and upload an application to the Fermyon Cloud
+
+USAGE:
+    cloud deploy [OPTIONS]
+
+OPTIONS:
+        --buildinfo <BUILDINFO>
+            Build metadata to append to the bindle version
+
+    -d, --staging-dir <STAGING_DIR>
+            Path to assemble the bindle before pushing (defaults to a temporary directory)
+
+    -e, --deploy-existing-bindle
+            Deploy existing bindle if it already exists on bindle server
+
+        --environment-name <environment-name>
+            Deploy to the Fermyon instance saved under the specified name. If omitted, Spin deploys
+            to the default unnamed instance [env: FERMYON_DEPLOYMENT_ENVIRONMENT=]
+
+    -f, --from <APP_MANIFEST_FILE>
+            The application to deploy. This may be a manifest (spin.toml) file, or a directory
+            containing a spin.toml file. If omitted, it defaults to "spin.toml" [default: spin.toml]
+
+    -h, --help
+            Print help information
+
+        --key-value <KEY_VALUES>
+            Set a key/value pair (key=value) in the deployed application's default store. Any
+            existing value will be overwritten. Can be used multiple times
+
+        --no-buildinfo
+            Disable attaching buildinfo [env: SPIN_DEPLOY_NO_BUILDINFO=]
+
+        --readiness-timeout <READINESS_TIMEOUT_SECS>
+            How long in seconds to wait for a deployed HTTP application to become ready. The default
+            is 60 seconds. Set it to 0 to skip waiting for readiness [default: 60]
+
+    -V, --version
+            Print version information
+
+        --variable <VARIABLES>
+            Set a variable (variable=value) in the deployed application. Any existing value will be
+            overwritten. Can be used multiple times
 ```
 
 {{ blockEnd }}
@@ -740,6 +918,85 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.3.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin cloud login --help
+
+cloud-login 0.1.1
+Login to Fermyon Cloud
+
+USAGE:
+    cloud login [OPTIONS]
+
+OPTIONS:
+        --auth-method <auth-method>
+            [env: AUTH_METHOD=] [possible values: github, token]
+
+        --environment-name <environment-name>
+            Save the login details under the specified name instead of making them the default. Use
+            named environments with `spin deploy --environment-name <name>` [env:
+            FERMYON_DEPLOYMENT_ENVIRONMENT=]
+
+    -h, --help
+            Print help information
+
+    -k, --insecure
+            Ignore server certificate errors
+
+        --list
+            List saved logins
+
+        --status
+            Display login status
+
+        --token <TOKEN>
+            Auth Token [env: SPIN_AUTH_TOKEN=]
+
+        --url <CLOUD_SERVER_URL>
+            URL of Fermyon Cloud Instance [env: CLOUD_URL=] [default: https://cloud.fermyon.com/]
+
+    -V, --version
+            Print version information
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+#### Variables (Cloud)
+
+{{ tabs "spin-version" }}
+
+{{ startTab "v1.3.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin cloud variables --help
+
+cloud-variables 0.1.1
+Manage Spin application variables
+
+USAGE:
+    cloud variables <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+SUBCOMMANDS:
+    delete    Delete variables
+    help      Print this message or the help of the given subcommand(s)
+    list      List all variables of an application
+    set       Set variables
+
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 ### Deploy
@@ -885,6 +1142,60 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.3.0"}}
+
+<!-- @selectiveCpy -->
+```console
+$ spin deploy --help
+
+cloud-deploy 0.1.1
+Package and upload an application to the Fermyon Cloud
+
+USAGE:
+    cloud deploy [OPTIONS]
+
+OPTIONS:
+        --buildinfo <BUILDINFO>
+            Build metadata to append to the bindle version
+
+    -d, --staging-dir <STAGING_DIR>
+            Path to assemble the bindle before pushing (defaults to a temporary directory)
+
+    -e, --deploy-existing-bindle
+            Deploy existing bindle if it already exists on bindle server
+
+        --environment-name <environment-name>
+            Deploy to the Fermyon instance saved under the specified name. If omitted, Spin deploys
+            to the default unnamed instance [env: FERMYON_DEPLOYMENT_ENVIRONMENT=]
+
+    -f, --from <APP_MANIFEST_FILE>
+            The application to deploy. This may be a manifest (spin.toml) file, or a directory
+            containing a spin.toml file. If omitted, it defaults to "spin.toml" [default: spin.toml]
+
+    -h, --help
+            Print help information
+
+        --key-value <KEY_VALUES>
+            Set a key/value pair (key=value) in the deployed application's default store. Any
+            existing value will be overwritten. Can be used multiple times
+
+        --no-buildinfo
+            Disable attaching buildinfo [env: SPIN_DEPLOY_NO_BUILDINFO=]
+
+        --readiness-timeout <READINESS_TIMEOUT_SECS>
+            How long in seconds to wait for a deployed HTTP application to become ready. The default
+            is 60 seconds. Set it to 0 to skip waiting for readiness [default: 60]
+
+    -V, --version
+            Print version information
+
+        --variable <VARIABLES>
+            Set a variable (variable=value) in the deployed application. Any existing value will be
+            overwritten. Can be used multiple times
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 ### Help
@@ -986,6 +1297,42 @@ SUBCOMMANDS:
     up           Start the Spin application
     watch        Build and run the Spin application, rebuilding and restarting it when files
                      change
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin help
+
+spin 1.3.0 (9fb8256 2023-06-12)
+The Spin CLI
+
+USAGE:
+    spin <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+SUBCOMMANDS:
+    add          Scaffold a new component into an existing application
+    build        Build the Spin application
+    cloud        Commands for publishing applications to the Fermyon Cloud.
+    deploy       Package and upload an application to the Fermyon Cloud.
+    help         Print this message or the help of the given subcommand(s)
+    login        Log into the Fermyon Cloud.
+    new          Scaffold a new application based on a template
+    plugins      Install/uninstall Spin plugins
+    registry     Commands for working with OCI registries to distribute applications
+    templates    Commands for working with WebAssembly component templates
+    up           Start the Spin application
+    watch        Build and run the Spin application, rebuilding and restarting it when files
+                     change
+
 ```
 
 {{ blockEnd }}
@@ -1172,6 +1519,52 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.3.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin login --help
+
+cloud-login 0.1.1
+Login to Fermyon Cloud
+
+USAGE:
+    cloud login [OPTIONS]
+
+OPTIONS:
+        --auth-method <auth-method>
+            [env: AUTH_METHOD=] [possible values: github, token]
+
+        --environment-name <environment-name>
+            Save the login details under the specified name instead of making them the default. Use
+            named environments with `spin deploy --environment-name <name>` [env:
+            FERMYON_DEPLOYMENT_ENVIRONMENT=]
+
+    -h, --help
+            Print help information
+
+    -k, --insecure
+            Ignore server certificate errors
+
+        --list
+            List saved logins
+
+        --status
+            Display login status
+
+        --token <TOKEN>
+            Auth Token [env: SPIN_AUTH_TOKEN=]
+
+        --url <CLOUD_SERVER_URL>
+            URL of Fermyon Cloud Instance [env: CLOUD_URL=] [default: https://cloud.fermyon.com/]
+
+    -V, --version
+            Print version information
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 ### New
@@ -1283,6 +1676,41 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.3.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin new --help  
+
+spin-new 
+Scaffold a new application based on a template
+
+USAGE:
+    spin new [OPTIONS] [ARGS]
+
+ARGS:
+    <TEMPLATE_ID>    The template from which to create the new application or component. Run
+                     `spin templates list` to see available options
+    <NAME>           The name of the new application or component
+
+OPTIONS:
+    -a, --accept-defaults              An optional argument that allows to skip prompts for the
+                                       manifest file by accepting the defaults if available on the
+                                       template
+    -h, --help                         Print help information
+    -o, --output <OUTPUT_PATH>         The directory in which to create the new application or
+                                       component. The default is the name argument
+        --tag <TAGS>                   Filter templates to select by tags
+    -v, --value <VALUES>               Parameter values to be passed to the template (in name=value
+                                       format)
+        --values-file <VALUES_FILE>    A TOML file which contains parameter values in name = "value"
+                                       format. Parameters passed as CLI option overwrite parameters
+                                       specified in the file
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 **Please note: `spin new` vs `spin add`**.  These commands are similar except that:
@@ -1349,6 +1777,33 @@ SUBCOMMANDS:
 {{ blockEnd }}
 
 {{ startTab "v1.2.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins --help
+
+spin-plugins 
+Install/uninstall Spin plugins
+
+USAGE:
+    spin plugins <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    help         Print this message or the help of the given subcommand(s)
+    install      Install plugin from a manifest
+    list         List available or installed plugins
+    uninstall    Remove a plugin from your installation
+    update       Fetch the latest Spin plugins from the spin-plugins repository
+    upgrade      Upgrade one or all plugins
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -1504,6 +1959,47 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.3.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins install --help
+
+spin-plugins-install 
+Install plugin from a manifest.
+
+The binary file and manifest of the plugin is copied to the local Spin plugins directory.
+
+USAGE:
+    spin plugins install [OPTIONS] [PLUGIN_NAME]
+
+ARGS:
+    <PLUGIN_NAME>
+            Name of Spin plugin
+
+OPTIONS:
+    -f, --file <LOCAL_PLUGIN_MANIFEST>
+            Path to local plugin manifest
+
+    -h, --help
+            Print help information
+
+        --override-compatibility-check
+            Overrides a failed compatibility check of the plugin with the current version of Spin
+
+    -u, --url <REMOTE_PLUGIN_MANIFEST>
+            URL of remote plugin manifest to install
+
+    -v, --version <VERSION>
+            Specific version of a plugin to be install from the centralized plugins repository
+
+    -y, --yes
+            Skips prompt to accept the installation of the plugin
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 #### List (Plugins)
@@ -1551,6 +2047,26 @@ OPTIONS:
 {{ blockEnd }}
 
 {{ startTab "v1.2.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins list --help   
+
+spin-plugins-list 
+List available or installed plugins
+
+USAGE:
+    spin plugins list [OPTIONS]
+
+OPTIONS:
+    -h, --help         Print help information
+        --installed    List only installed plugins
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -1642,6 +2158,28 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.3.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins uninstall --help
+
+spin-plugins-uninstall 
+Remove a plugin from your installation
+
+USAGE:
+    spin plugins uninstall <NAME>
+
+ARGS:
+    <NAME>    Name of Spin plugin
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 #### Update (Plugins)
@@ -1687,6 +2225,25 @@ OPTIONS:
 {{ blockEnd }}
 
 {{ startTab "v1.2.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins update --help   
+
+spin-plugins-update 
+Fetch the latest Spin plugins from the spin-plugins repository
+
+USAGE:
+    spin plugins update
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -1843,6 +2400,50 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.3.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins upgrade --help
+
+spin-plugins-upgrade 
+Upgrade one or all plugins
+
+USAGE:
+    spin plugins upgrade [OPTIONS] [PLUGIN_NAME]
+
+ARGS:
+    <PLUGIN_NAME>    Name of Spin plugin to upgrade
+
+OPTIONS:
+    -a, --all
+            Upgrade all plugins
+
+    -d, --downgrade
+            Allow downgrading a plugin's version
+
+    -f, --file <LOCAL_PLUGIN_MANIFEST>
+            Path to local plugin manifest
+
+    -h, --help
+            Print help information
+
+        --override-compatibility-check
+            Overrides a failed compatibility check of the plugin with the current version of Spin
+
+    -u, --url <REMOTE_PLUGIN_MANIFEST>
+            Path to remote plugin manifest
+
+    -v, --version <VERSION>
+            Specific version of a plugin to be install from the centralized plugins repository
+
+    -y, --yes
+            Skips prompt to accept the installation of the plugin[s]
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 **Note:** For additional information, please see the [Managing Plugins](/spin/managing-plugins) and/or [Creating Plugins](/spin/plugin-authoring) sections of the documentation.
@@ -1904,6 +2505,31 @@ SUBCOMMANDS:
 {{ blockEnd }}
 
 {{ startTab "v1.2.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry --help
+
+spin-registry 
+Commands for working with OCI registries to distribute applications
+
+USAGE:
+    spin registry <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    help     Print this message or the help of the given subcommand(s)
+    login    Log in to a registry
+    pull     Pull a Spin application from a registry
+    push     Push a Spin application to a registry
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -2009,6 +2635,31 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.3.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry login --help
+
+spin-registry-login 
+Log in to a registry
+
+USAGE:
+    spin registry login [OPTIONS] <SERVER>
+
+ARGS:
+    <SERVER>    
+
+OPTIONS:
+    -h, --help                   Print help information
+    -p, --password <PASSWORD>    Password for the registry
+        --password-stdin         Take the password from stdin
+    -u, --username <USERNAME>    Username for the registry
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 #### Pull (OCI Registry)
@@ -2062,6 +2713,29 @@ OPTIONS:
 {{ blockEnd }}
 
 {{ startTab "v1.2.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry pull --help
+
+spin-registry-pull 
+Pull a Spin application from a registry
+
+USAGE:
+    spin registry pull [OPTIONS] <REFERENCE>
+
+ARGS:
+    <REFERENCE>    Reference of the Spin application
+
+OPTIONS:
+    -h, --help        Print help information
+    -k, --insecure    Ignore server certificate errors
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -2248,6 +2922,32 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.3.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates --help    
+
+spin-templates 
+Commands for working with WebAssembly component templates
+
+USAGE:
+    spin templates <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    help         Print this message or the help of the given subcommand(s)
+    install      Install templates from a Git repository or local directory
+    list         List the installed templates
+    uninstall    Remove a template from your installation
+    upgrade      Upgrade templates to match your current version of Spin
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
     
 #### Install (Templates)
@@ -2362,6 +3062,42 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.3.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates install --help
+
+spin-templates-install 
+Install templates from a Git repository or local directory.
+
+The files of the templates are copied to the local template store: a directory in your data or home
+directory.
+
+USAGE:
+    spin templates install [OPTIONS]
+
+OPTIONS:
+        --branch <BRANCH>
+            The optional branch of the git repository
+
+        --dir <FROM_DIR>
+            Local directory containing the template(s) to install
+
+        --git <FROM_GIT>
+            The URL of the templates git repository. The templates must be in a git repository in a
+            "templates" directory
+
+    -h, --help
+            Print help information
+
+        --upgrade
+            If present, updates existing templates instead of skipping
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 #### List (Templates)
@@ -2411,6 +3147,27 @@ OPTIONS:
 {{ blockEnd }}
 
 {{ startTab "v1.2.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates list --help   
+
+spin-templates-list 
+List the installed templates
+
+USAGE:
+    spin templates list [OPTIONS]
+
+OPTIONS:
+    -h, --help          Print help information
+        --tag <TAGS>    Filter templates matching all provided tags
+        --verbose       Whether to show additional template details in the list
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -2484,6 +3241,28 @@ OPTIONS:
 {{ blockEnd }}
 
 {{ startTab "v1.2.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates uninstall --help
+
+spin-templates-uninstall 
+Remove a template from your installation
+
+USAGE:
+    spin templates uninstall <TEMPLATE_ID>
+
+ARGS:
+    <TEMPLATE_ID>    The template to uninstall
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -2582,6 +3361,41 @@ OPTIONS:
 {{ blockEnd }}
 
 {{ startTab "v1.2.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates upgrade --help  
+
+spin-templates-upgrade 
+Upgrade templates to match your current version of Spin.
+
+The files of the templates are copied to the local template store: a directory in your data or home
+directory.
+
+USAGE:
+    spin templates upgrade [OPTIONS]
+
+OPTIONS:
+        --all
+            By default, Spin displays the list of installed repositories and prompts you to choose
+            which to upgrade.  Pass this flag to upgrade all repositories without prompting
+
+        --branch <BRANCH>
+            The optional branch of the git repository, if a specific repository is given
+
+    -h, --help
+            Print help information
+
+        --repo <GIT_URL>
+            By default, Spin displays the list of installed repositories and prompts you to choose
+            which to upgrade.  Pass this flag to upgrade only the specified repository without
+            prompting
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -2801,6 +3615,91 @@ TRIGGER OPTIONS:
             
             For local apps, this defaults to `.spin/` relative to the `spin.toml` file. For remote
             apps, this has no default (unset). Passing an empty value forces the value to be unset.
+
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin up --help
+
+spin-up 
+Start the Spin application
+
+USAGE:
+    spin up [OPTIONS]
+
+OPTIONS:
+        --direct-mounts         For local apps with directory mounts and no excluded files, mount
+                                them directly instead of using a temporary directory
+    -e, --env <ENV>             Pass an environment variable (key=value) to all components of the
+                                application
+    -f, --from <APPLICATION>    The application to run. This may be a manifest (spin.toml) file, a
+                                directory containing a spin.toml file, or a remote registry
+                                reference. If omitted, it defaults to "spin.toml"
+    -h, --help                  
+    -k, --insecure              Ignore server certificate errors from bindle server or registry
+        --temp <TMP>            Temporary directory for the static assets of the components
+
+TRIGGER OPTIONS:
+        --allow-transient-write
+            Set the static assets of the components in the temporary directory as writable
+
+        --cache <WASMTIME_CACHE_FILE>
+            Wasmtime cache configuration file
+            
+            [env: WASMTIME_CACHE_FILE=]
+
+        --disable-cache
+            Disable Wasmtime cache
+            
+            [env: DISABLE_WASMTIME_CACHE=]
+
+        --follow <FOLLOW_ID>
+            Print output to stdout/stderr only for given component(s)
+
+        --key-value <KEY_VALUES>
+            Set a key/value pair (key=value) in the application's default store. Any existing value
+            will be overwritten. Can be used multiple times
+
+    -L, --log-dir <APP_LOG_DIR>
+            Log directory for the stdout and stderr of components
+
+        --listen <ADDRESS>
+            IP address and port to listen on
+            
+            [default: 127.0.0.1:3000]
+
+    -q, --quiet
+            Silence all component output to stdout/stderr
+
+        --runtime-config-file <RUNTIME_CONFIG_FILE>
+            Configuration file for config providers and wasmtime config
+            
+            [env: RUNTIME_CONFIG_FILE=]
+
+        --state-dir <STATE_DIR>
+            Set the application state directory path. This is used in the default locations for
+            logs, key value stores, etc.
+            
+            For local apps, this defaults to `.spin/` relative to the `spin.toml` file. For remote
+            apps, this has no default (unset). Passing an empty value forces the value to be unset.
+
+        --tls-cert <TLS_CERT>
+            The path to the certificate to use for https, if this is not set, normal http will be
+            used. The cert should be in PEM format
+            
+            [env: SPIN_TLS_CERT=]
+
+        --tls-key <TLS_KEY>
+            The path to the certificate key to use for https, if this is not set, normal http will
+            be used. The key should be in PKCS#8 format
+            
+            [env: SPIN_TLS_KEY=]
 
 ```
 
@@ -3315,6 +4214,36 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.3.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin watch --help
+
+spin-watch 
+Build and run the Spin application, rebuilding and restarting it when files change
+
+USAGE:
+    spin watch [OPTIONS] [UP_ARGS]...
+
+ARGS:
+    <UP_ARGS>...    Arguments to be passed through to spin up
+
+OPTIONS:
+    -c, --clear                       Clear the screen before each run
+    -d, --debounce <DEBOUNCE>         Set the timeout between detected change and re-execution, in
+                                      milliseconds [default: 100]
+    -f, --from <APP_MANIFEST_FILE>    The application to watch. This may be a manifest (spin.toml)
+                                      file, or a directory containing a spin.toml file. If omitted,
+                                      it defaults to "spin.toml" [default: spin.toml]
+    -h, --help                        Print help information
+        --skip-build                  Only run the Spin application, restarting it when build
+                                      artifacts change
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 `spin watch` relies on configuration in your application manifest to know what files it should watch. For each component you should set the `component.build.watch` parameter with a list of glob patterns that your source files will match:
@@ -3379,6 +4308,23 @@ CLI commands have four phases that indicate levels of stability:
 {{ blockEnd }}
 
 {{ startTab "v1.2.0"}}
+
+| Command                                                                               | Stability    |
+| ------------------------------------------------------------------------------------- | ------------ |
+| <code>spin add</code>                                                                 | Stable       |
+| <code>spin build</code>                                                               | Stable       |
+| <code>spin new</code>                                                                 | Stable       |
+| <code>spin plugins <install&vert;list&vert;uninstall&vert;update&vert;upgrade></code> | Stable       |
+| <code>spin templates <install&vert;list&vert;uninstall&vert;upgrade></code>           | Stable       |
+| <code>spin up</code>                                                                  | Stable       |
+| <code>spin cloud <deploy&vert;login></code>                                           | Stabilizing  |
+| <code>spin registry</code>                                                            | Stabilizing  |
+| <code>spin watch</code>                                                               | Experimental |
+| <code>spin bindle <prepare&vert;push></code>                                          | Deprecated   |
+
+{{ blockEnd }}
+
+{{ startTab "v1.3.0"}}
 
 | Command                                                                               | Stability    |
 | ------------------------------------------------------------------------------------- | ------------ |

--- a/content/spin/running-apps.md
+++ b/content/spin/running-apps.md
@@ -80,6 +80,7 @@ Some trigger types support additional `spin up` flags.  For example, HTTP applic
 Spin's `watch` command rebuilds and restarts Spin applications whenever files change. You can use the `spin watch` [command](https://developer.fermyon.com/common/cli-reference#watch) in place of the `spin build` and `spin up` commands, to build, run and then keep your Spin application running without manual intervention while staying on the latest code and files.
 
 > The `watch` command accepts valid Spin [up](https://developer.fermyon.com/common/cli-reference#up) options and passes them through to `spin up` for you when running/rerunning the Spin application.
+E.g., `spin watch --listen 127.0.0.1:3001`
 
 By default, Spin watch monitors:
 
@@ -101,10 +102,20 @@ files = ["my-files/changing-file.txt"]
 source = "target/wasm32-wasi/release/test.wasm"
 [component.build]
 command = "cargo build --target wasm32-wasi --release"
+# Example watch configuration for a Rust application
 watch = ["src/**/*.rs", "Cargo.toml"]
 ```
 
 If you would prefer Spin watch to only rerun the application (without a rebuild) when changes occur, you can use the `--skip-build` option when running the `spin watch` command.  In this case, Spin will ignore the `component.build.watch` section, and monitor only the `spin.toml`, `component.source` and `component.files`.
+
+The table below outlines exactly which files `spin watch` will monitor for changes depending on how you run the command. `spin watch` uses the configuration found on every component in your application.
+
+| Files                   | `spin watch` monitors for changes              | `spin watch --skip-build` monitors for changes |
+| ----------------------- | ---------------------------------------------- | ---------------------------------------------- |
+| Application manifest `spin.toml`   | Yes                                            | Yes                                            |
+| `component.build.watch` | Yes                                            | No                                             |
+| `component.files`       | Yes                                            | Yes                                            |
+| `component.source`      | No (Yes if the component has no build command) | Yes  
 
 Spin watch waits up to 100 milliseconds before responding to filesystem events, then processes all events that occurred in that interval together. This is so that if you make several changes close together (for example, using a Save All command), you get them all processed in one rebuild/reload cycle, rather than going through a cycle for each one. You can override the interval by passing in the `--debounce` option; e.g. `spin watch --debounce 1000` will make Spin watch respond to filesystem events at most once per second.
 


### PR DESCRIPTION
Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [X] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [X] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
