### PR TITLE
Update build.yml to sync with latest bart version being used

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install bart
         run: |
-          curl -LOs https://github.com/fermyon/bartholomew/releases/download/v0.7.0/bart
+          curl -LOs https://github.com/fermyon/bartholomew/releases/download/v0.8.0/bart
           chmod +x bart
           mv bart /usr/local/bin
 


### PR DESCRIPTION
Signed-off-by: tpmccallum tim.mccallum@fermyon.com

We [recently updated to Bartholomew 0.8.0](https://github.com/fermyon/developer/commit/c13d9859625287e33876b1fa5c803c4f75f17938) and removed the common folder etc. This PR is to just update/sync the version of Bart in the GH workflows with what is being used in the developer site's module section.
