### PR TITLE
Spin internal data layout

### DIFF
--- a/content/spin/distributing-apps.md
+++ b/content/spin/distributing-apps.md
@@ -80,7 +80,7 @@ $ spin up -f ghcr.io/alyssa-p-hacker/hello-world:v1
 
 > Remember that if the artifact is private you will need to be logged in, with permission to access it.
 
-> Spin optimises downloads using a local [registry cache](/spin/cache).
+> Spin optimizes downloads using a local [registry cache](/spin/cache). When running an application from a remote registry, Spin always tries to check the registry for updates, even if the application has already been pulled. However, content files that are already pulled will not be re-downloaded. This applies even if they were downloaded as part of a different application.
 
 ### Running Published Applications by Digest
 

--- a/templates/spin_sidebar.hbs
+++ b/templates/spin_sidebar.hbs
@@ -154,8 +154,8 @@
                     <li><a {{#if (active_content request.spin-path-info "/spin/dynamic-configuration" )}} class="active"
                             {{/if}} href="{{site.info.base_url}}/spin/dynamic-configuration">Dynamic Application
                             Configuration</a></li>
-            <li><a {{#if (active_content request.spin-path-info "/spin/cache" )}} class="active" {{/if}} href="{{site.info.base_url}}/spin/cache">Spin Cache</a></li>
-                    
+                    <li><a {{#if (active_content request.spin-path-info "/spin/cache" )}} class="active" 
+                            {{/if}} href="{{site.info.base_url}}/spin/cache">Spin Internal Data Layout</a></li>
                     <li><a {{#if (active_content request.spin-path-info "/spin/template-authoring" )}} class="active"
                             {{/if}} href="{{site.info.base_url}}/spin/template-authoring">Creating Spin Templates</a>
                     </li>


### PR DESCRIPTION
Fixes #680.

@tpmccallum I moved a couple of sentences from the "registry cache" page to the "running published applications" section, and moved the cache layout diagram to give more prominence to the explanation.  I'm happy to revert those changes if you prefer them as they were.

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)

<img width="1225" alt="Screenshot 2023-07-10 at 2 34 40 pm" src="https://github.com/fermyon/developer/assets/9831342/394c0294-0716-4328-9375-a78d4c44d049">

- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)

![Screenshot 2023-07-10 at 2 33 56 pm](https://github.com/fermyon/developer/assets/9831342/c3dfe11a-5d5e-44c1-9e1f-9b5bc92aacc6)

- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors

<img width="593" alt="Screenshot 2023-07-10 at 2 35 20 pm" src="https://github.com/fermyon/developer/assets/9831342/d19279a9-1b43-491a-a852-2544ed7281e3">

- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
