### PR TITLE
Make link from variables API guide to config page more prominent

### DIFF
--- a/content/spin/variables.md
+++ b/content/spin/variables.md
@@ -11,7 +11,9 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/variables.md"
 
 Spin supports dynamic application variables. Instead of being static, their values can be updated without modifying the application, creating a simpler experience for rotating secrets, updating API endpoints, and more. 
 
-These variables are defined in a Spin application manifest (in the `[variables]` section), and their values can be set or overridden at runtime by a [configuration provider](/spin/dynamic-configuration.md#custom-config-providers). When running Spin locally, the configuration provider can be Hashicorp Vault for secrets, or host environment variables. Refer to the [dynamic configuration documentation](/spin/dynamic-configuration.md) to learn how to configure variables locally.
+These variables are defined in a Spin application manifest (in the `[variables]` section), and their values can be set or overridden at runtime by a [configuration provider](/spin/dynamic-configuration.md#custom-config-providers). When running Spin locally, the configuration provider can be Hashicorp Vault for secrets, or host environment variables.
+
+For information about defining variables and component configuration keys, such as manifest syntax, naming restrictions, and value template syntax, refer to the [dynamic configuration documentation](/spin/dynamic-configuration.md).
 
 ## Adding Variables to Your Applications
 


### PR DESCRIPTION
Relating to https://github.com/fermyon/spin/issues/1628

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)

<img width="1174" alt="Screenshot 2023-07-03 at 11 15 49 am" src="https://github.com/fermyon/developer/assets/9831342/d9025621-98e0-45b4-bbb1-c76431ac08dc">

- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)

![Screenshot 2023-07-03 at 11 19 17 am](https://github.com/fermyon/developer/assets/9831342/685c4f4b-0aca-42ef-9258-054fb115feeb)

- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors

<img width="489" alt="Screenshot 2023-07-03 at 11 21 17 am" src="https://github.com/fermyon/developer/assets/9831342/2d418d33-55ee-4bee-9997-391d3beea05e">

- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
