### PR TITLE
Update variables.md

### DIFF
--- a/content/cloud/variables.md
+++ b/content/cloud/variables.md
@@ -17,7 +17,7 @@ Spin supports dynamic application variables. Instead of being static, their valu
 
 These variables are defined in a Spin application manifest (in the `[variables]` section) and are provided by a configuration provider. When using Spin locally, the configuration provider can be Vault for secrets or host environment variables. You can refer to the [dynamic configuration documentation](/spin/dynamic-configuration.md) to learn how to configure variables locally. In Fermyon Cloud, you can set and update variables for Spin applications using the [`spin cloud variables`](/cloud/cloud-command-reference.md#spin-cloud-variables) command.
 
-This tutorial will guide you through the process of creating a simple application that validates passwords. Here's a video tutorial to follow along:
+This tutorial will guide you through the process of creating a simple application that validates passwords. If you prefer to learn through video, you can follow along with this recording.
 
 <iframe width="900" height="506" src="https://www.youtube.com/embed/T9B3VgGTYr0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
@@ -25,7 +25,7 @@ This tutorial will guide you through the process of creating a simple applicatio
 
 Before starting, ensure that you have Spin v1.3.0 or greater installed on your computer. You can follow the official Fermyon Cloud Quickstart guide to [install Spin](/cloud/quickstart#install-spin) and [log into Fermyon Cloud](/cloud/quickstart#log-in-to-the-fermyon-cloud).
 
-Since this example is written in Python, make sure you have the required tools installed in order to write Spin applications in Python. The Spin CLI facilitates the creation of new Spin applications using application [templates](/cloud/cli-reference#templates). In this tutorial, we will use the `http-py` template. Install it along with the `py2wasm` Spin plugin, which enables compiling Python apps to Wasm, using the following commands:
+Since this example is written in Python, make sure you have the required tools installed to write Spin applications in Python. The Spin CLI facilitates the creation of new Spin applications using application [templates](/cloud/cli-reference#templates). In this tutorial, we will use the `http-py` template. Install it along with the `py2wasm` Spin plugin, which enables compiling Python apps to Wasm, using the following commands:
 
 <!-- @selectiveCpy -->
 
@@ -74,18 +74,21 @@ HTTP path: /...
 
 ## Adding Variables to an Application Component
 
-Our application receives a password via the HTTP request body, compares it to an expected password, and returns a JSON response indicating whether the submitted password matched or not.
+Our application receives a password via the HTTP request body, compares it to an expected password, and returns a JSON response indicating whether the submitted password matches or not.
 
-In reality, you'd have multiple usernames and password hashes in a database, but for this tutorial we will configure the expected password using a Spin application variable. We'll name the variable `password` and set `required = true` since there is no reasonable default value. To do this, add a top-level `[variables]` section to the application manifest (`spin.toml`) and declare the variable within it.
+In reality, you'd have multiple usernames and password hashes in a database, but for this tutorial, we will configure the expected password using a Spin application variable. We'll name the variable `password` and set `required = true` since there is no reasonable default value. To do this, add a top-level `[variables]` section to the application manifest (`spin.toml`) and declare the variable within it:
 
-<!-- @selectiveCpy -->
+<!-- @nocpy -->
+
 ```toml
 # Add this above the [component] section
 [variables]
 password = { required = true }
 ```
 
-To surface the variable to the `pw-checker` component, add a `[component.config]` section in the component and specify the variable within it. Instead of statically assigning the value of the config variable, we are referencing the dynamic variable with [mustache](https://mustache.github.io/)-inspired string templates. Only components that explicitly use the variables in their configuration section will get access to them. This enables only exposing variables and secrets to the desired components of an application.
+To surface the variable to the `pw-checker` component, add a `[component.config]` section in the component and specify the variable within it. Instead of statically assigning the value of the config variable, we are referencing the dynamic variable with [mustache](https://mustache.github.io/)-inspired string templates. Only components that explicitly use the variables in their configuration section will get access to them. This enables only exposing variables and secrets to the desired components of an application:
+
+<!-- @nocpy -->
 
 ```toml
 # Add this below the [component.build] section
@@ -95,7 +98,8 @@ password = "\{{ password }}"
 
 The resulting application manifest should look similar to the following:
 
-<!-- @selectiveCpy -->
+<!-- @nocpy -->
+
 ```toml
 spin_manifest_version = "1"
 description = "A Spin app with a dynamically updatable variable"
@@ -119,9 +123,10 @@ password = "\{{ password }}"
 
 ## Using Variables in a Spin Application
 
-Now that we have defined our variables and surfaced them to our component, we are ready to implement our Spin application. The application should get the user-provided password from the body of the HTTP request, compare it to the expected password set in our configuration variable, and authenticate accordingly. We will use the Spin `spin_config` module to retrieve the value of the `password` variable. 
+Now that we have defined our variables and surfaced them to our component, we are ready to implement our Spin application. The application should get the user-provided password from the body of the HTTP request, compare it to the expected password set in our configuration variable, and authenticate accordingly. We will use the Spin `spin_config` module to retrieve the value of the `password` variable:
 
-<!-- @selectiveCpy -->
+<!-- @nocpy -->
+
 ```py
 from spin_http import Response
 from spin_config import config_get
@@ -138,9 +143,10 @@ def handle_request(request):
                     bytes(response, "utf-8"))
 ```
 
-Build and run the application locally to test it out. We will use the [environment variable provider](/spin/dynamic-configuration.md#environment-variable-provider) to set the variable values locally. The provider gets the variable values from the `spin` process's environment, searching for environment variables prefixed with `SPIN_CONFIG_`.
+Build and run the application locally to test it out. We will use the [environment variable provider](/spin/dynamic-configuration.md#environment-variable-provider) to set the variable values locally. The provider gets the variable values from the `spin` process's environment, searching for environment variables prefixed with `SPIN_CONFIG_`:
 
 <!-- @selectiveCpy -->
+
 ```bash
 $ spin build
 $ SPIN_CONFIG_PASSWORD="123" spin up
@@ -151,9 +157,10 @@ Available Routes:
   pw-checker: http://127.0.0.1:3000 (wildcard)
 ```
 
-Send a request to the application with the correct password in the body to authenticate successfully.
+Send a request to the application with the correct password in the body to authenticate successfully:
 
 <!-- @selectiveCpy -->
+
 ```bash
 $ curl -d "123" http://127.0.0.1:3000
 {"authentication": "accepted"}
@@ -161,9 +168,10 @@ $ curl -d "123" http://127.0.0.1:3000
 
 ## Deploying the Application to Fermyon Cloud
 
-Let's deploy our application to the cloud with initial values for our variables. All values are stored encrypted.
+Let's deploy our application to the cloud with initial values for our variables. All values are stored encrypted:
 
 <!-- @selectiveCpy -->
+
 ```bash
 $ spin deploy --variable password="123"
 Uploading pw_checker version 0.1.0+r7123456...
@@ -176,6 +184,7 @@ Available Routes:
 Check if we can authenticate again using the deployed application:
 
 <!-- @selectiveCpy -->
+
 ```bash
 $ curl -d "123" https://pw-checker-abcdefg.fermyon.app
 {"authentication": "accepted"}
@@ -186,15 +195,17 @@ We're in! Now, let's update one of the variables and observe how it dynamically 
 Set a new password and observe that access is now denied:
 
 <!-- @selectiveCpy -->
+
 ```bash
 $ spin cloud variables set password="456" --app "pw_checker"
 $ curl -d "123" https://pw-checker-abcdefg.fermyon.app                          
 {"authentication": "denied"}
 ```
 
-The `spin cloud variables` command can also be used to list application variables. Only names are listed, as values remain secret.
+The `spin cloud variables` command can also be used to list application variables. Only names are listed, as values remain secret:
 
 <!-- @selectiveCpy -->
+
 ```bash
 $ spin cloud variables list --app "pw_checker"
     password

--- a/content/cloud/variables.md
+++ b/content/cloud/variables.md
@@ -78,7 +78,7 @@ Our application receives a password via the HTTP request body, compares it to an
 
 In reality, you'd have multiple usernames and password hashes in a database, but for this tutorial, we will configure the expected password using a Spin application variable. We'll name the variable `password` and set `required = true` since there is no reasonable default value. To do this, add a top-level `[variables]` section to the application manifest (`spin.toml`) and declare the variable within it:
 
-<!-- @nocpy -->
+<!-- @selectiveCpy -->
 
 ```toml
 # Add this above the [component] section
@@ -88,7 +88,7 @@ password = { required = true }
 
 To surface the variable to the `pw-checker` component, add a `[component.config]` section in the component and specify the variable within it. Instead of statically assigning the value of the config variable, we are referencing the dynamic variable with [mustache](https://mustache.github.io/)-inspired string templates. Only components that explicitly use the variables in their configuration section will get access to them. This enables only exposing variables and secrets to the desired components of an application:
 
-<!-- @nocpy -->
+<!-- @selectiveCpy -->
 
 ```toml
 # Add this below the [component.build] section
@@ -125,7 +125,7 @@ password = "\{{ password }}"
 
 Now that we have defined our variables and surfaced them to our component, we are ready to implement our Spin application. The application should get the user-provided password from the body of the HTTP request, compare it to the expected password set in our configuration variable, and authenticate accordingly. We will use the Spin `spin_config` module to retrieve the value of the `password` variable:
 
-<!-- @nocpy -->
+<!-- @selectiveCpy -->
 
 ```py
 from spin_http import Response


### PR DESCRIPTION
Signed-off-by: tpmccallum tim.mccallum@fermyon.com

Update variables markdown file; consistent annotations and `.` vs `:` etc. Also included change from #709 so all goes ahead in one commit (and because 709 has an `Expected — Waiting for status to be reported` error present which is blocking the PR)

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)

<img width="917" alt="Screenshot 2023-06-30 at 11 16 29 am" src="https://github.com/fermyon/developer/assets/9831342/5fc4bf32-c72a-47cd-9e8c-fcedc29731a3">

- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)

<img width="1284" alt="Screenshot 2023-06-30 at 11 17 20 am" src="https://github.com/fermyon/developer/assets/9831342/bd0f8a52-11ab-44a0-b9f5-7fd5903fa9ba">

- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors
- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
