### PR TITLE
Plugin environment variables

### DIFF
--- a/content/spin/plugin-authoring.md
+++ b/content/spin/plugin-authoring.md
@@ -8,6 +8,7 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/plugin-author
 - [What Are Spin Plugins?](#what-are-spin-plugins)
 - [How to Find and Use a Spin Plugin](#how-to-find-and-use-a-spin-plugin)
 - [Authoring a Spin Plugin](#authoring-a-spin-plugin)
+  - [Environment Variables Available to the Plugin Executable](#environment-variables-available-to-the-plugin-executable)
   - [Packaging a Plugin](#packaging-a-plugin)
   - [Creating a Spin Plugin Manifest](#creating-a-spin-plugin-manifest)
   - [Installing a Local Plugin](#installing-a-local-plugin)
@@ -69,6 +70,30 @@ Spin plugins are implemented as a manifest that points to one or more `.tar.gz` 
 
 1. Create tar archives of the executables for the platforms you want to support
 2. Compose a manifest that describes the plugin and lists the URLs for those tar archives
+
+### Environment Variables Available to the Plugin Executable
+
+Your plugin may need to know information about the instance of Spin it's running in. For example, suppose your plugin wants to call `spin build`. The trouble is that you don't know if it's on the user's system PATH. Suppose, further, that your plugin would prefer to call `spin build -c` (to build only a specific component) if it's available but can fall back to `spin build` (to build everything) if it's not. The `-c` option only exists in Spin 1.4 and above, so this optimization requires that you know which version of Spin you're running in.
+
+To help with this, when a user uses Spin to run your plugin, Spin sets a number of environment variables on the plugin process. Your code can use these environment variables to find out things like the path to the Spin binary and which version of Spin it is. When your plugin runs, the parent Spin process will set these to the right values for the _user's_ instance of Spin. In the example above, when your plugin wants to run `spin build`, it can consult the `SPIN_BIN_PATH` environment variable for the program path, and be confident that the `SPIN_VERSION` environment variable matches the Spin binary at that location.
+
+The variables Spin sets are:
+
+| Name               | Meaning                                                                                                               | Example |
+|--------------------|-----------------------------------------------------------------------------------------------------------------------|---------|
+| SPIN_BIN_PATH      | The path to the Spin executable that the user is running. Use this if your plugin issues commands using the Spin CLI. | /Users/alice/.cargo/bin/spin |
+| SPIN_BRANCH        | The Git branch from which the Spin executable was built.                                                              | main |
+| SPIN_BUILD_DATE    | The date on which the Spin executable was built, in yyyy-mm-dd format.                                                | 2023-05-15 |
+| SPIN_COMMIT_DATE   | The date of the Git commit from which the Spin executable was built, in yyyy-mm-dd format.                            | 2023-05-15 |
+| SPIN_COMMIT_SHA    | The SHA of the Git commit from which the Spin executable was built.                                                   | 49fb11b |
+| SPIN_DEBUG         | Whether the Spin executable is a debug build.                                                                         | false |
+| SPIN_TARGET_TRIPLE | The processor and operating system for which the Spin executable was built, in Rust target-triple format.             | aarch64-apple-darwin |
+| SPIN_VERSION       | The version of Spin. This can be used to detect features availability, or to determine pre-stable command syntax.     | 1.3.0 |
+| SPIN_VERSION_MAJOR | The major version of Spin.                                                                                            | 1 |
+| SPIN_VERSION_MINOR | The minor version of Spin.                                                                                            | 3 |
+| SPIN_VERSION_PRE   | The prerelease version string, or empty if this is a released version of Spin.                                        | pre0 |
+
+> These variables aren't set if the launching Spin instance is version 1.3 or earlier. If you depend on these variables, set the `spinCompatibility` entry in the manifest to require 1.4 or above.
 
 ### Packaging a Plugin
 


### PR DESCRIPTION
Fixes #632.

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
