### PR TITLE
Refactor cli

### DIFF
--- a/content/cloud/cloud-command-reference.md
+++ b/content/cloud/cloud-command-reference.md
@@ -1,9 +1,9 @@
-title = "Fermyon Cloud Plugin Command Line Interface (CLI) Reference"
+title = "Cloud Command Reference"
 date = "2023-06-07T22:41:02.478752Z"
 template = "cloud_main"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/cloud/cloud-plugin-reference.md"
+url = "https://github.com/fermyon/developer/blob/main/content/cloud/cloud-command-reference.md"
 
 ---
 - [Spin Cloud Command](#spin-cloud-command)
@@ -20,7 +20,7 @@ url = "https://github.com/fermyon/developer/blob/main/content/cloud/cloud-plugin
 
 ## Spin Cloud Command
 
-Fermyon provides a [`cloud` plugin](https://github.com/fermyon/cloud-plugin) for the Spin CLI for you to manage Spin applications in Fermyon Cloud. This page documents the `spin cloud` command. Specifically, all of the available options and subcommands. For more information on subcommand stability, see the [subcommands stability table](#subcommand-stability-table). You can reproduce the Spin Cloud command documentation on your machine by using the `--help` flag. For example:
+Fermyon provides a [`cloud` plugin](https://github.com/fermyon/cloud-plugin) for the [Spin CLI](./cli-reference.md) for you to manage Spin applications in Fermyon Cloud. This page documents the `spin cloud` command. Specifically, all of the available options and subcommands. For more information on subcommand stability, see the [subcommands stability table](#subcommand-stability-table). You can reproduce the Spin Cloud command documentation on your machine by using the `--help` flag. For example:
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin cloud

--- a/content/cloud/cloud-plugin-reference.md
+++ b/content/cloud/cloud-plugin-reference.md
@@ -1,23 +1,29 @@
-title = "Cloud Command Reference"
+title = "Fermyon Cloud Plugin Command Line Interface (CLI) Reference"
 date = "2023-06-07T22:41:02.478752Z"
 template = "cloud_main"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/cloud/cloud-plugin.md"
+url = "https://github.com/fermyon/developer/blob/main/content/cloud/cloud-plugin-reference.md"
 
 ---
 - [Spin Cloud Command](#spin-cloud-command)
-  - [Deploy](#deploy)
-  - [Login](#login)
-  - [Variables](#variables)
-    - [Set (Variables)](#set-variables)
-    - [Delete (Variables)](#delete-variables)
-    - [List (Variables)](#list-variables)
-  - [Subcommand Stability Table](#subcommand-stability-table)
+- [spin cloud](#spin-cloud)
+- [spin cloud deploy](#spin-cloud-deploy)
+- [spin cloud help](#spin-cloud-help)
+- [spin cloud login](#spin-cloud-login)
+- [spin cloud variables](#spin-cloud-variables)
+- [spin cloud variables delete](#spin-cloud-variables-delete)
+- [spin cloud variables help](#spin-cloud-variables-help)
+- [spin cloud variables list](#spin-cloud-variables-list)
+- [spin cloud variables set](#spin-cloud-variables-set)
+- [Subcommand Stability Table](#subcommand-stability-table)
 
 ## Spin Cloud Command
 
 Fermyon provides a [`cloud` plugin](https://github.com/fermyon/cloud-plugin) for the Spin CLI for you to manage Spin applications in Fermyon Cloud. This page documents the `spin cloud` command. Specifically, all of the available options and subcommands. For more information on subcommand stability, see the [subcommands stability table](#subcommand-stability-table). You can reproduce the Spin Cloud command documentation on your machine by using the `--help` flag. For example:
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin cloud
 
 {{ tabs "cloud-plugin-version" }}
 
@@ -51,7 +57,8 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
-### Deploy
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin cloud deploy
 
 {{ tabs "cloud-plugin-version" }}
 
@@ -113,7 +120,40 @@ OPTIONS:
 
 {{ blockEnd }}
 
-### Login
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin cloud help
+
+{{ tabs "spin-version" }}
+
+{{ startTab "v0.1.1"}}
+
+<!-- @selectiveCpy -->
+```console
+$ spin cloud help
+
+cloud-plugin 0.1.1
+Fermyon Engineering <engineering@fermyon.com>
+
+USAGE:
+    cloud <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+SUBCOMMANDS:
+    deploy       Package and upload an application to the Fermyon Cloud
+    help         Print this message or the help of the given subcommand(s)
+    login        Login to Fermyon Cloud
+    variables    Manage Spin application variables
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin cloud login
 
 {{ tabs "cloud-plugin-version" }}
 
@@ -166,7 +206,8 @@ OPTIONS:
 
 {{ blockEnd }}
 
-### Variables
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin cloud variables
 
 {{ tabs "cloud-plugin-version" }} 
 
@@ -199,7 +240,122 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
-#### Set (Variables)
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin cloud variables delete
+
+{{ tabs "spin-version" }}
+
+{{ startTab "v0.1.1"}}
+
+Spin compatibility: `>= v1.3`
+
+<!-- @selectiveCpy -->
+```console
+$ spin cloud variables delete --help
+
+cloud-variables-delete 0.1.1
+Delete variables
+
+USAGE:
+    cloud variables delete [OPTIONS] --app <app> [VARIABLES_TO_DELETE]...
+
+ARGS:
+    <VARIABLES_TO_DELETE>...    Variable pair to set
+
+OPTIONS:
+        --app <app>
+            Name of Spin app
+
+        --environment-name <environment-name>
+            Deploy to the Fermyon instance saved under the specified name. If omitted, Spin deploys
+            to the default unnamed instance [env: FERMYON_DEPLOYMENT_ENVIRONMENT=]
+
+    -h, --help
+            Print help information
+
+    -V, --version
+            Print version information
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin cloud variables help
+
+{{ tabs "spin-version" }}
+
+{{ startTab "v0.1.1"}}
+
+Spin compatibility: `>= v1.3`
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin cloud variables help
+
+cloud-variables 0.1.1
+Manage Spin application variables
+
+USAGE:
+    cloud variables <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+SUBCOMMANDS:
+    delete    Delete variables
+    help      Print this message or the help of the given subcommand(s)
+    list      List all variables of an application
+    set       Set variables
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin cloud variables list
+
+{{ tabs "cloud-plugin-version" }} 
+
+{{ startTab "v0.1.1"}}
+
+Spin compatibility: `>= v1.3`
+
+<!-- @selectiveCpy -->
+```console
+$ spin cloud variables list --help
+
+cloud-variables-list 0.1.1
+List all variables of an application
+
+USAGE:
+    cloud variables list [OPTIONS] --app <app>
+
+OPTIONS:
+        --app <app>
+            Name of Spin app
+
+        --environment-name <environment-name>
+            Deploy to the Fermyon instance saved under the specified name. If omitted, Spin deploys
+            to the default unnamed instance [env: FERMYON_DEPLOYMENT_ENVIRONMENT=]
+
+    -h, --help
+            Print help information
+
+    -V, --version
+            Print version information
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin cloud variables set
 
 {{ tabs "cloud-plugin-version" }} 
 
@@ -239,84 +395,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-#### Delete (Variables)
-
-{{ tabs "cloud-plugin-version" }} 
-
-{{ startTab "v0.1.1"}}
-
-Spin compatibility: `>= v1.3`
-
-<!-- @selectiveCpy -->
-```console
-$ spin cloud variables delete --help
-
-cloud-variables-delete 0.1.1
-Delete variables
-
-USAGE:
-    cloud variables delete [OPTIONS] --app <app> [VARIABLES_TO_DELETE]...
-
-ARGS:
-    <VARIABLES_TO_DELETE>...    Variable pair to set
-
-OPTIONS:
-        --app <app>
-            Name of Spin app
-
-        --environment-name <environment-name>
-            Deploy to the Fermyon instance saved under the specified name. If omitted, Spin deploys
-            to the default unnamed instance [env: FERMYON_DEPLOYMENT_ENVIRONMENT=]
-
-    -h, --help
-            Print help information
-
-    -V, --version
-            Print version information
-```
-
-{{ blockEnd }}
-
-{{ blockEnd }}
-
-#### List (Variables)
-
-{{ tabs "cloud-plugin-version" }} 
-
-{{ startTab "v0.1.1"}}
-
-Spin compatibility: `>= v1.3`
-
-<!-- @selectiveCpy -->
-```console
-$ spin cloud variables list --help
-
-cloud-variables-list 0.1.1
-List all variables of an application
-
-USAGE:
-    cloud variables list [OPTIONS] --app <app>
-
-OPTIONS:
-        --app <app>
-            Name of Spin app
-
-        --environment-name <environment-name>
-            Deploy to the Fermyon instance saved under the specified name. If omitted, Spin deploys
-            to the default unnamed instance [env: FERMYON_DEPLOYMENT_ENVIRONMENT=]
-
-    -h, --help
-            Print help information
-
-    -V, --version
-            Print version information
-```
-
-{{ blockEnd }}
-
-{{ blockEnd }}
-
-### Subcommand Stability Table
+## Subcommand Stability Table
 
 CLI commands have four phases that indicate levels of stability:
 
@@ -333,9 +412,9 @@ Spin compatibility: `>= v1.3`
 
 | Command                                                    | Stability   |
 | ---------------------------------------------------------- | ----------- |
-| <code>cloud deploy</code>                                                 | Stabilizing      |
-| <code>cloud login</code>                                               | Stabilizing      |
-| <code>cloud variables</code>                                                 | Stabilizing      |
+| <code>cloud deploy</code>                                  | Stabilizing |
+| <code>cloud login</code>                                   | Stabilizing |
+| <code>cloud variables</code>                               | Stabilizing |
 
 {{ blockEnd }}
 

--- a/content/cloud/cloud-plugin-reference.md
+++ b/content/cloud/cloud-plugin-reference.md
@@ -123,7 +123,7 @@ OPTIONS:
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin cloud help
 
-{{ tabs "spin-version" }}
+{{ tabs "cloud-plugin-version" }}
 
 {{ startTab "v0.1.1"}}
 
@@ -243,7 +243,7 @@ SUBCOMMANDS:
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin cloud variables delete
 
-{{ tabs "spin-version" }}
+{{ tabs "cloud-plugin-version" }}
 
 {{ startTab "v0.1.1"}}
 
@@ -284,7 +284,7 @@ OPTIONS:
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin cloud variables help
 
-{{ tabs "spin-version" }}
+{{ tabs "cloud-plugin-version" }}
 
 {{ startTab "v0.1.1"}}
 

--- a/content/cloud/variables.md
+++ b/content/cloud/variables.md
@@ -15,7 +15,7 @@ url = "https://github.com/fermyon/developer/blob/main//content/cloud/variables.m
 
 Spin supports dynamic application variables. Instead of being static, their values can be updated without modifying the application, creating a simpler experience for rotating secrets, updating API endpoints, and more. 
 
-These variables are defined in a Spin application manifest (in the `[variables]` section) and are provided by a configuration provider. When using Spin locally, the configuration provider can be Vault for secrets or host environment variables. You can refer to the [dynamic configuration documentation](/spin/dynamic-configuration.md) to learn how to configure variables locally. In Fermyon Cloud, you can set and update variables for Spin applications using the [`spin cloud variables`](/cloud/cloud-plugin-reference.md#spin-cloud-variables) command.
+These variables are defined in a Spin application manifest (in the `[variables]` section) and are provided by a configuration provider. When using Spin locally, the configuration provider can be Vault for secrets or host environment variables. You can refer to the [dynamic configuration documentation](/spin/dynamic-configuration.md) to learn how to configure variables locally. In Fermyon Cloud, you can set and update variables for Spin applications using the [`spin cloud variables`](/cloud/cloud-command-reference.md#spin-cloud-variables) command.
 
 This tutorial will guide you through the process of creating a simple application that validates passwords.
 

--- a/content/cloud/variables.md
+++ b/content/cloud/variables.md
@@ -15,7 +15,7 @@ url = "https://github.com/fermyon/developer/blob/main//content/cloud/variables.m
 
 Spin supports dynamic application variables. Instead of being static, their values can be updated without modifying the application, creating a simpler experience for rotating secrets, updating API endpoints, and more. 
 
-These variables are defined in a Spin application manifest (in the `[variables]` section) and are provided by a configuration provider. When using Spin locally, the configuration provider can be Vault for secrets or host environment variables. You can refer to the [dynamic configuration documentation](/spin/dynamic-configuration.md) to learn how to configure variables locally. In Fermyon Cloud, you can set and update variables for Spin applications using the [`spin cloud variables`](/cloud/cloud-plugin.md#variables) command.
+These variables are defined in a Spin application manifest (in the `[variables]` section) and are provided by a configuration provider. When using Spin locally, the configuration provider can be Vault for secrets or host environment variables. You can refer to the [dynamic configuration documentation](/spin/dynamic-configuration.md) to learn how to configure variables locally. In Fermyon Cloud, you can set and update variables for Spin applications using the [`spin cloud variables`](/cloud/cloud-plugin-reference.md#spin-cloud-variables) command.
 
 This tutorial will guide you through the process of creating a simple application that validates passwords.
 

--- a/content/spin/cli-reference.md
+++ b/content/spin/cli-reference.md
@@ -16,19 +16,16 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/cli-reference
 - [spin cloud variables](#spin-cloud-variables)
 - [spin help](#spin-help)
 - [spin new](#spin-new)
-- [spin plugin](#spin-plugin)
 - [spin plugins](#spin-plugins)
 - [spin plugins install](#spin-plugins-install)
 - [spin plugins list](#spin-plugins-list)
 - [spin plugins uninstall](#spin-plugins-uninstall)
 - [spin plugins update](#spin-plugins-update)
 - [spin plugins upgrade](#spin-plugins-upgrade)
-- [spin oci](#spin-oci)
 - [spin registry](#spin-registry)
 - [spin registry login](#spin-registry-login)
 - [spin registry pull](#spin-registry-pull)
 - [spin registry push](#spin-registry-push)
-- [spin template](#spin-template)
 - [spin templates](#spin-templates)
 - [spin templates install](#spin-templates-install)
 - [spin templates list](#spin-templates-list)
@@ -44,11 +41,9 @@ For information on command stability, see the [CLI stability table](#cli-stabili
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin add
 
-Adding a subcommand (and again issuing the `--help` command) will provide information specific to that particular subcommand. For example:
-
 {{ tabs "spin-version" }}
 
-{{ startTab "v1.0.0"}}
+{{ startTab "v1.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -84,7 +79,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.1.0"}}
+{{ startTab "v1.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -120,7 +115,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0/1.2.1"}}
+{{ startTab "v1.2"}}
 
 <!-- @selectiveCpy -->
 
@@ -156,7 +151,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.3.0"}}
+{{ startTab "v1.3"}}
 
 <!-- @selectiveCpy -->
 
@@ -199,7 +194,7 @@ OPTIONS:
 
 {{ tabs "spin-version" }}
 
-{{ startTab "v1.0.0"}}
+{{ startTab "v1.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -223,7 +218,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.1.0"}}
+{{ startTab "v1.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -247,7 +242,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0/1.2.1"}}
+{{ startTab "v1.2"}}
 
 <!-- @selectiveCpy -->
 
@@ -273,7 +268,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.3.0"}}
+{{ startTab "v1.3"}}
 
 <!-- @selectiveCpy -->
 
@@ -311,7 +306,7 @@ OPTIONS:
 
 {{ tabs "spin-version" }}
 
-{{ startTab "v1.0.0"}}
+{{ startTab "v1.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -335,7 +330,7 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.1.0"}}
+{{ startTab "v1.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -359,7 +354,7 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0/1.2.1"}}
+{{ startTab "v1.2"}}
 
 <!-- @selectiveCpy -->
 
@@ -383,7 +378,7 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.3.0"}}
+{{ startTab "v1.3"}}
 
 The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-plugin-reference).
 
@@ -401,7 +396,7 @@ The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](../cloud/c
 
 {{ tabs "spin-version" }}
 
-{{ startTab "v1.0.0"}}
+{{ startTab "v1.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -448,7 +443,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.1.0"}}
+{{ startTab "v1.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -495,7 +490,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0/1.2.1"}}
+{{ startTab "v1.2"}}
 
 <!-- @selectiveCpy -->
 
@@ -543,7 +538,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.3.0"}}
+{{ startTab "v1.3"}}
 
 The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-plugin-reference#spin-cloud-deploy).
 
@@ -554,8 +549,6 @@ The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](../
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin login
 
-Please note: the previous `spin login` command (from versions before Spin v0.9.0) has been kept to ensure backward compatibility. In the Spin v0.9.0 release, both the `spin login --help` and [`spin cloud login --help`](#cloud-login) commands will produce the same output.
-
 `spin login` is a shotcurt to [`spin cloud login`](#cloud-login).
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -563,7 +556,7 @@ Please note: the previous `spin login` command (from versions before Spin v0.9.0
 
 {{ tabs "spin-version" }}
 
-{{ startTab "v1.0.0"}}
+{{ startTab "v1.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -621,7 +614,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.1.0"}}
+{{ startTab "v1.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -679,7 +672,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0/1.2.1"}}
+{{ startTab "v1.2"}}
 
 <!-- @selectiveCpy -->
 
@@ -737,7 +730,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.3.0"}}
+{{ startTab "v1.3"}}
 
 The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-plugin-reference#spin-cloud-login).
 
@@ -750,7 +743,7 @@ The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](../c
 
 {{ tabs "spin-version" }}
 
-{{ startTab "v1.3.0"}}
+{{ startTab "v1.3"}}
 
 The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-plugin-reference#spin-cloud-variables).
 
@@ -763,7 +756,7 @@ The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](
 
 {{ tabs "spin-version" }}
 
-{{ startTab "v1.0.0"}}
+{{ startTab "v1.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -793,7 +786,7 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.1.0"}}
+{{ startTab "v1.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -827,14 +820,14 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0/1.2.1"}}
+{{ startTab "v1.2"}}
 
 <!-- @selectiveCpy -->
 
 ```console
 $ spin help      
 
-spin 1.2.0/1.2.1 
+spin 1.2.0
 The Spin CLI
 
 USAGE:
@@ -862,7 +855,7 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.3.0"}}
+{{ startTab "v1.3"}}
 
 <!-- @selectiveCpy -->
 
@@ -907,7 +900,7 @@ SUBCOMMANDS:
 
 {{ tabs "spin-version" }}
 
-{{ startTab "v1.0.0"}}
+{{ startTab "v1.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -942,7 +935,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.1.0"}}
+{{ startTab "v1.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -977,7 +970,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0/1.2.1"}}
+{{ startTab "v1.2"}}
 
 <!-- @selectiveCpy -->
 
@@ -1012,7 +1005,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.3.0"}}
+{{ startTab "v1.3"}}
 
 <!-- @selectiveCpy -->
 
@@ -1055,16 +1048,11 @@ OPTIONS:
 * `spin add` _adds_ a component to an _existing_ application - that is, it modifies an existing `spin.toml` file.
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
-## spin plugin
-
-`spin plugin` is an alias for [`spin plugins`](#plugins)
-
-<!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin plugins
 
 {{ tabs "spin-version" }}
 
-{{ startTab "v1.0.0"}}
+{{ startTab "v1.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -1091,7 +1079,7 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.1.0"}}
+{{ startTab "v1.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -1118,7 +1106,7 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0/1.2.1"}}
+{{ startTab "v1.2"}}
 
 <!-- @selectiveCpy -->
 
@@ -1145,7 +1133,7 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.3.0"}}
+{{ startTab "v1.3"}}
 
 <!-- @selectiveCpy -->
 
@@ -1179,7 +1167,7 @@ SUBCOMMANDS:
 
 {{ tabs "spin-version" }}
 
-{{ startTab "v1.0.0"}}
+{{ startTab "v1.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -1220,7 +1208,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.1.0"}}
+{{ startTab "v1.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -1261,7 +1249,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0/1.2.1"}}
+{{ startTab "v1.2"}}
 
 <!-- @selectiveCpy -->
 
@@ -1302,7 +1290,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.3.0"}}
+{{ startTab "v1.3"}}
 
 <!-- @selectiveCpy -->
 
@@ -1350,7 +1338,7 @@ OPTIONS:
 
 {{ tabs "spin-version" }}
 
-{{ startTab "v1.0.0"}}
+{{ startTab "v1.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -1370,7 +1358,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.1.0"}}
+{{ startTab "v1.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -1390,7 +1378,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0/1.2.1"}}
+{{ startTab "v1.2"}}
 
 <!-- @selectiveCpy -->
 
@@ -1410,7 +1398,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.3.0"}}
+{{ startTab "v1.3"}}
 
 <!-- @selectiveCpy -->
 
@@ -1437,7 +1425,7 @@ OPTIONS:
 
 {{ tabs "spin-version" }}
 
-{{ startTab "v1.0.0"}}
+{{ startTab "v1.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -1459,7 +1447,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.1.0"}}
+{{ startTab "v1.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -1481,7 +1469,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0/1.2.1"}}
+{{ startTab "v1.2"}}
 
 <!-- @selectiveCpy -->
 
@@ -1503,7 +1491,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.3.0"}}
+{{ startTab "v1.3"}}
 
 <!-- @selectiveCpy -->
 
@@ -1532,7 +1520,7 @@ OPTIONS:
 
 {{ tabs "spin-version" }}
 
-{{ startTab "v1.0.0"}}
+{{ startTab "v1.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -1551,7 +1539,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.1.0"}}
+{{ startTab "v1.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -1570,7 +1558,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0/1.2.1"}}
+{{ startTab "v1.2"}}
 
 <!-- @selectiveCpy -->
 
@@ -1589,7 +1577,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.3.0"}}
+{{ startTab "v1.3"}}
 
 <!-- @selectiveCpy -->
 
@@ -1615,7 +1603,7 @@ OPTIONS:
 
 {{ tabs "spin-version" }}
 
-{{ startTab "v1.0.0"}}
+{{ startTab "v1.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -1659,7 +1647,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.1.0"}}
+{{ startTab "v1.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -1703,7 +1691,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0/1.2.1"}}
+{{ startTab "v1.2"}}
 
 <!-- @selectiveCpy -->
 
@@ -1747,7 +1735,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.3.0"}}
+{{ startTab "v1.3"}}
 
 <!-- @selectiveCpy -->
 
@@ -1796,16 +1784,11 @@ OPTIONS:
 **Note:** For additional information, please see the [Managing Plugins](/spin/managing-plugins) and/or [Creating Plugins](/spin/plugin-authoring) sections of the documentation.
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
-## spin oci
-
-`spin oci` is an alias for  [`spin registry`](#registry)
-
-<!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin registry
 
 {{ tabs "spin-version" }}
 
-{{ startTab "v1.0.0"}}
+{{ startTab "v1.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -1831,7 +1814,7 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.1.0"}}
+{{ startTab "v1.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -1857,7 +1840,7 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0/1.2.1"}}
+{{ startTab "v1.2"}}
 
 <!-- @selectiveCpy -->
 
@@ -1882,7 +1865,7 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.3.0"}}
+{{ startTab "v1.3"}}
 
 <!-- @selectiveCpy -->
 
@@ -1914,7 +1897,7 @@ SUBCOMMANDS:
 
 {{ tabs "spin-version" }}
 
-{{ startTab "v1.0.0"}}
+{{ startTab "v1.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -1939,7 +1922,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.1.0"}}
+{{ startTab "v1.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -1964,7 +1947,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0/1.2.1"}}
+{{ startTab "v1.2"}}
 
 <!-- @selectiveCpy -->
 
@@ -1989,7 +1972,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.3.0"}}
+{{ startTab "v1.3"}}
 
 <!-- @selectiveCpy -->
 
@@ -2021,7 +2004,7 @@ OPTIONS:
 
 {{ tabs "spin-version" }}
 
-{{ startTab "v1.0.0"}}
+{{ startTab "v1.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -2044,7 +2027,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.1.0"}}
+{{ startTab "v1.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -2067,7 +2050,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0/1.2.1"}}
+{{ startTab "v1.2"}}
 
 <!-- @selectiveCpy -->
 
@@ -2090,7 +2073,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.3.0"}}
+{{ startTab "v1.3"}}
 
 <!-- @selectiveCpy -->
 
@@ -2120,7 +2103,7 @@ OPTIONS:
 
 {{ tabs "spin-version" }}
 
-{{ startTab "v1.0.0"}}
+{{ startTab "v1.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -2144,7 +2127,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.1.0"}}
+{{ startTab "v1.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -2168,7 +2151,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0/1.2.1"}}
+{{ startTab "v1.2"}}
 
 <!-- @selectiveCpy -->
 
@@ -2197,16 +2180,11 @@ OPTIONS:
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
-## spin template
-
-`spin template` is an alias for [`spin templates'](#templates)
-
-<!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin templates
 
 {{ tabs "spin-version" }}
 
-{{ startTab "v1.0.0"}}
+{{ startTab "v1.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -2232,7 +2210,7 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.1.0"}}
+{{ startTab "v1.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -2258,7 +2236,7 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0/1.2.1"}}
+{{ startTab "v1.2"}}
 
 <!-- @selectiveCpy -->
 
@@ -2284,7 +2262,7 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.3.0"}}
+{{ startTab "v1.3"}}
 
 <!-- @selectiveCpy -->
 
@@ -2317,7 +2295,7 @@ SUBCOMMANDS:
 
 {{ tabs "spin-version" }}
 
-{{ startTab "v1.0.0"}}
+{{ startTab "v1.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -2353,7 +2331,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.1.0"}}
+{{ startTab "v1.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -2389,7 +2367,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0/1.2.1"}}
+{{ startTab "v1.2"}}
 
 <!-- @selectiveCpy -->
 
@@ -2425,7 +2403,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.3.0"}}
+{{ startTab "v1.3"}}
 
 <!-- @selectiveCpy -->
 
@@ -2468,7 +2446,7 @@ OPTIONS:
 
 {{ tabs "spin-version" }}
 
-{{ startTab "v1.0.0"}}
+{{ startTab "v1.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -2489,7 +2467,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.1.0"}}
+{{ startTab "v1.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -2510,7 +2488,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0/1.2.1"}}
+{{ startTab "v1.2"}}
 
 <!-- @selectiveCpy -->
 
@@ -2531,7 +2509,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.3.0"}}
+{{ startTab "v1.3"}}
 
 <!-- @selectiveCpy -->
 
@@ -2561,7 +2539,7 @@ OPTIONS:
 
 {{ tabs "spin-version" }}
 
-{{ startTab "v1.0.0"}}
+{{ startTab "v1.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -2583,7 +2561,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.1.0"}}
+{{ startTab "v1.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -2605,7 +2583,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0/1.2.1"}}
+{{ startTab "v1.2"}}
 
 <!-- @selectiveCpy -->
 
@@ -2627,7 +2605,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.3.0"}}
+{{ startTab "v1.3"}}
 
 <!-- @selectiveCpy -->
 
@@ -2656,7 +2634,7 @@ OPTIONS:
 
 {{ tabs "spin-version" }}
 
-{{ startTab "v1.0.0"}}
+{{ startTab "v1.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -2691,7 +2669,42 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.1.0"}}
+{{ startTab "v1.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates upgrade --help1
+
+spin-templates-upgrade 
+Upgrade templates to match your current version of Spin.
+
+The files of the templates are copied to the local template store: a directory in your data or home
+directory.
+
+USAGE:
+    spin templates upgrade [OPTIONS]
+
+OPTIONS:
+        --all
+            By default, Spin displays the list of installed repositories and prompts you to choose
+            which to upgrade.  Pass this flag to upgrade all repositories without prompting
+
+        --branch <BRANCH>
+            The optional branch of the git repository, if a specific repository is given
+
+    -h, --help
+            Print help information
+
+        --repo <GIT_URL>
+            By default, Spin displays the list of installed repositories and prompts you to choose
+            which to upgrade.  Pass this flag to upgrade only the specified repository without
+            prompting
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.2"}}
 
 <!-- @selectiveCpy -->
 
@@ -2726,42 +2739,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0/1.2.1"}}
-
-<!-- @selectiveCpy -->
-
-```console
-$ spin templates upgrade --help  
-
-spin-templates-upgrade 
-Upgrade templates to match your current version of Spin.
-
-The files of the templates are copied to the local template store: a directory in your data or home
-directory.
-
-USAGE:
-    spin templates upgrade [OPTIONS]
-
-OPTIONS:
-        --all
-            By default, Spin displays the list of installed repositories and prompts you to choose
-            which to upgrade.  Pass this flag to upgrade all repositories without prompting
-
-        --branch <BRANCH>
-            The optional branch of the git repository, if a specific repository is given
-
-    -h, --help
-            Print help information
-
-        --repo <GIT_URL>
-            By default, Spin displays the list of installed repositories and prompts you to choose
-            which to upgrade.  Pass this flag to upgrade only the specified repository without
-            prompting
-```
-
-{{ blockEnd }}
-
-{{ startTab "v1.3.0"}}
+{{ startTab "v1.3"}}
 
 <!-- @selectiveCpy -->
 
@@ -2809,7 +2787,7 @@ Note: There are three trigger options which only applies to the HTTP trigger (`-
 
 {{ tabs "spin-version" }}
 
-{{ startTab "v1.0.0"}}
+{{ startTab "v1.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -2884,7 +2862,7 @@ TRIGGER OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.1.0"}}
+{{ startTab "v1.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -2959,7 +2937,7 @@ TRIGGER OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0/1.2.1"}}
+{{ startTab "v1.2"}}
 
 <!-- @selectiveCpy -->
 
@@ -3046,7 +3024,7 @@ TRIGGER OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.3.0"}}
+{{ startTab "v1.3"}}
 
 <!-- @selectiveCpy -->
 
@@ -3129,7 +3107,6 @@ TRIGGER OPTIONS:
             
             [env: SPIN_TLS_KEY=]
             Only appplies to HTTP triggers
-
 ```
 
 {{ blockEnd }}
@@ -3143,7 +3120,7 @@ TRIGGER OPTIONS:
 
 {{ tabs "spin-version" }}
 
-{{ startTab "v1.1.0"}}
+{{ startTab "v1.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -3171,7 +3148,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0/1.2.1"}}
+{{ startTab "v1.2"}}
 
 <!-- @selectiveCpy -->
 
@@ -3201,7 +3178,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.3.0"}}
+{{ startTab "v1.3"}}
 
 <!-- @selectiveCpy -->
 
@@ -3244,7 +3221,7 @@ CLI commands have four phases that indicate levels of stability:
 
 {{ tabs "spin-version" }}
 
-{{ startTab "v1.0.0"}}
+{{ startTab "v1.0"}}
 
 | Command                                                    | Stability   |
 | ---------------------------------------------------------- | ----------- |
@@ -3260,7 +3237,7 @@ CLI commands have four phases that indicate levels of stability:
 
 {{ blockEnd }}
 
-{{ startTab "v1.1.0"}}
+{{ startTab "v1.1"}}
 
 | Command                                                                               | Stability    |
 | ------------------------------------------------------------------------------------- | ------------ |
@@ -3277,7 +3254,7 @@ CLI commands have four phases that indicate levels of stability:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0/1.2.1"}}
+{{ startTab "v1.2"}}
 
 | Command                                                                               | Stability    |
 | ------------------------------------------------------------------------------------- | ------------ |
@@ -3294,7 +3271,7 @@ CLI commands have four phases that indicate levels of stability:
 
 {{ blockEnd }}
 
-{{ startTab "v1.3.0"}}
+{{ startTab "v1.3"}}
 
 | Command                                                                               | Stability    |
 | ------------------------------------------------------------------------------------- | ------------ |

--- a/content/spin/cli-reference.md
+++ b/content/spin/cli-reference.md
@@ -9,10 +9,10 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/cli-reference
 - [spin add](#spin-add)
 - [spin build](#spin-build)
 - [spin cloud](#spin-cloud)
-- [spin deploy](#spin-deploy)
 - [spin cloud deploy](#spin-cloud-deploy)
 - [spin cloud login](#spin-cloud-login)
 - [spin cloud variables](#spin-cloud-variables)
+- [spin deploy](#spin-deploy)
 - [spin help](#spin-help)
 - [spin login](#spin-login)
 - [spin new](#spin-new)
@@ -388,11 +388,6 @@ The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](../cloud/c
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
-## spin deploy
-
-`spin deploy` is a shotcurt to [`spin cloud deploy`](#cloud-deploy).
-
-<!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin cloud deploy
 
 {{ tabs "spin-version" }}
@@ -748,6 +743,11 @@ The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
+## spin deploy
+
+`spin deploy` is a shortcut to [`spin cloud deploy`](#spin-cloud-deploy).
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin help
 
 {{ tabs "spin-version" }}
@@ -894,7 +894,7 @@ SUBCOMMANDS:
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin login
 
-`spin login` is a shotcurt to [`spin cloud login`](#cloud-login).
+`spin login` is a shortcut to [`spin cloud login`](#spin-cloud-login).
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin new
@@ -2178,6 +2178,32 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.3" }}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry push --help
+
+spin-registry-push
+Push a Spin application to a registry
+
+USAGE:
+    spin registry push [OPTIONS] <REFERENCE>
+
+ARGS:
+    <REFERENCE>    Reference of the Spin application
+
+OPTIONS:
+    -f, --from <APP_MANIFEST_FILE>    The application to push. This may be a manifest (spin.toml)
+                                      file, or a directory containing a spin.toml file. If omitted,
+                                      it defaults to "spin.toml" [default: spin.toml]
+    -h, --help                        Print help information
+    -k, --insecure                    Ignore server certificate errors
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -2675,7 +2701,7 @@ OPTIONS:
 <!-- @selectiveCpy -->
 
 ```console
-$ spin templates upgrade --help1
+$ spin templates upgrade --help
 
 spin-templates-upgrade 
 Upgrade templates to match your current version of Spin.
@@ -2830,13 +2856,7 @@ TRIGGER OPTIONS:
             Print output to stdout/stderr only for given component(s)
 
     -L, --log-dir <APP_LOG_DIR>
-            Log directory for the stdout and stderr of components
-
-        --listen <ADDRESS>
-            IP address and port to listen on
-            
-            [default: 127.0.0.1:3000]
-            Only appplies to HTTP triggers            
+            Log directory for the stdout and stderr of components     
 
     -q, --quiet
             Silence all component output to stdout/stderr
@@ -2845,20 +2865,6 @@ TRIGGER OPTIONS:
             Configuration file for config providers and wasmtime config
             
             [env: RUNTIME_CONFIG_FILE=]
-
-        --tls-cert <TLS_CERT>
-            The path to the certificate to use for https, if this is not set, normal http will be
-            used. The cert should be in PEM format
-            
-            [env: SPIN_TLS_CERT=]
-            Only appplies to HTTP triggers
-
-        --tls-key <TLS_KEY>
-            The path to the certificate key to use for https, if this is not set, normal http will
-            be used. The key should be in PKCS#8 format
-            
-            [env: SPIN_TLS_KEY=]
-            Only appplies to HTTP triggers
 ```
 
 {{ blockEnd }}
@@ -2907,12 +2913,6 @@ TRIGGER OPTIONS:
     -L, --log-dir <APP_LOG_DIR>
             Log directory for the stdout and stderr of components
 
-        --listen <ADDRESS>
-            IP address and port to listen on
-            
-            [default: 127.0.0.1:3000]
-            Only appplies to HTTP triggers
-
     -q, --quiet
             Silence all component output to stdout/stderr
 
@@ -2920,20 +2920,6 @@ TRIGGER OPTIONS:
             Configuration file for config providers and wasmtime config
             
             [env: RUNTIME_CONFIG_FILE=]
-
-        --tls-cert <TLS_CERT>
-            The path to the certificate to use for https, if this is not set, normal http will be
-            used. The cert should be in PEM format
-            
-            [env: SPIN_TLS_CERT=]
-            Only appplies to HTTP triggers
-
-        --tls-key <TLS_KEY>
-            The path to the certificate key to use for https, if this is not set, normal http will
-            be used. The key should be in PKCS#8 format
-            
-            [env: SPIN_TLS_KEY=]
-            Only appplies to HTTP triggers
 ```
 
 {{ blockEnd }}
@@ -2987,12 +2973,6 @@ TRIGGER OPTIONS:
     -L, --log-dir <APP_LOG_DIR>
             Log directory for the stdout and stderr of components
 
-        --listen <ADDRESS>
-            IP address and port to listen on
-            
-            [default: 127.0.0.1:3000]
-            Only appplies to HTTP triggers
-
     -q, --quiet
             Silence all component output to stdout/stderr
 
@@ -3007,20 +2987,6 @@ TRIGGER OPTIONS:
             
             For local apps, this defaults to `.spin/` relative to the `spin.toml` file. For remote
             apps, this has no default (unset). Passing an empty value forces the value to be unset.
-        
-        --tls-cert <TLS_CERT>
-            The path to the certificate to use for https, if this is not set, normal http will be
-            used. The cert should be in PEM format
-            
-            [env: SPIN_TLS_CERT=]
-            Only appplies to HTTP triggers
-
-        --tls-key <TLS_KEY>
-            The path to the certificate key to use for https, if this is not set, normal http will
-            be used. The key should be in PKCS#8 format
-            
-            [env: SPIN_TLS_KEY=]
-            Only appplies to HTTP triggers
 ```
 
 {{ blockEnd }}
@@ -3074,12 +3040,6 @@ TRIGGER OPTIONS:
     -L, --log-dir <APP_LOG_DIR>
             Log directory for the stdout and stderr of components
 
-        --listen <ADDRESS>
-            IP address and port to listen on
-            
-            [default: 127.0.0.1:3000]
-            Only appplies to HTTP triggers
-
     -q, --quiet
             Silence all component output to stdout/stderr
 
@@ -3094,30 +3054,18 @@ TRIGGER OPTIONS:
             
             For local apps, this defaults to `.spin/` relative to the `spin.toml` file. For remote
             apps, this has no default (unset). Passing an empty value forces the value to be unset.
-
-        --tls-cert <TLS_CERT>
-            The path to the certificate to use for https, if this is not set, normal http will be
-            used. The cert should be in PEM format
-            
-            [env: SPIN_TLS_CERT=]
-            Only appplies to HTTP triggers
-
-        --tls-key <TLS_KEY>
-            The path to the certificate key to use for https, if this is not set, normal http will
-            be used. The key should be in PKCS#8 format
-            
-            [env: SPIN_TLS_KEY=]
-            Only appplies to HTTP triggers
 ```
 
 {{ blockEnd }}
 
 {{ blockEnd }}
 
+> **Please note:** If the `-f` or `--from` options do not accurately infer the intended registry or `.toml` file for your application, then you can explicitly specify either the `--from-registry` or  `--from-file` options to clarify this.
+
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ### spin up (HTTP Trigger)
 
-The following additional trigger options are available for the [spin up](#spin-up) command, when using the HTTP trigger. E.g., `spin up --listen`
+The following additional trigger options are available for the [spin up](#spin-up) command, when using the HTTP trigger. E.g. `spin up --listen`
 
 {{ tabs "spin-version" }}
 
@@ -3222,8 +3170,6 @@ The following additional trigger options are available for the [spin up](#spin-u
 {{ blockEnd }}
 
 {{ blockEnd }}
-
-> **Please note:** If the `-f` or `--from` options do not accurately infer the intended registry or `.toml` file for your application, then you can explicitly specify either the `--from-registry` or  `--from-file` options to clarify this.
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin watch

--- a/content/spin/cli-reference.md
+++ b/content/spin/cli-reference.md
@@ -11,10 +11,10 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/cli-reference
 - [spin cloud](#spin-cloud)
 - [spin deploy](#spin-deploy)
 - [spin cloud deploy](#spin-cloud-deploy)
-- [spin login](#spin-login)
 - [spin cloud login](#spin-cloud-login)
 - [spin cloud variables](#spin-cloud-variables)
 - [spin help](#spin-help)
+- [spin login](#spin-login)
 - [spin new](#spin-new)
 - [spin plugins](#spin-plugins)
 - [spin plugins install](#spin-plugins-install)
@@ -32,6 +32,7 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/cli-reference
 - [spin templates uninstall](#spin-templates-uninstall)
 - [spin templates upgrade](#spin-templates-upgrade)
 - [spin up](#spin-up)
+  - [spin up (HTTP Trigger)](#spin-up-http-trigger)
 - [spin watch](#spin-watch)
 - [Stability Table](#stability-table)
 
@@ -380,7 +381,7 @@ SUBCOMMANDS:
 
 {{ startTab "v1.3"}}
 
-The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-plugin-reference).
+The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-command-reference).
 
 {{ blockEnd }}
 
@@ -540,16 +541,11 @@ OPTIONS:
 
 {{ startTab "v1.3"}}
 
-The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-plugin-reference#spin-cloud-deploy).
+The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-command-reference#spin-cloud-deploy).
 
 {{ blockEnd }}
 
 {{ blockEnd }}
-
-<!-- markdownlint-disable-next-line titlecase-rule -->
-## spin login
-
-`spin login` is a shotcurt to [`spin cloud login`](#cloud-login).
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin cloud login
@@ -732,7 +728,7 @@ OPTIONS:
 
 {{ startTab "v1.3"}}
 
-The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-plugin-reference#spin-cloud-login).
+The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-command-reference#spin-cloud-login).
 
 {{ blockEnd }}
 
@@ -745,7 +741,7 @@ The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](../c
 
 {{ startTab "v1.3"}}
 
-The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-plugin-reference#spin-cloud-variables).
+The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-command-reference#spin-cloud-variables).
 
 {{ blockEnd }}
 
@@ -894,6 +890,11 @@ SUBCOMMANDS:
 {{ blockEnd }}
 
 > Please note: Spin `help` is a convenient way to access help using a subcommand, instead of using the `--help` option. For example, `spin help cloud` will give you the same output as `spin cloud --help`. Similarly, `spin help build` will give you the same output as `spin build --help` and so forth.
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin login
+
+`spin login` is a shotcurt to [`spin cloud login`](#cloud-login).
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin new
@@ -2783,7 +2784,7 @@ OPTIONS:
 
 The following options are available in relation to running your Spin application.
 
-Note: There are three trigger options which only applies to the HTTP trigger (`--listen`, `--tls-cert` and `--tls-key`).
+Note: There are three trigger options which only applies to the [HTTP trigger](#spin-up-http-triggers) (`--listen`, `--tls-cert` and `--tls-key`).
 
 {{ tabs "spin-version" }}
 
@@ -3107,6 +3108,115 @@ TRIGGER OPTIONS:
             
             [env: SPIN_TLS_KEY=]
             Only appplies to HTTP triggers
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+### spin up (HTTP Trigger)
+
+The following additional trigger options are available for the [spin up](#spin-up) command, when using the HTTP trigger. E.g., `spin up --listen`
+
+{{ tabs "spin-version" }}
+
+{{ startTab "v1.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+    --listen <ADDRESS>
+        IP address and port to listen on
+
+        [default: 127.0.0.1:3000]
+
+    --tls-cert <TLS_CERT>
+        The path to the certificate to use for https, if this is not set, normal http will be
+        used. The cert should be in PEM format
+
+        [env: SPIN_TLS_CERT=]
+
+    --tls-key <TLS_KEY>
+        The path to the certificate key to use for https, if this is not set, normal http will
+        be used. The key should be in PKCS#8 format
+
+        [env: SPIN_TLS_KEY=]
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+    --listen <ADDRESS>
+        IP address and port to listen on
+
+        [default: 127.0.0.1:3000]
+
+    --tls-cert <TLS_CERT>
+        The path to the certificate to use for https, if this is not set, normal http will be
+        used. The cert should be in PEM format
+
+        [env: SPIN_TLS_CERT=]
+
+    --tls-key <TLS_KEY>
+        The path to the certificate key to use for https, if this is not set, normal http will
+        be used. The key should be in PKCS#8 format
+
+        [env: SPIN_TLS_KEY=]
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.2"}}
+
+<!-- @selectiveCpy -->
+
+```console
+    --listen <ADDRESS>
+        IP address and port to listen on
+
+        [default: 127.0.0.1:3000]
+
+    --tls-cert <TLS_CERT>
+        The path to the certificate to use for https, if this is not set, normal http will be
+        used. The cert should be in PEM format
+
+        [env: SPIN_TLS_CERT=]
+
+    --tls-key <TLS_KEY>
+        The path to the certificate key to use for https, if this is not set, normal http will
+        be used. The key should be in PKCS#8 format
+
+        [env: SPIN_TLS_KEY=]
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3"}}
+
+<!-- @selectiveCpy -->
+
+```console
+    --listen <ADDRESS>
+        IP address and port to listen on
+
+        [default: 127.0.0.1:3000]
+
+    --tls-cert <TLS_CERT>
+        The path to the certificate to use for https, if this is not set, normal http will be
+        used. The cert should be in PEM format
+
+        [env: SPIN_TLS_CERT=]
+
+    --tls-key <TLS_KEY>
+        The path to the certificate key to use for https, if this is not set, normal http will
+        be used. The key should be in PKCS#8 format
+
+        [env: SPIN_TLS_KEY=]
 ```
 
 {{ blockEnd }}

--- a/content/spin/cli-reference.md
+++ b/content/spin/cli-reference.md
@@ -6,139 +6,43 @@ enable_shortcodes = true
 url = "https://github.com/fermyon/developer/blob/main/content/spin/cli-reference.md"
 
 ---
-- [Spin](#spin)
-  - [Add](#add)
-  - [Build](#build)
-  - [Cloud](#cloud)
-    - [Deploy (Cloud)](#deploy-cloud)
-    - [Login (Cloud)](#login-cloud)
-  - [Deploy](#deploy)
-  - [Help](#help)
-  - [Login](#login)
-  - [New](#new)
-  - [Plugins](#plugins)
-    - [Install (Plugins)](#install-plugins)
-    - [List (Plugins)](#list-plugins)
-    - [Uninstall (Plugins)](#uninstall-plugins)
-    - [Update (Plugins)](#update-plugins)
-    - [Upgrade (Plugins)](#upgrade-plugins)
-  - [OCI Registry](#oci-registry)
-    - [Login (OCI Registry)](#login-oci-registry)
-    - [Pull (OCI Registry)](#pull-oci-registry)
-    - [Push (OCI Registry)](#push-oci-registry)
-  - [Templates](#templates)
-    - [Install (Templates)](#install-templates)
-    - [List (Templates)](#list-templates)
-    - [Uninstall (Templates)](#uninstall-templates)
-    - [Upgrade (Templates)](#upgrade-templates)
-  - [Up](#up)
-    - [Trigger Options](#trigger-options)
-      - [Redis Request Handler](#redis-request-handler)
-      - [HTTP Request Handler](#http-request-handler)
-  - [Watch](#watch)
-  - [CLI Stability Table](#cli-stability-table)
+- [spin add](#spin-add)
+- [spin build](#spin-build)
+- [spin cloud](#spin-cloud)
+- [spin deploy](#spin-deploy)
+- [spin cloud deploy](#spin-cloud-deploy)
+- [spin login](#spin-login)
+- [spin cloud login](#spin-cloud-login)
+- [spin cloud variables](#spin-cloud-variables)
+- [spin help](#spin-help)
+- [spin new](#spin-new)
+- [spin plugin](#spin-plugin)
+- [spin plugins](#spin-plugins)
+- [spin plugins install](#spin-plugins-install)
+- [spin plugins list](#spin-plugins-list)
+- [spin plugins uninstall](#spin-plugins-uninstall)
+- [spin plugins update](#spin-plugins-update)
+- [spin plugins upgrade](#spin-plugins-upgrade)
+- [spin oci](#spin-oci)
+- [spin registry](#spin-registry)
+- [spin registry login](#spin-registry-login)
+- [spin registry pull](#spin-registry-pull)
+- [spin registry push](#spin-registry-push)
+- [spin template](#spin-template)
+- [spin templates](#spin-templates)
+- [spin templates install](#spin-templates-install)
+- [spin templates list](#spin-templates-list)
+- [spin templates uninstall](#spin-templates-uninstall)
+- [spin templates upgrade](#spin-templates-upgrade)
+- [spin up](#spin-up)
+- [spin watch](#spin-watch)
+- [Stability Table](#stability-table)
 
-## Spin
+This page documents the Spin Command Line Interface (CLI).
 
-This page documents the Spin Command Line Interface (CLI). Specifically, all of the available Spin Options and Subcommands. For more information on command stability, see the [CLI stability table](#cli-stability-table). You can reproduce the Spin CLI documentation on your machine by using the `--help` flag. For example:
-
-{{ tabs "spin-version" }}
-
-{{ startTab "v1.0.0"}}
-
-<!-- @selectiveCpy -->
-
-```console
-$ spin --help
-
-USAGE:
-    spin <SUBCOMMAND>
-
-OPTIONS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-
-SUBCOMMANDS:
-    add          Scaffold a new component into an existing application
-    build        Build the Spin application
-    cloud        Commands for publishing applications to the Fermyon Platform
-    deploy       Package and upload an application to the Fermyon Platform
-    help         Print this message or the help of the given subcommand(s)
-    login        Log into the Fermyon Platform
-    new          Scaffold a new application based on a template
-    plugins      Install/uninstall Spin plugins
-    registry     Commands for working with OCI registries to distribute applications
-    templates    Commands for working with WebAssembly component templates
-    up           Start the Spin application
-```
-
-{{ blockEnd }}
-
-{{ startTab "v1.1.0"}}
-
-<!-- @selectiveCpy -->
-
-```console
-$ spin --help
-
-USAGE:
-    spin <SUBCOMMAND>
-
-OPTIONS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-
-SUBCOMMANDS:
-    add          Scaffold a new component into an existing application
-    build        Build the Spin application
-    cloud        Commands for publishing applications to the Fermyon Platform
-    deploy       Package and upload an application to the Fermyon Platform
-    help         Print this message or the help of the given subcommand(s)
-    login        Log into the Fermyon Platform
-    new          Scaffold a new application based on a template
-    plugins      Install/uninstall Spin plugins
-    registry     Commands for working with OCI registries to distribute applications
-    templates    Commands for working with WebAssembly component templates
-    up           Start the Spin application
-    watch        Rebuild and restart the Spin application when files changes
-```
-
-{{ blockEnd }}
-
-{{ startTab "v1.2.0"}}
-
-<!-- @selectiveCpy -->
-
-```console
-$ spin --help
-
-USAGE:
-    spin <SUBCOMMAND>
-
-OPTIONS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-
-SUBCOMMANDS:
-    add          Scaffold a new component into an existing application
-    build        Build the Spin application
-    cloud        Commands for publishing applications to the Fermyon Platform
-    deploy       Package and upload an application to the Fermyon Platform
-    help         Print this message or the help of the given subcommand(s)
-    login        Log into the Fermyon Platform
-    new          Scaffold a new application based on a template
-    plugins      Install/uninstall Spin plugins
-    registry     Commands for working with OCI registries to distribute applications
-    templates    Commands for working with WebAssembly component templates
-    up           Start the Spin application
-    watch        Build and run the Spin application, rebuilding and restarting it when files
-```
-
-{{ blockEnd }}
-
-{{ blockEnd }}
-
-### Add
+For information on command stability, see the [CLI stability table](#cli-stability-table).
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin add
 
 Adding a subcommand (and again issuing the `--help` command) will provide information specific to that particular subcommand. For example:
 
@@ -216,7 +120,43 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin add --help
+
+spin-add 
+Scaffold a new component into an existing application
+
+USAGE:
+    spin add [OPTIONS] [ARGS]
+
+ARGS:
+    <TEMPLATE_ID>    The template from which to create the new application or component. Run
+                     `spin templates list` to see available options
+    <NAME>           The name of the new application or component
+
+OPTIONS:
+    -a, --accept-defaults              An optional argument that allows to skip prompts for the
+                                       manifest file by accepting the defaults if available on the
+                                       template
+    -f, --file <APP_MANIFEST_FILE>     Path to spin.toml
+    -h, --help                         Print help information
+    -o, --output <OUTPUT_PATH>         The directory in which to create the new application or
+                                       component. The default is the name argument
+        --tag <TAGS>                   Filter templates to select by tags
+    -v, --value <VALUES>               Parameter values to be passed to the template (in name=value
+                                       format)
+        --values-file <VALUES_FILE>    A TOML file which contains parameter values in name = "value"
+                                       format. Parameters passed as CLI option overwrite parameters
+                                       specified in the file
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -254,7 +194,8 @@ OPTIONS:
 
 {{ blockEnd }}
 
-### Build
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin build
 
 {{ tabs "spin-version" }}
 
@@ -306,7 +247,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -332,9 +273,41 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.3.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin build --help
+
+spin-build 
+Build the Spin application
+
+USAGE:
+    spin build [OPTIONS] [UP_ARGS]...
+
+ARGS:
+    <UP_ARGS>...    
+
+OPTIONS:
+    -c, --component-id <COMPONENT_ID>...
+            Component ID to build. This can be specified multiple times. The default is all
+            components
+    -f, --from <APP_MANIFEST_FILE>
+            The application to build. This may be a manifest (spin.toml) file, or a directory
+            containing a spin.toml file. If omitted, it defaults to "spin.toml" [default: spin.toml]
+    -h, --help
+            Print help information
+    -u, --up
+            Run the application after building
+```
+
 {{ blockEnd }}
 
-### Cloud
+{{ blockEnd }}
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin cloud
 
 {{ tabs "spin-version" }}
 
@@ -386,7 +359,7 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -410,9 +383,21 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.3.0"}}
+
+The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-plugin-reference).
+
 {{ blockEnd }}
 
-#### Deploy (Cloud)
+{{ blockEnd }}
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin deploy
+
+`spin deploy` is a shotcurt to [`spin cloud deploy`](#cloud-deploy).
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin cloud deploy
 
 {{ tabs "spin-version" }}
 
@@ -510,7 +495,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -558,11 +543,23 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.3.0"}}
+
+The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-plugin-reference#spin-cloud-deploy).
+
 {{ blockEnd }}
 
-#### Login (Cloud)
+{{ blockEnd }}
 
-Please note: the previous `spin login` command (from versions before Spin v0.9.0) has been kept to ensure backward compatibility. In the Spin v0.9.0 release, both the `spin login --help` and `spin cloud login --help` commands will produce the same output, which is as follows:
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin login
+
+Please note: the previous `spin login` command (from versions before Spin v0.9.0) has been kept to ensure backward compatibility. In the Spin v0.9.0 release, both the `spin login --help` and [`spin cloud login --help`](#cloud-login) commands will produce the same output.
+
+`spin login` is a shotcurt to [`spin cloud login`](#cloud-login).
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin cloud login
 
 {{ tabs "spin-version" }}
 
@@ -682,7 +679,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -740,154 +737,29 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.3.0"}}
+
+The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-plugin-reference#spin-cloud-login).
+
 {{ blockEnd }}
 
-### Deploy
+{{ blockEnd }}
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin cloud variables
 
 {{ tabs "spin-version" }}
 
-{{ startTab "v1.0.0"}}
+{{ startTab "v1.3.0"}}
 
-<!-- @selectiveCpy -->
-```console
-$ spin deploy --help
-
-spin-deploy 
-Package and upload an application to the Fermyon Platform
-
-USAGE:
-    spin deploy [OPTIONS]
-
-OPTIONS:
-        --buildinfo <BUILDINFO>
-            Build metadata to append to the bindle version
-
-    -d, --staging-dir <STAGING_DIR>
-            Path to assemble the bindle before pushing (defaults to a temporary directory)
-
-    -e, --deploy-existing-bindle
-            Deploy existing bindle if it already exists on bindle server
-
-        --environment-name <environment-name>
-            Deploy to the Fermyon instance saved under the specified name. If omitted, Spin deploys
-            to the default unnamed instance [env: FERMYON_DEPLOYMENT_ENVIRONMENT=]
-
-    -f, --file <APP_MANIFEST_FILE>
-            Path to spin.toml [default: spin.toml]
-
-    -h, --help
-            Print help information
-
-        --key-value <KEY_VALUES>
-            Pass a key/value (key=value) to all components of the application. Can be used multiple
-            times
-
-        --no-buildinfo
-            Disable attaching buildinfo [env: SPIN_DEPLOY_NO_BUILDINFO=]
-
-        --readiness-timeout <READINESS_TIMEOUT_SECS>
-            How long in seconds to wait for a deployed HTTP application to become ready. The default
-            is 60 seconds. Set it to 0 to skip waiting for readiness [default: 60]
-```
-
-{{ blockEnd }}
-
-{{ startTab "v1.1.0"}}
-
-<!-- @selectiveCpy -->
-```console
-$ spin deploy --help
-
-spin-deploy 
-Package and upload an application to the Fermyon Platform
-
-USAGE:
-    spin deploy [OPTIONS]
-
-OPTIONS:
-        --buildinfo <BUILDINFO>
-            Build metadata to append to the bindle version
-
-    -d, --staging-dir <STAGING_DIR>
-            Path to assemble the bindle before pushing (defaults to a temporary directory)
-
-    -e, --deploy-existing-bindle
-            Deploy existing bindle if it already exists on bindle server
-
-        --environment-name <environment-name>
-            Deploy to the Fermyon instance saved under the specified name. If omitted, Spin deploys
-            to the default unnamed instance [env: FERMYON_DEPLOYMENT_ENVIRONMENT=]
-
-    -f, --file <APP_MANIFEST_FILE>
-            Path to spin.toml [default: spin.toml]
-
-    -h, --help
-            Print help information
-
-        --key-value <KEY_VALUES>
-            Pass a key/value (key=value) to all components of the application. Can be used multiple
-            times
-
-        --no-buildinfo
-            Disable attaching buildinfo [env: SPIN_DEPLOY_NO_BUILDINFO=]
-
-        --readiness-timeout <READINESS_TIMEOUT_SECS>
-            How long in seconds to wait for a deployed HTTP application to become ready. The default
-            is 60 seconds. Set it to 0 to skip waiting for readiness [default: 60]
-```
-
-{{ blockEnd }}
-
-{{ startTab "v1.2.0"}}
-
-<!-- @selectiveCpy -->
-```console
-$ spin deploy --help
-
-spin-deploy 
-Package and upload an application to the Fermyon Platform
-
-USAGE:
-    spin deploy [OPTIONS]
-
-OPTIONS:
-        --buildinfo <BUILDINFO>
-            Build metadata to append to the bindle version
-
-    -d, --staging-dir <STAGING_DIR>
-            Path to assemble the bindle before pushing (defaults to a temporary directory)
-
-    -e, --deploy-existing-bindle
-            Deploy existing bindle if it already exists on bindle server
-
-        --environment-name <environment-name>
-            Deploy to the Fermyon instance saved under the specified name. If omitted, Spin deploys
-            to the default unnamed instance [env: FERMYON_DEPLOYMENT_ENVIRONMENT=]
-
-    -f, --from <APP_MANIFEST_FILE>
-            The application to deploy. This may be a manifest (spin.toml) file, or a directory
-            containing a spin.toml file. If omitted, it defaults to "spin.toml" [default: spin.toml]
-
-    -h, --help
-            Print help information
-
-        --key-value <KEY_VALUES>
-            Set a key/value pair (key=value) in the deployed application's default store. Any
-            existing value will be overwritten. Can be used multiple times
-
-        --no-buildinfo
-            Disable attaching buildinfo [env: SPIN_DEPLOY_NO_BUILDINFO=]
-
-        --readiness-timeout <READINESS_TIMEOUT_SECS>
-            How long in seconds to wait for a deployed HTTP application to become ready. The default
-            is 60 seconds. Set it to 0 to skip waiting for readiness [default: 60]
-```
+The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-plugin-reference#spin-cloud-variables).
 
 {{ blockEnd }}
 
 {{ blockEnd }}
 
-### Help
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin help
 
 {{ tabs "spin-version" }}
 
@@ -955,14 +827,14 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
 
 <!-- @selectiveCpy -->
 
 ```console
 $ spin help      
 
-spin 1.2.0 
+spin 1.2.0/1.2.1 
 The Spin CLI
 
 USAGE:
@@ -990,191 +862,48 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.3.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin help
+
+spin 1.3.0 (9fb8256 2023-06-12)
+The Spin CLI
+
+USAGE:
+    spin <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+SUBCOMMANDS:
+    add          Scaffold a new component into an existing application
+    build        Build the Spin application
+    cloud        Commands for publishing applications to the Fermyon Cloud.
+    deploy       Package and upload an application to the Fermyon Cloud.
+    help         Print this message or the help of the given subcommand(s)
+    login        Log into the Fermyon Cloud.
+    new          Scaffold a new application based on a template
+    plugins      Install/uninstall Spin plugins
+    registry     Commands for working with OCI registries to distribute applications
+    templates    Commands for working with WebAssembly component templates
+    up           Start the Spin application
+    watch        Build and run the Spin application, rebuilding and restarting it when files
+                     change
+
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 > Please note: Spin `help` is a convenient way to access help using a subcommand, instead of using the `--help` option. For example, `spin help cloud` will give you the same output as `spin cloud --help`. Similarly, `spin help build` will give you the same output as `spin build --help` and so forth.
 
-### Login
-
-{{ tabs "spin-version" }}
-
-{{ startTab "v1.0.0"}}
-
-<!-- @selectiveCpy -->
-
-```console
-$ spin login --help
-
-spin-login 
-Log into the Fermyon Platform
-
-USAGE:
-    spin login [OPTIONS]
-
-OPTIONS:
-        --auth-method <auth-method>
-            [env: AUTH_METHOD=] [possible values: github, username, token]
-
-        --bindle-password <BINDLE_PASSWORD>
-            Basic http auth password for the bindle server [env: BINDLE_PASSWORD=]
-
-        --bindle-server <BINDLE_SERVER_URL>
-            URL of bindle server [env: BINDLE_URL=]
-
-        --bindle-username <BINDLE_USERNAME>
-            Basic http auth username for the bindle server [env: BINDLE_USERNAME=]
-
-        --environment-name <environment-name>
-            Save the login details under the specified name instead of making them the default. Use
-            named environments with `spin deploy --environment-name <name>` [env:
-            FERMYON_DEPLOYMENT_ENVIRONMENT=]
-
-    -h, --help
-            Print help information
-
-    -k, --insecure
-            Ignore server certificate errors from bindle and hippo
-
-        --list
-            List saved logins
-
-        --password <HIPPO_PASSWORD>
-            Hippo password [env: HIPPO_PASSWORD=]
-
-        --status
-            Display login status
-
-        --token <TOKEN>
-            Auth Token [env: SPIN_AUTH_TOKEN=]
-
-        --url <HIPPO_SERVER_URL>
-            URL of hippo server [env: HIPPO_URL=] [default: https://cloud.fermyon.com/]
-
-        --username <HIPPO_USERNAME>
-            Hippo username [env: HIPPO_USERNAME=]
-```
-
-{{ blockEnd }}
-
-{{ startTab "v1.1.0"}}
-
-<!-- @selectiveCpy -->
-
-```console
-$ spin login --help
-
-spin-login 
-Log into the Fermyon Platform
-
-USAGE:
-    spin login [OPTIONS]
-
-OPTIONS:
-        --auth-method <auth-method>
-            [env: AUTH_METHOD=] [possible values: github, username, token]
-
-        --bindle-password <BINDLE_PASSWORD>
-            Basic http auth password for the bindle server [env: BINDLE_PASSWORD=]
-
-        --bindle-server <BINDLE_SERVER_URL>
-            URL of bindle server [env: BINDLE_URL=]
-
-        --bindle-username <BINDLE_USERNAME>
-            Basic http auth username for the bindle server [env: BINDLE_USERNAME=]
-
-        --environment-name <environment-name>
-            Save the login details under the specified name instead of making them the default. Use
-            named environments with `spin deploy --environment-name <name>` [env:
-            FERMYON_DEPLOYMENT_ENVIRONMENT=]
-
-    -h, --help
-            Print help information
-
-    -k, --insecure
-            Ignore server certificate errors from bindle and hippo
-
-        --list
-            List saved logins
-
-        --password <HIPPO_PASSWORD>
-            Hippo password [env: HIPPO_PASSWORD=]
-
-        --status
-            Display login status
-
-        --token <TOKEN>
-            Auth Token [env: SPIN_AUTH_TOKEN=]
-
-        --url <HIPPO_SERVER_URL>
-            URL of hippo server [env: HIPPO_URL=] [default: https://cloud.fermyon.com/]
-
-        --username <HIPPO_USERNAME>
-            Hippo username [env: HIPPO_USERNAME=]
-```
-
-{{ blockEnd }}
-
-{{ startTab "v1.2.0"}}
-
-<!-- @selectiveCpy -->
-
-```console
-$ spin login --help
-
-spin-login 
-Log into the Fermyon Platform
-
-USAGE:
-    spin login [OPTIONS]
-
-OPTIONS:
-        --auth-method <auth-method>
-            [env: AUTH_METHOD=] [possible values: github, username, token]
-
-        --bindle-password <BINDLE_PASSWORD>
-            Basic http auth password for the bindle server [env: BINDLE_PASSWORD=]
-
-        --bindle-server <BINDLE_SERVER_URL>
-            URL of bindle server [env: BINDLE_URL=]
-
-        --bindle-username <BINDLE_USERNAME>
-            Basic http auth username for the bindle server [env: BINDLE_USERNAME=]
-
-        --environment-name <environment-name>
-            Save the login details under the specified name instead of making them the default. Use
-            named environments with `spin deploy --environment-name <name>` [env:
-            FERMYON_DEPLOYMENT_ENVIRONMENT=]
-
-    -h, --help
-            Print help information
-
-    -k, --insecure
-            Ignore server certificate errors from bindle and hippo
-
-        --list
-            List saved logins
-
-        --password <HIPPO_PASSWORD>
-            Hippo password [env: HIPPO_PASSWORD=]
-
-        --status
-            Display login status
-
-        --token <TOKEN>
-            Auth Token [env: SPIN_AUTH_TOKEN=]
-
-        --url <HIPPO_SERVER_URL>
-            URL of hippo server [env: HIPPO_URL=] [default: https://cloud.fermyon.com/]
-
-        --username <HIPPO_USERNAME>
-            Hippo username [env: HIPPO_USERNAME=]
-```
-
-{{ blockEnd }}
-
-{{ blockEnd }}
-
-### New
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin new
 
 {{ tabs "spin-version" }}
 
@@ -1248,7 +977,42 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin new --help  
+
+spin-new 
+Scaffold a new application based on a template
+
+USAGE:
+    spin new [OPTIONS] [ARGS]
+
+ARGS:
+    <TEMPLATE_ID>    The template from which to create the new application or component. Run
+                     `spin templates list` to see available options
+    <NAME>           The name of the new application or component
+
+OPTIONS:
+    -a, --accept-defaults              An optional argument that allows to skip prompts for the
+                                       manifest file by accepting the defaults if available on the
+                                       template
+    -h, --help                         Print help information
+    -o, --output <OUTPUT_PATH>         The directory in which to create the new application or
+                                       component. The default is the name argument
+        --tag <TAGS>                   Filter templates to select by tags
+    -v, --value <VALUES>               Parameter values to be passed to the template (in name=value
+                                       format)
+        --values-file <VALUES_FILE>    A TOML file which contains parameter values in name = "value"
+                                       format. Parameters passed as CLI option overwrite parameters
+                                       specified in the file
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -1290,7 +1054,13 @@ OPTIONS:
 * `spin new` creates a _new_ application - that is, a new directory with a new `spin.toml` file.
 * `spin add` _adds_ a component to an _existing_ application - that is, it modifies an existing `spin.toml` file.
 
-### Plugins
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin plugin
+
+`spin plugin` is an alias for [`spin plugins`](#plugins)
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin plugins
 
 {{ tabs "spin-version" }}
 
@@ -1348,7 +1118,34 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins --help
+
+spin-plugins 
+Install/uninstall Spin plugins
+
+USAGE:
+    spin plugins <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    help         Print this message or the help of the given subcommand(s)
+    install      Install plugin from a manifest
+    list         List available or installed plugins
+    uninstall    Remove a plugin from your installation
+    update       Fetch the latest Spin plugins from the spin-plugins repository
+    upgrade      Upgrade one or all plugins
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -1377,7 +1174,8 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
-#### Install (Plugins)
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin plugins install
 
 {{ tabs "spin-version" }}
 
@@ -1463,7 +1261,48 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins install --help
+
+spin-plugins-install 
+Install plugin from a manifest.
+
+The binary file and manifest of the plugin is copied to the local Spin plugins directory.
+
+USAGE:
+    spin plugins install [OPTIONS] [PLUGIN_NAME]
+
+ARGS:
+    <PLUGIN_NAME>
+            Name of Spin plugin
+
+OPTIONS:
+    -f, --file <LOCAL_PLUGIN_MANIFEST>
+            Path to local plugin manifest
+
+    -h, --help
+            Print help information
+
+        --override-compatibility-check
+            Overrides a failed compatibility check of the plugin with the current version of Spin
+
+    -u, --url <REMOTE_PLUGIN_MANIFEST>
+            URL of remote plugin manifest to install
+
+    -v, --version <VERSION>
+            Specific version of a plugin to be install from the centralized plugins repository
+
+    -y, --yes
+            Skips prompt to accept the installation of the plugin
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -1506,7 +1345,8 @@ OPTIONS:
 
 {{ blockEnd }}
 
-#### List (Plugins)
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin plugins list
 
 {{ tabs "spin-version" }}
 
@@ -1550,7 +1390,27 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins list --help   
+
+spin-plugins-list 
+List available or installed plugins
+
+USAGE:
+    spin plugins list [OPTIONS]
+
+OPTIONS:
+    -h, --help         Print help information
+        --installed    List only installed plugins
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -1572,7 +1432,8 @@ OPTIONS:
 
 {{ blockEnd }}
 
-#### Uninstall (Plugins)
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin plugins uninstall
 
 {{ tabs "spin-version" }}
 
@@ -1620,7 +1481,29 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins uninstall --help
+
+spin-plugins-uninstall 
+Remove a plugin from your installation
+
+USAGE:
+    spin plugins uninstall <NAME>
+
+ARGS:
+    <NAME>    Name of Spin plugin
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -1644,7 +1527,8 @@ OPTIONS:
 
 {{ blockEnd }}
 
-#### Update (Plugins)
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin plugins update
 
 {{ tabs "spin-version" }}
 
@@ -1686,7 +1570,26 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins update --help   
+
+spin-plugins-update 
+Fetch the latest Spin plugins from the spin-plugins repository
+
+USAGE:
+    spin plugins update
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -1707,7 +1610,8 @@ OPTIONS:
 
 {{ blockEnd }}
 
-#### Upgrade (Plugins)
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin plugins upgrade
 
 {{ tabs "spin-version" }}
 
@@ -1799,7 +1703,51 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins upgrade --help
+
+spin-plugins-upgrade 
+Upgrade one or all plugins
+
+USAGE:
+    spin plugins upgrade [OPTIONS] [PLUGIN_NAME]
+
+ARGS:
+    <PLUGIN_NAME>    Name of Spin plugin to upgrade
+
+OPTIONS:
+    -a, --all
+            Upgrade all plugins
+
+    -d, --downgrade
+            Allow downgrading a plugin's version
+
+    -f, --file <LOCAL_PLUGIN_MANIFEST>
+            Path to local plugin manifest
+
+    -h, --help
+            Print help information
+
+        --override-compatibility-check
+            Overrides a failed compatibility check of the plugin with the current version of Spin
+
+    -u, --url <REMOTE_PLUGIN_MANIFEST>
+            Path to remote plugin manifest
+
+    -v, --version <VERSION>
+            Specific version of a plugin to be install from the centralized plugins repository
+
+    -y, --yes
+            Skips prompt to accept the installation of the plugin[s]
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -1847,7 +1795,13 @@ OPTIONS:
 
 **Note:** For additional information, please see the [Managing Plugins](/spin/managing-plugins) and/or [Creating Plugins](/spin/plugin-authoring) sections of the documentation.
 
-### OCI Registry
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin oci
+
+`spin oci` is an alias for  [`spin registry`](#registry)
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin registry
 
 {{ tabs "spin-version" }}
 
@@ -1903,7 +1857,32 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry --help
+
+spin-registry 
+Commands for working with OCI registries to distribute applications
+
+USAGE:
+    spin registry <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    help     Print this message or the help of the given subcommand(s)
+    login    Log in to a registry
+    pull     Pull a Spin application from a registry
+    push     Push a Spin application to a registry
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -1930,7 +1909,8 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
-#### Login (OCI Registry)
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin registry login
 
 {{ tabs "spin-version" }}
 
@@ -1984,7 +1964,32 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry login --help
+
+spin-registry-login 
+Log in to a registry
+
+USAGE:
+    spin registry login [OPTIONS] <SERVER>
+
+ARGS:
+    <SERVER>    
+
+OPTIONS:
+    -h, --help                   Print help information
+    -p, --password <PASSWORD>    Password for the registry
+        --password-stdin         Take the password from stdin
+    -u, --username <USERNAME>    Username for the registry
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -2011,7 +2016,8 @@ OPTIONS:
 
 {{ blockEnd }}
 
-#### Pull (OCI Registry)
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin registry pull
 
 {{ tabs "spin-version" }}
 
@@ -2061,7 +2067,30 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry pull --help
+
+spin-registry-pull 
+Pull a Spin application from a registry
+
+USAGE:
+    spin registry pull [OPTIONS] <REFERENCE>
+
+ARGS:
+    <REFERENCE>    Reference of the Spin application
+
+OPTIONS:
+    -h, --help        Print help information
+    -k, --insecure    Ignore server certificate errors
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -2086,7 +2115,8 @@ OPTIONS:
 
 {{ blockEnd }}
 
-#### Push (OCI Registry)
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin registry push
 
 {{ tabs "spin-version" }}
 
@@ -2138,7 +2168,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -2166,7 +2196,13 @@ OPTIONS:
 
 {{ blockEnd }}
 
-### Templates
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin template
+
+`spin template` is an alias for [`spin templates'](#templates)
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin templates
 
 {{ tabs "spin-version" }}
 
@@ -2222,7 +2258,33 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates --help    
+
+spin-templates 
+Commands for working with WebAssembly component templates
+
+USAGE:
+    spin templates <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    help         Print this message or the help of the given subcommand(s)
+    install      Install templates from a Git repository or local directory
+    list         List the installed templates
+    uninstall    Remove a template from your installation
+    upgrade      Upgrade templates to match your current version of Spin
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -2249,8 +2311,9 @@ SUBCOMMANDS:
 {{ blockEnd }}
 
 {{ blockEnd }}
-    
-#### Install (Templates)
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin templates install
 
 {{ tabs "spin-version" }}
 
@@ -2326,7 +2389,43 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates install --help
+
+spin-templates-install 
+Install templates from a Git repository or local directory.
+
+The files of the templates are copied to the local template store: a directory in your data or home
+directory.
+
+USAGE:
+    spin templates install [OPTIONS]
+
+OPTIONS:
+        --branch <BRANCH>
+            The optional branch of the git repository
+
+        --dir <FROM_DIR>
+            Local directory containing the template(s) to install
+
+        --git <FROM_GIT>
+            The URL of the templates git repository. The templates must be in a git repository in a
+            "templates" directory
+
+    -h, --help
+            Print help information
+
+        --upgrade
+            If present, updates existing templates instead of skipping
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -2364,7 +2463,8 @@ OPTIONS:
 
 {{ blockEnd }}
 
-#### List (Templates)
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin templates list
 
 {{ tabs "spin-version" }}
 
@@ -2410,7 +2510,28 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates list --help   
+
+spin-templates-list 
+List the installed templates
+
+USAGE:
+    spin templates list [OPTIONS]
+
+OPTIONS:
+    -h, --help          Print help information
+        --tag <TAGS>    Filter templates matching all provided tags
+        --verbose       Whether to show additional template details in the list
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -2433,7 +2554,8 @@ OPTIONS:
 
 {{ blockEnd }}
 
-#### Uninstall (Templates)
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin templates uninstall
 
 <!-- @selectiveCpy -->
 
@@ -2483,7 +2605,29 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates uninstall --help
+
+spin-templates-uninstall 
+Remove a template from your installation
+
+USAGE:
+    spin templates uninstall <TEMPLATE_ID>
+
+ARGS:
+    <TEMPLATE_ID>    The template to uninstall
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -2507,7 +2651,8 @@ OPTIONS:
 
 {{ blockEnd }}
 
-#### Upgrade (Templates)
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin templates upgrade
 
 {{ tabs "spin-version" }}
 
@@ -2581,7 +2726,42 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates upgrade --help  
+
+spin-templates-upgrade 
+Upgrade templates to match your current version of Spin.
+
+The files of the templates are copied to the local template store: a directory in your data or home
+directory.
+
+USAGE:
+    spin templates upgrade [OPTIONS]
+
+OPTIONS:
+        --all
+            By default, Spin displays the list of installed repositories and prompts you to choose
+            which to upgrade.  Pass this flag to upgrade all repositories without prompting
+
+        --branch <BRANCH>
+            The optional branch of the git repository, if a specific repository is given
+
+    -h, --help
+            Print help information
+
+        --repo <GIT_URL>
+            By default, Spin displays the list of installed repositories and prompts you to choose
+            which to upgrade.  Pass this flag to upgrade only the specified repository without
+            prompting
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -2620,9 +2800,12 @@ OPTIONS:
 
 **Note:** For additional information, please see the [Managing Templates](/spin/managing-templates) and/or [Creating Templates](/spin/template-authoring) sections of the documentation.
 
-### Up
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin up
 
-The following options are available in relation to running your Spin application. Additionally, depending on the type of trigger that your application uses (i.e. HTTP or Redis trigger), there are trigger-specific options available. Details of the trigger options can be found in the next section (below).
+The following options are available in relation to running your Spin application.
+
+Note: There are three trigger options which only applies to the HTTP trigger (`--listen`, `--tls-cert` and `--tls-key`).
 
 {{ tabs "spin-version" }}
 
@@ -2670,6 +2853,12 @@ TRIGGER OPTIONS:
     -L, --log-dir <APP_LOG_DIR>
             Log directory for the stdout and stderr of components
 
+        --listen <ADDRESS>
+            IP address and port to listen on
+            
+            [default: 127.0.0.1:3000]
+            Only appplies to HTTP triggers            
+
     -q, --quiet
             Silence all component output to stdout/stderr
 
@@ -2678,6 +2867,19 @@ TRIGGER OPTIONS:
             
             [env: RUNTIME_CONFIG_FILE=]
 
+        --tls-cert <TLS_CERT>
+            The path to the certificate to use for https, if this is not set, normal http will be
+            used. The cert should be in PEM format
+            
+            [env: SPIN_TLS_CERT=]
+            Only appplies to HTTP triggers
+
+        --tls-key <TLS_KEY>
+            The path to the certificate key to use for https, if this is not set, normal http will
+            be used. The key should be in PKCS#8 format
+            
+            [env: SPIN_TLS_KEY=]
+            Only appplies to HTTP triggers
 ```
 
 {{ blockEnd }}
@@ -2726,6 +2928,12 @@ TRIGGER OPTIONS:
     -L, --log-dir <APP_LOG_DIR>
             Log directory for the stdout and stderr of components
 
+        --listen <ADDRESS>
+            IP address and port to listen on
+            
+            [default: 127.0.0.1:3000]
+            Only appplies to HTTP triggers
+
     -q, --quiet
             Silence all component output to stdout/stderr
 
@@ -2734,11 +2942,24 @@ TRIGGER OPTIONS:
             
             [env: RUNTIME_CONFIG_FILE=]
 
+        --tls-cert <TLS_CERT>
+            The path to the certificate to use for https, if this is not set, normal http will be
+            used. The cert should be in PEM format
+            
+            [env: SPIN_TLS_CERT=]
+            Only appplies to HTTP triggers
+
+        --tls-key <TLS_KEY>
+            The path to the certificate key to use for https, if this is not set, normal http will
+            be used. The key should be in PKCS#8 format
+            
+            [env: SPIN_TLS_KEY=]
+            Only appplies to HTTP triggers
 ```
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
 
 <!-- @selectiveCpy -->
 
@@ -2787,6 +3008,12 @@ TRIGGER OPTIONS:
     -L, --log-dir <APP_LOG_DIR>
             Log directory for the stdout and stderr of components
 
+        --listen <ADDRESS>
+            IP address and port to listen on
+            
+            [default: 127.0.0.1:3000]
+            Only appplies to HTTP triggers
+
     -q, --quiet
             Silence all component output to stdout/stderr
 
@@ -2801,6 +3028,107 @@ TRIGGER OPTIONS:
             
             For local apps, this defaults to `.spin/` relative to the `spin.toml` file. For remote
             apps, this has no default (unset). Passing an empty value forces the value to be unset.
+        
+        --tls-cert <TLS_CERT>
+            The path to the certificate to use for https, if this is not set, normal http will be
+            used. The cert should be in PEM format
+            
+            [env: SPIN_TLS_CERT=]
+            Only appplies to HTTP triggers
+
+        --tls-key <TLS_KEY>
+            The path to the certificate key to use for https, if this is not set, normal http will
+            be used. The key should be in PKCS#8 format
+            
+            [env: SPIN_TLS_KEY=]
+            Only appplies to HTTP triggers
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin up --help
+
+spin-up 
+Start the Spin application
+
+USAGE:
+    spin up [OPTIONS]
+
+OPTIONS:
+        --direct-mounts         For local apps with directory mounts and no excluded files, mount
+                                them directly instead of using a temporary directory
+    -e, --env <ENV>             Pass an environment variable (key=value) to all components of the
+                                application
+    -f, --from <APPLICATION>    The application to run. This may be a manifest (spin.toml) file, a
+                                directory containing a spin.toml file, or a remote registry
+                                reference. If omitted, it defaults to "spin.toml"
+    -h, --help                  
+    -k, --insecure              Ignore server certificate errors from bindle server or registry
+        --temp <TMP>            Temporary directory for the static assets of the components
+
+TRIGGER OPTIONS:
+        --allow-transient-write
+            Set the static assets of the components in the temporary directory as writable
+
+        --cache <WASMTIME_CACHE_FILE>
+            Wasmtime cache configuration file
+            
+            [env: WASMTIME_CACHE_FILE=]
+
+        --disable-cache
+            Disable Wasmtime cache
+            
+            [env: DISABLE_WASMTIME_CACHE=]
+
+        --follow <FOLLOW_ID>
+            Print output to stdout/stderr only for given component(s)
+
+        --key-value <KEY_VALUES>
+            Set a key/value pair (key=value) in the application's default store. Any existing value
+            will be overwritten. Can be used multiple times
+
+    -L, --log-dir <APP_LOG_DIR>
+            Log directory for the stdout and stderr of components
+
+        --listen <ADDRESS>
+            IP address and port to listen on
+            
+            [default: 127.0.0.1:3000]
+            Only appplies to HTTP triggers
+
+    -q, --quiet
+            Silence all component output to stdout/stderr
+
+        --runtime-config-file <RUNTIME_CONFIG_FILE>
+            Configuration file for config providers and wasmtime config
+            
+            [env: RUNTIME_CONFIG_FILE=]
+
+        --state-dir <STATE_DIR>
+            Set the application state directory path. This is used in the default locations for
+            logs, key value stores, etc.
+            
+            For local apps, this defaults to `.spin/` relative to the `spin.toml` file. For remote
+            apps, this has no default (unset). Passing an empty value forces the value to be unset.
+
+        --tls-cert <TLS_CERT>
+            The path to the certificate to use for https, if this is not set, normal http will be
+            used. The cert should be in PEM format
+            
+            [env: SPIN_TLS_CERT=]
+            Only appplies to HTTP triggers
+
+        --tls-key <TLS_KEY>
+            The path to the certificate key to use for https, if this is not set, normal http will
+            be used. The key should be in PKCS#8 format
+            
+            [env: SPIN_TLS_KEY=]
+            Only appplies to HTTP triggers
 
 ```
 
@@ -2810,450 +3138,8 @@ TRIGGER OPTIONS:
 
 > **Please note:** If the `-f` or `--from` options do not accurately infer the intended registry or `.toml` file for your application, then you can explicitly specify either the `--from-registry` or  `--from-file` options to clarify this.
 
-#### Trigger Options
-
-##### Redis Request Handler
-
-Below, please see the available trigger options for the Redis request handler.
-
-{{ tabs "spin-version" }}
-
-{{ startTab "v1.0.0"}}
-
-<!-- @selectiveCpy -->
-
-```console
-$ spin up --help
-
-spin-up 
-Start the Spin application
-
-OPTIONS:
-        --direct-mounts         For local apps with directory mounts and no excluded files, mount
-                                them directly instead of using a temporary directory
-    -e, --env <ENV>             Pass an environment variable (key=value) to all components of the
-                                application
-    -f, --from <APPLICATION>    The application to run. This may be a manifest (spin.toml) file, a
-                                directory containing a spin.toml file, or a remote registry
-                                reference. If omitted, it defaults to "spin.toml"
-    -h, --help                  
-    -k, --insecure              Ignore server certificate errors from bindle server or registry
-        --temp <TMP>            Temporary directory for the static assets of the components
-
-TRIGGER OPTIONS:
-        --allow-transient-write
-            Set the static assets of the components in the temporary directory as writable
-
-        --cache <WASMTIME_CACHE_FILE>
-            Wasmtime cache configuration file
-            
-            [env: WASMTIME_CACHE_FILE=]
-
-        --disable-cache
-            Disable Wasmtime cache
-            
-            [env: DISABLE_WASMTIME_CACHE=]
-
-        --follow <FOLLOW_ID>
-            Print output to stdout/stderr only for given component(s)
-
-    -L, --log-dir <APP_LOG_DIR>
-            Log directory for the stdout and stderr of components
-
-    -q, --quiet
-            Silence all component output to stdout/stderr
-
-        --runtime-config-file <RUNTIME_CONFIG_FILE>
-            Configuration file for config providers and wasmtime config
-            
-            [env: RUNTIME_CONFIG_FILE=]
-
-        --state-dir <STATE_DIR>
-            Set the application state directory path. This is used in the default locations for
-            logs, key value stores, etc.
-            
-            For local apps, this defaults to `.spin/` relative to the `spin.toml` file. For remote
-            apps, this has no default (unset). Passing an empty value forces the value to be unset.
-```
-
-{{ blockEnd }}
-
-{{ startTab "v1.1.0"}}
-
-<!-- @selectiveCpy -->
-
-```console
-$ spin up --help
-
-spin-up 
-Start the Spin application
-
-OPTIONS:
-        --direct-mounts         For local apps with directory mounts and no excluded files, mount
-                                them directly instead of using a temporary directory
-    -e, --env <ENV>             Pass an environment variable (key=value) to all components of the
-                                application
-    -f, --from <APPLICATION>    The application to run. This may be a manifest (spin.toml) file, a
-                                directory containing a spin.toml file, or a remote registry
-                                reference. If omitted, it defaults to "spin.toml"
-    -h, --help                  
-    -k, --insecure              Ignore server certificate errors from bindle server or registry
-        --temp <TMP>            Temporary directory for the static assets of the components
-
-TRIGGER OPTIONS:
-        --allow-transient-write
-            Set the static assets of the components in the temporary directory as writable
-
-        --cache <WASMTIME_CACHE_FILE>
-            Wasmtime cache configuration file
-            
-            [env: WASMTIME_CACHE_FILE=]
-
-        --disable-cache
-            Disable Wasmtime cache
-            
-            [env: DISABLE_WASMTIME_CACHE=]
-
-        --follow <FOLLOW_ID>
-            Print output to stdout/stderr only for given component(s)
-
-    -L, --log-dir <APP_LOG_DIR>
-            Log directory for the stdout and stderr of components
-
-    -q, --quiet
-            Silence all component output to stdout/stderr
-
-        --runtime-config-file <RUNTIME_CONFIG_FILE>
-            Configuration file for config providers and wasmtime config
-            
-            [env: RUNTIME_CONFIG_FILE=]
-
-        --state-dir <STATE_DIR>
-            Set the application state directory path. This is used in the default locations for
-            logs, key value stores, etc.
-            
-            For local apps, this defaults to `.spin/` relative to the `spin.toml` file. For remote
-            apps, this has no default (unset). Passing an empty value forces the value to be unset.
-```
-
-{{ blockEnd }}
-
-{{ startTab "v1.2.0"}}
-
-<!-- @selectiveCpy -->
-
-```console
-$ spin up --help
-
-spin-up 
-Start the Spin application
-
-USAGE:
-    spin up [OPTIONS]
-
-OPTIONS:
-        --direct-mounts         For local apps with directory mounts and no excluded files, mount
-                                them directly instead of using a temporary directory
-    -e, --env <ENV>             Pass an environment variable (key=value) to all components of the
-                                application
-    -f, --from <APPLICATION>    The application to run. This may be a manifest (spin.toml) file, a
-                                directory containing a spin.toml file, or a remote registry
-                                reference. If omitted, it defaults to "spin.toml"
-    -h, --help                  
-    -k, --insecure              Ignore server certificate errors from bindle server or registry
-        --temp <TMP>            Temporary directory for the static assets of the components
-
-TRIGGER OPTIONS:
-        --allow-transient-write
-            Set the static assets of the components in the temporary directory as writable
-
-        --cache <WASMTIME_CACHE_FILE>
-            Wasmtime cache configuration file
-            
-            [env: WASMTIME_CACHE_FILE=]
-
-        --disable-cache
-            Disable Wasmtime cache
-            
-            [env: DISABLE_WASMTIME_CACHE=]
-
-        --follow <FOLLOW_ID>
-            Print output to stdout/stderr only for given component(s)
-
-        --key-value <KEY_VALUES>
-            Set a key/value pair (key=value) in the application's default store. Any existing value
-            will be overwritten. Can be used multiple times
-
-    -L, --log-dir <APP_LOG_DIR>
-            Log directory for the stdout and stderr of components
-
-    -q, --quiet
-            Silence all component output to stdout/stderr
-
-        --runtime-config-file <RUNTIME_CONFIG_FILE>
-            Configuration file for config providers and wasmtime config
-            
-            [env: RUNTIME_CONFIG_FILE=]
-
-        --state-dir <STATE_DIR>
-            Set the application state directory path. This is used in the default locations for
-            logs, key value stores, etc.
-            
-            For local apps, this defaults to `.spin/` relative to the `spin.toml` file. For remote
-            apps, this has no default (unset). Passing an empty value forces the value to be unset.
-```
-
-{{ blockEnd }}
-
-{{ blockEnd }}
-
-##### HTTP Request Handler
-
-Below, please see the available trigger options for the HTTP request handler. Note the additional three trigger options that the HTTP request handler offers (`--listen`, `--tls-cert` and `--tls-key`).
-
-{{ tabs "spin-version" }}
-
-{{ startTab "v1.0.0"}}
-
-<!-- @selectiveCpy -->
-
-```console
-$ spin up --help
-
-spin-up 
-Start the Spin application
-
-OPTIONS:
-        --direct-mounts         For local apps with directory mounts and no excluded files, mount
-                                them directly instead of using a temporary directory
-    -e, --env <ENV>             Pass an environment variable (key=value) to all components of the
-                                application
-    -f, --from <APPLICATION>    The application to run. This may be a manifest (spin.toml) file, a
-                                directory containing a spin.toml file, or a remote registry
-                                reference. If omitted, it defaults to "spin.toml"
-    -h, --help                  
-    -k, --insecure              Ignore server certificate errors from bindle server or registry
-        --temp <TMP>            Temporary directory for the static assets of the components
-
-TRIGGER OPTIONS:
-        --allow-transient-write
-            Set the static assets of the components in the temporary directory as writable
-
-        --cache <WASMTIME_CACHE_FILE>
-            Wasmtime cache configuration file
-            
-            [env: WASMTIME_CACHE_FILE=]
-
-        --disable-cache
-            Disable Wasmtime cache
-            
-            [env: DISABLE_WASMTIME_CACHE=]
-
-        --follow <FOLLOW_ID>
-            Print output to stdout/stderr only for given component(s)
-
-    -L, --log-dir <APP_LOG_DIR>
-            Log directory for the stdout and stderr of components
-
-        --listen <ADDRESS>
-            IP address and port to listen on
-            
-            [default: 127.0.0.1:3000]
-
-    -q, --quiet
-            Silence all component output to stdout/stderr
-
-        --runtime-config-file <RUNTIME_CONFIG_FILE>
-            Configuration file for config providers and wasmtime config
-            
-            [env: RUNTIME_CONFIG_FILE=]
-
-        --state-dir <STATE_DIR>
-            Set the application state directory path. This is used in the default locations for
-            logs, key value stores, etc.
-            
-            For local apps, this defaults to `.spin/` relative to the `spin.toml` file. For remote
-            apps, this has no default (unset). Passing an empty value forces the value to be unset.
-
-        --tls-cert <TLS_CERT>
-            The path to the certificate to use for https, if this is not set, normal http will be
-            used. The cert should be in PEM format
-            
-            [env: SPIN_TLS_CERT=]
-
-        --tls-key <TLS_KEY>
-            The path to the certificate key to use for https, if this is not set, normal http will
-            be used. The key should be in PKCS#8 format
-            
-            [env: SPIN_TLS_KEY=]
-```
-
-{{ blockEnd }}
-
-{{ startTab "v1.1.0"}}
-
-<!-- @selectiveCpy -->
-
-```console
-$ spin up --help
-
-spin-up 
-Start the Spin application
-
-OPTIONS:
-        --direct-mounts         For local apps with directory mounts and no excluded files, mount
-                                them directly instead of using a temporary directory
-    -e, --env <ENV>             Pass an environment variable (key=value) to all components of the
-                                application
-    -f, --from <APPLICATION>    The application to run. This may be a manifest (spin.toml) file, a
-                                directory containing a spin.toml file, or a remote registry
-                                reference. If omitted, it defaults to "spin.toml"
-    -h, --help                  
-    -k, --insecure              Ignore server certificate errors from bindle server or registry
-        --temp <TMP>            Temporary directory for the static assets of the components
-
-TRIGGER OPTIONS:
-        --allow-transient-write
-            Set the static assets of the components in the temporary directory as writable
-
-        --cache <WASMTIME_CACHE_FILE>
-            Wasmtime cache configuration file
-            
-            [env: WASMTIME_CACHE_FILE=]
-
-        --disable-cache
-            Disable Wasmtime cache
-            
-            [env: DISABLE_WASMTIME_CACHE=]
-
-        --follow <FOLLOW_ID>
-            Print output to stdout/stderr only for given component(s)
-
-    -L, --log-dir <APP_LOG_DIR>
-            Log directory for the stdout and stderr of components
-
-        --listen <ADDRESS>
-            IP address and port to listen on
-            
-            [default: 127.0.0.1:3000]
-
-    -q, --quiet
-            Silence all component output to stdout/stderr
-
-        --runtime-config-file <RUNTIME_CONFIG_FILE>
-            Configuration file for config providers and wasmtime config
-            
-            [env: RUNTIME_CONFIG_FILE=]
-
-        --state-dir <STATE_DIR>
-            Set the application state directory path. This is used in the default locations for
-            logs, key value stores, etc.
-            
-            For local apps, this defaults to `.spin/` relative to the `spin.toml` file. For remote
-            apps, this has no default (unset). Passing an empty value forces the value to be unset.
-
-        --tls-cert <TLS_CERT>
-            The path to the certificate to use for https, if this is not set, normal http will be
-            used. The cert should be in PEM format
-            
-            [env: SPIN_TLS_CERT=]
-
-        --tls-key <TLS_KEY>
-            The path to the certificate key to use for https, if this is not set, normal http will
-            be used. The key should be in PKCS#8 format
-            
-            [env: SPIN_TLS_KEY=]
-```
-
-{{ blockEnd }}
-
-{{ startTab "v1.2.0"}}
-
-<!-- @selectiveCpy -->
-
-```console
-$ spin up --help
-
-spin-up 
-Start the Spin application
-
-USAGE:
-    spin up [OPTIONS]
-
-OPTIONS:
-        --direct-mounts         For local apps with directory mounts and no excluded files, mount
-                                them directly instead of using a temporary directory
-    -e, --env <ENV>             Pass an environment variable (key=value) to all components of the
-                                application
-    -f, --from <APPLICATION>    The application to run. This may be a manifest (spin.toml) file, a
-                                directory containing a spin.toml file, or a remote registry
-                                reference. If omitted, it defaults to "spin.toml"
-    -h, --help                  
-    -k, --insecure              Ignore server certificate errors from bindle server or registry
-        --temp <TMP>            Temporary directory for the static assets of the components
-
-TRIGGER OPTIONS:
-        --allow-transient-write
-            Set the static assets of the components in the temporary directory as writable
-
-        --cache <WASMTIME_CACHE_FILE>
-            Wasmtime cache configuration file
-            
-            [env: WASMTIME_CACHE_FILE=]
-
-        --disable-cache
-            Disable Wasmtime cache
-            
-            [env: DISABLE_WASMTIME_CACHE=]
-
-        --follow <FOLLOW_ID>
-            Print output to stdout/stderr only for given component(s)
-
-        --key-value <KEY_VALUES>
-            Set a key/value pair (key=value) in the application's default store. Any existing value
-            will be overwritten. Can be used multiple times
-
-    -L, --log-dir <APP_LOG_DIR>
-            Log directory for the stdout and stderr of components
-
-        --listen <ADDRESS>
-            IP address and port to listen on
-            
-            [default: 127.0.0.1:3000]
-
-    -q, --quiet
-            Silence all component output to stdout/stderr
-
-        --runtime-config-file <RUNTIME_CONFIG_FILE>
-            Configuration file for config providers and wasmtime config
-            
-            [env: RUNTIME_CONFIG_FILE=]
-
-        --state-dir <STATE_DIR>
-            Set the application state directory path. This is used in the default locations for
-            logs, key value stores, etc.
-            
-            For local apps, this defaults to `.spin/` relative to the `spin.toml` file. For remote
-            apps, this has no default (unset). Passing an empty value forces the value to be unset.
-
-        --tls-cert <TLS_CERT>
-            The path to the certificate to use for https, if this is not set, normal http will be
-            used. The cert should be in PEM format
-            
-            [env: SPIN_TLS_CERT=]
-
-        --tls-key <TLS_KEY>
-            The path to the certificate key to use for https, if this is not set, normal http will
-            be used. The key should be in PKCS#8 format
-            
-            [env: SPIN_TLS_KEY=]
-```
-
-{{ blockEnd }}
-
-{{ blockEnd }}
-
-### Watch
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin watch
 
 {{ tabs "spin-version" }}
 
@@ -3285,7 +3171,37 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin watch --help
+
+spin-watch 
+Build and run the Spin application, rebuilding and restarting it when files change
+
+USAGE:
+    spin watch [OPTIONS] [UP_ARGS]...
+
+ARGS:
+    <UP_ARGS>...    Arguments to be passed through to spin up
+
+OPTIONS:
+    -c, --clear                       Clear the screen before each run
+    -d, --debounce <DEBOUNCE>         Set the timeout between detected change and re-execution, in
+                                      milliseconds [default: 100]
+    -f, --from <APP_MANIFEST_FILE>    The application to watch. This may be a manifest (spin.toml)
+                                      file, or a directory containing a spin.toml file. If omitted,
+                                      it defaults to "spin.toml" [default: spin.toml]
+    -h, --help                        Print help information
+        --skip-build                  Only run the Spin application, restarting it when build
+                                      artifacts change
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3.0"}}
 
 <!-- @selectiveCpy -->
 
@@ -3317,24 +3233,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-`spin watch` relies on configuration in your application manifest to know what files it should watch. For each component you should set the `component.build.watch` parameter with a list of glob patterns that your source files will match:
-
-```toml
-[component.build]
-# Example watch configuration for a Rust application
-watch = ["src/**/*.rs", "Cargo.toml"]
-```
-
-The table below outlines exactly which files `spin watch` will monitor for changes depending on how you run the command. `spin watch` uses the configuration found on every component in your application.
-
-| Files                   | `spin watch` monitors for changes              | `spin watch --skip-build` monitors for changes |
-| ----------------------- | ---------------------------------------------- | ---------------------------------------------- |
-| Application manifest    | Yes                                            | Yes                                            |
-| `component.build.watch` | Yes                                            | No                                             |
-| `component.files`       | Yes                                            | Yes                                            |
-| `component.source`      | No (Yes if the component has no build command) | Yes                                            |
-
-### CLI Stability Table
+## Stability Table
 
 CLI commands have four phases that indicate levels of stability:
 
@@ -3373,12 +3272,29 @@ CLI commands have four phases that indicate levels of stability:
 | <code>spin up</code>                                                                  | Stable       |
 | <code>spin cloud <deploy&vert;login></code>                                           | Stabilizing  |
 | <code>spin registry</code>                                                            | Stabilizing  |
-| <code>spin watch</code>                                                               | Stabilizing |
+| <code>spin watch</code>                                                               | Experimental |
 | <code>spin bindle <prepare&vert;push></code>                                          | Deprecated   |
 
 {{ blockEnd }}
 
-{{ startTab "v1.2.0"}}
+{{ startTab "v1.2.0/1.2.1"}}
+
+| Command                                                                               | Stability    |
+| ------------------------------------------------------------------------------------- | ------------ |
+| <code>spin add</code>                                                                 | Stable       |
+| <code>spin build</code>                                                               | Stable       |
+| <code>spin new</code>                                                                 | Stable       |
+| <code>spin plugins <install&vert;list&vert;uninstall&vert;update&vert;upgrade></code> | Stable       |
+| <code>spin templates <install&vert;list&vert;uninstall&vert;upgrade></code>           | Stable       |
+| <code>spin up</code>                                                                  | Stable       |
+| <code>spin cloud <deploy&vert;login></code>                                           | Stabilizing  |
+| <code>spin registry</code>                                                            | Stabilizing  |
+| <code>spin watch</code>                                                               | Experimental |
+| <code>spin bindle <prepare&vert;push></code>                                          | Deprecated   |
+
+{{ blockEnd }}
+
+{{ startTab "v1.3.0"}}
 
 | Command                                                                               | Stability    |
 | ------------------------------------------------------------------------------------- | ------------ |

--- a/content/spin/running-apps.md
+++ b/content/spin/running-apps.md
@@ -80,6 +80,7 @@ Some trigger types support additional `spin up` flags.  For example, HTTP applic
 Spin's `watch` command rebuilds and restarts Spin applications whenever files change. You can use the `spin watch` [command](https://developer.fermyon.com/common/cli-reference#watch) in place of the `spin build` and `spin up` commands, to build, run and then keep your Spin application running without manual intervention while staying on the latest code and files.
 
 > The `watch` command accepts valid Spin [up](https://developer.fermyon.com/common/cli-reference#up) options and passes them through to `spin up` for you when running/rerunning the Spin application.
+E.g., `spin watch --listen 127.0.0.1:3001`
 
 By default, Spin watch monitors:
 
@@ -101,10 +102,20 @@ files = ["my-files/changing-file.txt"]
 source = "target/wasm32-wasi/release/test.wasm"
 [component.build]
 command = "cargo build --target wasm32-wasi --release"
+# Example watch configuration for a Rust application
 watch = ["src/**/*.rs", "Cargo.toml"]
 ```
 
 If you would prefer Spin watch to only rerun the application (without a rebuild) when changes occur, you can use the `--skip-build` option when running the `spin watch` command.  In this case, Spin will ignore the `component.build.watch` section, and monitor only the `spin.toml`, `component.source` and `component.files`.
+
+The table below outlines exactly which files `spin watch` will monitor for changes depending on how you run the command. `spin watch` uses the configuration found on every component in your application.
+
+| Files                   | `spin watch` monitors for changes              | `spin watch --skip-build` monitors for changes |
+| ----------------------- | ---------------------------------------------- | ---------------------------------------------- |
+| Application manifest `spin.toml`   | Yes                                            | Yes                                            |
+| `component.build.watch` | Yes                                            | No                                             |
+| `component.files`       | Yes                                            | Yes                                            |
+| `component.source`      | No (Yes if the component has no build command) | Yes  
 
 Spin watch waits up to 100 milliseconds before responding to filesystem events, then processes all events that occurred in that interval together. This is so that if you make several changes close together (for example, using a Save All command), you get them all processed in one rebuild/reload cycle, rather than going through a cycle for each one. You can override the interval by passing in the `--debounce` option; e.g. `spin watch --debounce 1000` will make Spin watch respond to filesystem events at most once per second.
 

--- a/content/spin/running-apps.md
+++ b/content/spin/running-apps.md
@@ -80,7 +80,7 @@ Some trigger types support additional `spin up` flags.  For example, HTTP applic
 Spin's `watch` command rebuilds and restarts Spin applications whenever files change. You can use the `spin watch` [command](https://developer.fermyon.com/common/cli-reference#watch) in place of the `spin build` and `spin up` commands, to build, run and then keep your Spin application running without manual intervention while staying on the latest code and files.
 
 > The `watch` command accepts valid Spin [up](https://developer.fermyon.com/common/cli-reference#up) options and passes them through to `spin up` for you when running/rerunning the Spin application.
-E.g., `spin watch --listen 127.0.0.1:3001`
+E.g. `spin watch --listen 127.0.0.1:3001`
 
 By default, Spin watch monitors:
 

--- a/templates/cloud_sidebar.hbs
+++ b/templates/cloud_sidebar.hbs
@@ -79,8 +79,8 @@
                             href="{{site.info.base_url}}/cloud/rest-api">REST API</a></li>
                     <li><a {{#if (active_content request.spin-path-info "/cloud/cli-reference" )}} class="active"
                             {{/if}} href="{{site.info.base_url}}/cloud/cli-reference">Spin CLI Reference</a></li>
-                    <li><a {{#if (active_content request.spin-path-info "/cloud/cloud-plugin" )}} class="active"
-                            {{/if}} href="{{site.info.base_url}}/cloud/cloud-plugin">Cloud Command Reference</a></li>
+                    <li><a {{#if (active_content request.spin-path-info "/cloud/cloud-plugin-reference" )}} class="active"
+                            {{/if}} href="{{site.info.base_url}}/cloud/cloud-plugin-reference">Fermyon Cloud Plugin CLI Reference</a></li>
                     <li><a {{#if (active_content request.spin-path-info "/cloud/changelog" )}} class="active"
                             {{/if}} href="{{site.info.base_url}}/cloud/changelog">Changelog</a></li>
                 </ul>

--- a/templates/cloud_sidebar.hbs
+++ b/templates/cloud_sidebar.hbs
@@ -79,8 +79,8 @@
                             href="{{site.info.base_url}}/cloud/rest-api">REST API</a></li>
                     <li><a {{#if (active_content request.spin-path-info "/cloud/cli-reference" )}} class="active"
                             {{/if}} href="{{site.info.base_url}}/cloud/cli-reference">Spin CLI Reference</a></li>
-                    <li><a {{#if (active_content request.spin-path-info "/cloud/cloud-plugin-reference" )}} class="active"
-                            {{/if}} href="{{site.info.base_url}}/cloud/cloud-plugin-reference">Fermyon Cloud Plugin CLI Reference</a></li>
+                    <li><a {{#if (active_content request.spin-path-info "/cloud/cloud-command-reference" )}} class="active"
+                            {{/if}} href="{{site.info.base_url}}/cloud/cloud-command-reference">Cloud Command Reference</a></li>
                     <li><a {{#if (active_content request.spin-path-info "/cloud/changelog" )}} class="active"
                             {{/if}} href="{{site.info.base_url}}/cloud/changelog">Changelog</a></li>
                 </ul>


### PR DESCRIPTION
This PR picks up from here: https://github.com/fermyon/developer/pull/698 to add the 1.3 CLI reference, now with the Cloud Plugin having it's own reference, and links between.

Also a bit of restructuring the headers to mimic the commands in the CLI.