### PR TITLE
Add Spin v 1.4 CLI Reference

### DIFF
--- a/content/spin/cli-reference.md
+++ b/content/spin/cli-reference.md
@@ -1037,11 +1037,9 @@ SUBCOMMANDS:
     deploy       Package and upload an application to the Fermyon Cloud.
     doctor       Detect and fix problems with Spin applications
     help         Print this message or the help of the given subcommand(s)
-    js2wasm*     A plugin to convert js files to Spin compatible modules
     login        Log into the Fermyon Cloud.
     new          Scaffold a new application based on a template
     plugins      Install/uninstall Spin plugins
-    py2wasm*     A plugin to convert Python applications to Spin compatible modules
     registry     Commands for working with OCI registries to distribute applications
     templates    Commands for working with WebAssembly component templates
     up           Start the Spin application

--- a/content/spin/cli-reference.md
+++ b/content/spin/cli-reference.md
@@ -15,7 +15,6 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/cli-reference
 - [spin deploy](#spin-deploy)
 - [spin doctor](#spin-doctor)
 - [spin help](#spin-help)
-- [spin js2wasm](#spin-js2wasm)
 - [spin login](#spin-login)
 - [spin new](#spin-new)
 - [spin plugins](#spin-plugins)
@@ -24,7 +23,6 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/cli-reference
 - [spin plugins uninstall](#spin-plugins-uninstall)
 - [spin plugins update](#spin-plugins-update)
 - [spin plugins upgrade](#spin-plugins-upgrade)
-- [spin py2wasm](#spin-py2wasm)
 - [spin registry](#spin-registry)
 - [spin registry login](#spin-registry-login)
 - [spin registry pull](#spin-registry-pull)
@@ -40,6 +38,8 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/cli-reference
 - [Stability Table](#stability-table)
 
 This page documents the Spin Command Line Interface (CLI).
+
+> Please note: When using the `spin --help` command you may see additional commands (followed by an asterisk symbol). These additional commands that are visible on your machine will show up depending on what plugins you have installed locally.
 
 For information on command stability, see the [CLI stability table](#cli-stability-table).
 
@@ -1056,42 +1056,6 @@ SUBCOMMANDS:
 {{ blockEnd }}
 
 > Please note: Spin `help` is a convenient way to access help using a subcommand, instead of using the `--help` option. For example, `spin help cloud` will give you the same output as `spin cloud --help`. Similarly, `spin help build` will give you the same output as `spin build --help` and so forth.
-
-<!-- markdownlint-disable-next-line titlecase-rule -->
-## spin js2wasm
-
-{{ tabs "spin-version" }}
-
-{{ startTab "v1.4"}}
-
-<!-- @selectiveCpy -->
-
-```console
-$ spin js2wasm --help
-
-js2wasm 0.4.0
-A spin plugin to convert javascript files to Spin compatible modules
-
-USAGE:
-    js2wasm [OPTIONS] <input>
-
-FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
-
-OPTIONS:
-    -o <output>         [default: index.wasm]
-
-ARGS:
-    <input> 
-
-```
-
-{{ blockEnd }}
-
-{{ blockEnd }}
-
-> As denoted by the `*` when using the `spin --help` command, [js2wasm](/spin/javascript-components) is implemented via plugin. This is why `spin js2wasm --help` above shows slightly different commands (relative to the other commands that see on this page).
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin login
@@ -2194,52 +2158,6 @@ OPTIONS:
 {{ blockEnd }}
 
 **Note:** For additional information, please see the [Managing Plugins](/spin/managing-plugins) and/or [Creating Plugins](/spin/plugin-authoring) sections of the documentation.
-
-<!-- markdownlint-disable-next-line titlecase-rule -->
-## spin py2wasm
-
-{{ tabs "spin-version" }}
-
-{{ startTab "v1.4"}}
-
-<!-- @selectiveCpy -->
-
-```console
-$ spin py2wasm --help
-
-A Spin plugin to convert Python apps to Spin-compatible WebAssembly modules
-
-Usage: py2wasm [OPTIONS] <APP_NAME>
-
-Arguments:
-  <APP_NAME>
-          The name of a Python module containing a `handle_request` function for handling Spin HTTP requests
-
-Options:
-  -p, --python-path <PYTHON_PATH>
-          `PYTHONPATH` for specifying directory containing the app and optionally other directories containing dependencies.
-          
-          If `pipenv` is in `$PATH` and `pipenv --venv` produces a path containing a `site-packages` subdirectory, that directory will be appended to this value as a convenience for `pipenv` users.
-          
-          [default: .]
-
-  -o, --output <OUTPUT>
-          Output file to write the resulting module to
-          
-          [default: index.wasm]
-
-  -h, --help
-          Print help (see a summary with '-h')
-
-  -V, --version
-          Print version
-```
-
-{{ blockEnd }}
-
-{{ blockEnd }}
-
-> As denoted by the `*` when using the `spin --help` command, [py2wasm](/spin/python-components) is implemented via plugin. This is why `spin py2wasm --help` above shows slightly different commands (relative to the other commands that see on this page).
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin registry

--- a/content/spin/cli-reference.md
+++ b/content/spin/cli-reference.md
@@ -13,7 +13,9 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/cli-reference
 - [spin cloud login](#spin-cloud-login)
 - [spin cloud variables](#spin-cloud-variables)
 - [spin deploy](#spin-deploy)
+- [spin doctor](#spin-doctor)
 - [spin help](#spin-help)
+- [spin js2wasm](#spin-js2wasm)
 - [spin login](#spin-login)
 - [spin new](#spin-new)
 - [spin plugins](#spin-plugins)
@@ -22,6 +24,7 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/cli-reference
 - [spin plugins uninstall](#spin-plugins-uninstall)
 - [spin plugins update](#spin-plugins-update)
 - [spin plugins upgrade](#spin-plugins-upgrade)
+- [spin py2wasm](#spin-py2wasm)
 - [spin registry](#spin-registry)
 - [spin registry login](#spin-registry-login)
 - [spin registry pull](#spin-registry-pull)
@@ -39,6 +42,7 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/cli-reference
 This page documents the Spin Command Line Interface (CLI).
 
 For information on command stability, see the [CLI stability table](#cli-stability-table).
+
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin add
 
@@ -188,6 +192,42 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin add --help
+
+spin-add 
+Scaffold a new component into an existing application
+
+USAGE:
+    spin add [OPTIONS] [ARGS]
+
+ARGS:
+    <TEMPLATE_ID>    The template from which to create the new application or component. Run
+                     `spin templates list` to see available options
+    <NAME>           The name of the new application or component
+
+OPTIONS:
+    -a, --accept-defaults              An optional argument that allows to skip prompts for the
+                                       manifest file by accepting the defaults if available on the
+                                       template
+    -f, --file <APP_MANIFEST_FILE>     Path to spin.toml
+    -h, --help                         Print help information
+    -o, --output <OUTPUT_PATH>         The directory in which to create the new application or
+                                       component. The default is the name argument
+        --tag <TAGS>                   Filter templates to select by tags
+    -v, --value <VALUES>               Parameter values to be passed to the template (in name=value
+                                       format)
+        --values-file <VALUES_FILE>    A TOML file which contains parameter values in name = "value"
+                                       format. Parameters passed as CLI option overwrite parameters
+                                       specified in the file
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -300,6 +340,40 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin build --help
+
+spin-build 
+Build the Spin application
+
+USAGE:
+    spin build [OPTIONS] [--] [UP_ARGS]...
+
+ARGS:
+    <UP_ARGS>...    
+
+OPTIONS:
+    -c, --component-id <COMPONENT_ID>...
+            Component ID to build. This can be specified multiple times. The default is all
+            components
+
+    -f, --from <APP_MANIFEST_FILE>
+            The application to build. This may be a manifest (spin.toml) file, or a directory
+            containing a spin.toml file. If omitted, it defaults to "spin.toml" [default: spin.toml]
+
+    -h, --help
+            Print help information
+
+    -u, --up
+            Run the application after building
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -380,6 +454,12 @@ SUBCOMMANDS:
 {{ blockEnd }}
 
 {{ startTab "v1.3"}}
+
+The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-command-reference).
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
 
 The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-command-reference).
 
@@ -535,6 +615,12 @@ OPTIONS:
 {{ blockEnd }}
 
 {{ startTab "v1.3"}}
+
+The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-command-reference#spin-cloud-deploy).
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
 
 The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-command-reference#spin-cloud-deploy).
 
@@ -727,6 +813,12 @@ The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](../c
 
 {{ blockEnd }}
 
+{{ startTab "v1.4"}}
+
+The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-command-reference#spin-cloud-login).
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -740,12 +832,47 @@ The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](
 
 {{ blockEnd }}
 
+{{ startTab "v1.4"}}
+
+The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-command-reference#spin-cloud-variables).
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin deploy
 
 `spin deploy` is a shortcut to [`spin cloud deploy`](#spin-cloud-deploy).
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin doctor
+
+{{ tabs "spin-version" }}
+
+{{ startTab "v1.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin doctor --help
+
+spin-doctor 
+Detect and fix problems with Spin applications
+
+USAGE:
+    spin doctor [OPTIONS]
+
+OPTIONS:
+    -f, --from <APP_MANIFEST_FILE>    The application to check. This may be a manifest (spin.toml)
+                                      file, or a directory containing a spin.toml file. If omitted,
+                                      it defaults to "spin.toml" [default: spin.toml]
+    -h, --help                        Print help information
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin help
@@ -887,9 +1014,84 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin help
+
+The Spin CLI
+
+USAGE:
+    spin <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+SUBCOMMANDS:
+    add          Scaffold a new component into an existing application
+    build        Build the Spin application
+    cloud*       Commands for publishing applications to the Fermyon Cloud.
+    deploy       Package and upload an application to the Fermyon Cloud.
+    doctor       Detect and fix problems with Spin applications
+    help         Print this message or the help of the given subcommand(s)
+    js2wasm*     A plugin to convert js files to Spin compatible modules
+    login        Log into the Fermyon Cloud.
+    new          Scaffold a new application based on a template
+    plugins      Install/uninstall Spin plugins
+    py2wasm*     A plugin to convert Python applications to Spin compatible modules
+    registry     Commands for working with OCI registries to distribute applications
+    templates    Commands for working with WebAssembly component templates
+    up           Start the Spin application
+    watch        Build and run the Spin application, rebuilding and restarting it when files
+                     change
+
+* implemented via plugin
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 > Please note: Spin `help` is a convenient way to access help using a subcommand, instead of using the `--help` option. For example, `spin help cloud` will give you the same output as `spin cloud --help`. Similarly, `spin help build` will give you the same output as `spin build --help` and so forth.
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin js2wasm
+
+{{ tabs "spin-version" }}
+
+{{ startTab "v1.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin js2wasm --help
+
+js2wasm 0.4.0
+A spin plugin to convert javascript files to Spin compatible modules
+
+USAGE:
+    js2wasm [OPTIONS] <input>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -o <output>         [default: index.wasm]
+
+ARGS:
+    <input> 
+
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+> As denoted by the `*` when using the `spin --help` command, [js2wasm](/spin/javascript-components) is implemented via plugin. This is why `spin js2wasm --help` above shows slightly different commands (relative to the other commands that see on this page).
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin login
@@ -1041,6 +1243,41 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin new --help  
+
+spin-new 
+Scaffold a new application based on a template
+
+USAGE:
+    spin new [OPTIONS] [ARGS]
+
+ARGS:
+    <TEMPLATE_ID>    The template from which to create the new application or component. Run
+                     `spin templates list` to see available options
+    <NAME>           The name of the new application or component
+
+OPTIONS:
+    -a, --accept-defaults              An optional argument that allows to skip prompts for the
+                                       manifest file by accepting the defaults if available on the
+                                       template
+    -h, --help                         Print help information
+    -o, --output <OUTPUT_PATH>         The directory in which to create the new application or
+                                       component. The default is the name argument
+        --tag <TAGS>                   Filter templates to select by tags
+    -v, --value <VALUES>               Parameter values to be passed to the template (in name=value
+                                       format)
+        --values-file <VALUES_FILE>    A TOML file which contains parameter values in name = "value"
+                                       format. Parameters passed as CLI option overwrite parameters
+                                       specified in the file
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 **Please note: `spin new` vs `spin add`**.  These commands are similar except that:
@@ -1135,6 +1372,33 @@ SUBCOMMANDS:
 {{ blockEnd }}
 
 {{ startTab "v1.3"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins --help
+
+spin-plugins 
+Install/uninstall Spin plugins
+
+USAGE:
+    spin plugins <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    help         Print this message or the help of the given subcommand(s)
+    install      Install plugin from a manifest
+    list         List available or installed plugins
+    uninstall    Remove a plugin from your installation
+    update       Fetch the latest Spin plugins from the spin-plugins repository
+    upgrade      Upgrade one or all plugins
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
 
 <!-- @selectiveCpy -->
 
@@ -1332,6 +1596,47 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins install --help
+
+spin-plugins-install 
+Install plugin from a manifest.
+
+The binary file and manifest of the plugin is copied to the local Spin plugins directory.
+
+USAGE:
+    spin plugins install [OPTIONS] [PLUGIN_NAME]
+
+ARGS:
+    <PLUGIN_NAME>
+            Name of Spin plugin
+
+OPTIONS:
+    -f, --file <LOCAL_PLUGIN_MANIFEST>
+            Path to local plugin manifest
+
+    -h, --help
+            Print help information
+
+        --override-compatibility-check
+            Overrides a failed compatibility check of the plugin with the current version of Spin
+
+    -u, --url <REMOTE_PLUGIN_MANIFEST>
+            URL of remote plugin manifest to install
+
+    -v, --version <VERSION>
+            Specific version of a plugin to be install from the centralized plugins repository
+
+    -y, --yes
+            Skips prompt to accept the installation of the plugin
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -1400,6 +1705,26 @@ OPTIONS:
 {{ blockEnd }}
 
 {{ startTab "v1.3"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins list --help   
+
+spin-plugins-list 
+List available or installed plugins
+
+USAGE:
+    spin plugins list [OPTIONS]
+
+OPTIONS:
+    -h, --help         Print help information
+        --installed    List only installed plugins
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
 
 <!-- @selectiveCpy -->
 
@@ -1514,6 +1839,28 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins uninstall --help
+
+spin-plugins-uninstall 
+Remove a plugin from your installation
+
+USAGE:
+    spin plugins uninstall <NAME>
+
+ARGS:
+    <NAME>    Name of Spin plugin
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -1579,6 +1926,25 @@ OPTIONS:
 {{ blockEnd }}
 
 {{ startTab "v1.3"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins update --help   
+
+spin-plugins-update 
+Fetch the latest Spin plugins from the spin-plugins repository
+
+USAGE:
+    spin plugins update
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
 
 <!-- @selectiveCpy -->
 
@@ -1780,9 +2146,100 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins upgrade --help
+
+spin-plugins-upgrade 
+Upgrade one or all plugins
+
+USAGE:
+    spin plugins upgrade [OPTIONS] [PLUGIN_NAME]
+
+ARGS:
+    <PLUGIN_NAME>    Name of Spin plugin to upgrade
+
+OPTIONS:
+    -a, --all
+            Upgrade all plugins
+
+    -d, --downgrade
+            Allow downgrading a plugin's version
+
+    -f, --file <LOCAL_PLUGIN_MANIFEST>
+            Path to local plugin manifest
+
+    -h, --help
+            Print help information
+
+        --override-compatibility-check
+            Overrides a failed compatibility check of the plugin with the current version of Spin
+
+    -u, --url <REMOTE_PLUGIN_MANIFEST>
+            Path to remote plugin manifest
+
+    -v, --version <VERSION>
+            Specific version of a plugin to be install from the centralized plugins repository
+
+    -y, --yes
+            Skips prompt to accept the installation of the plugin[s]
+
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 **Note:** For additional information, please see the [Managing Plugins](/spin/managing-plugins) and/or [Creating Plugins](/spin/plugin-authoring) sections of the documentation.
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin py2wasm
+
+{{ tabs "spin-version" }}
+
+{{ startTab "v1.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin py2wasm --help
+
+A Spin plugin to convert Python apps to Spin-compatible WebAssembly modules
+
+Usage: py2wasm [OPTIONS] <APP_NAME>
+
+Arguments:
+  <APP_NAME>
+          The name of a Python module containing a `handle_request` function for handling Spin HTTP requests
+
+Options:
+  -p, --python-path <PYTHON_PATH>
+          `PYTHONPATH` for specifying directory containing the app and optionally other directories containing dependencies.
+          
+          If `pipenv` is in `$PATH` and `pipenv --venv` produces a path containing a `site-packages` subdirectory, that directory will be appended to this value as a convenience for `pipenv` users.
+          
+          [default: .]
+
+  -o, --output <OUTPUT>
+          Output file to write the resulting module to
+          
+          [default: index.wasm]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+> As denoted by the `*` when using the `spin --help` command, [py2wasm](/spin/python-components) is implemented via plugin. This is why `spin py2wasm --help` above shows slightly different commands (relative to the other commands that see on this page).
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin registry
@@ -1867,6 +2324,31 @@ SUBCOMMANDS:
 {{ blockEnd }}
 
 {{ startTab "v1.3"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry --help
+
+spin-registry 
+Commands for working with OCI registries to distribute applications
+
+USAGE:
+    spin registry <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    help     Print this message or the help of the given subcommand(s)
+    login    Log in to a registry
+    pull     Pull a Spin application from a registry
+    push     Push a Spin application to a registry
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
 
 <!-- @selectiveCpy -->
 
@@ -1998,6 +2480,31 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry login --help
+
+spin-registry-login 
+Log in to a registry
+
+USAGE:
+    spin registry login [OPTIONS] <SERVER>
+
+ARGS:
+    <SERVER>    
+
+OPTIONS:
+    -h, --help                   Print help information
+    -p, --password <PASSWORD>    Password for the registry
+        --password-stdin         Take the password from stdin
+    -u, --username <USERNAME>    Username for the registry
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -2075,6 +2582,29 @@ OPTIONS:
 {{ blockEnd }}
 
 {{ startTab "v1.3"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry pull --help
+
+spin-registry-pull 
+Pull a Spin application from a registry
+
+USAGE:
+    spin registry pull [OPTIONS] <REFERENCE>
+
+ARGS:
+    <REFERENCE>    Reference of the Spin application
+
+OPTIONS:
+    -h, --help        Print help information
+    -k, --insecure    Ignore server certificate errors
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
 
 <!-- @selectiveCpy -->
 
@@ -2204,6 +2734,32 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.4" }}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry push --help
+
+spin-registry-push
+Push a Spin application to a registry
+
+USAGE:
+    spin registry push [OPTIONS] <REFERENCE>
+
+ARGS:
+    <REFERENCE>    Reference of the Spin application
+
+OPTIONS:
+    -f, --from <APP_MANIFEST_FILE>    The application to push. This may be a manifest (spin.toml)
+                                      file, or a directory containing a spin.toml file. If omitted,
+                                      it defaults to "spin.toml" [default: spin.toml]
+    -h, --help                        Print help information
+    -k, --insecure                    Ignore server certificate errors
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -2264,6 +2820,32 @@ SUBCOMMANDS:
 {{ blockEnd }}
 
 {{ startTab "v1.2"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates --help    
+
+spin-templates 
+Commands for working with WebAssembly component templates
+
+USAGE:
+    spin templates <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    help         Print this message or the help of the given subcommand(s)
+    install      Install templates from a Git repository or local directory
+    list         List the installed templates
+    uninstall    Remove a template from your installation
+    upgrade      Upgrade templates to match your current version of Spin
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3"}}
 
 <!-- @selectiveCpy -->
 
@@ -2466,6 +3048,42 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates install --help
+
+spin-templates-install 
+Install templates from a Git repository or local directory.
+
+The files of the templates are copied to the local template store: a directory in your data or home
+directory.
+
+USAGE:
+    spin templates install [OPTIONS]
+
+OPTIONS:
+        --branch <BRANCH>
+            The optional branch of the git repository
+
+        --dir <FROM_DIR>
+            Local directory containing the template(s) to install
+
+        --git <FROM_GIT>
+            The URL of the templates git repository. The templates must be in a git repository in a
+            "templates" directory
+
+    -h, --help
+            Print help information
+
+        --upgrade
+            If present, updates existing templates instead of skipping
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -2537,6 +3155,27 @@ OPTIONS:
 {{ blockEnd }}
 
 {{ startTab "v1.3"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates list --help   
+
+spin-templates-list 
+List the installed templates
+
+USAGE:
+    spin templates list [OPTIONS]
+
+OPTIONS:
+    -h, --help          Print help information
+        --tag <TAGS>    Filter templates matching all provided tags
+        --verbose       Whether to show additional template details in the list
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
 
 <!-- @selectiveCpy -->
 
@@ -2633,6 +3272,28 @@ OPTIONS:
 {{ blockEnd }}
 
 {{ startTab "v1.3"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates uninstall --help
+
+spin-templates-uninstall 
+Remove a template from your installation
+
+USAGE:
+    spin templates uninstall <TEMPLATE_ID>
+
+ARGS:
+    <TEMPLATE_ID>    The template to uninstall
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
 
 <!-- @selectiveCpy -->
 
@@ -2767,6 +3428,41 @@ OPTIONS:
 {{ blockEnd }}
 
 {{ startTab "v1.3"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates upgrade --help  
+
+spin-templates-upgrade 
+Upgrade templates to match your current version of Spin.
+
+The files of the templates are copied to the local template store: a directory in your data or home
+directory.
+
+USAGE:
+    spin templates upgrade [OPTIONS]
+
+OPTIONS:
+        --all
+            By default, Spin displays the list of installed repositories and prompts you to choose
+            which to upgrade.  Pass this flag to upgrade all repositories without prompting
+
+        --branch <BRANCH>
+            The optional branch of the git repository, if a specific repository is given
+
+    -h, --help
+            Print help information
+
+        --repo <GIT_URL>
+            By default, Spin displays the list of installed repositories and prompts you to choose
+            which to upgrade.  Pass this flag to upgrade only the specified repository without
+            prompting
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
 
 <!-- @selectiveCpy -->
 
@@ -3058,6 +3754,77 @@ TRIGGER OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin up --help
+
+spin-up 
+Start the Spin application
+
+USAGE:
+    spin up [OPTIONS]
+
+OPTIONS:
+        --direct-mounts         For local apps with directory mounts and no excluded files, mount
+                                them directly instead of using a temporary directory
+    -e, --env <ENV>             Pass an environment variable (key=value) to all components of the
+                                application
+    -f, --from <APPLICATION>    The application to run. This may be a manifest (spin.toml) file, a
+                                directory containing a spin.toml file, or a remote registry
+                                reference. If omitted, it defaults to "spin.toml"
+    -h, --help                  
+    -k, --insecure              Ignore server certificate errors from bindle server or registry
+        --temp <TMP>            Temporary directory for the static assets of the components
+
+TRIGGER OPTIONS:
+        --allow-transient-write
+            Set the static assets of the components in the temporary directory as writable
+
+        --cache <WASMTIME_CACHE_FILE>
+            Wasmtime cache configuration file
+            
+            [env: WASMTIME_CACHE_FILE=]
+
+        --disable-cache
+            Disable Wasmtime cache
+            
+            [env: DISABLE_WASMTIME_CACHE=]
+
+        --follow <FOLLOW_ID>
+            Print output to stdout/stderr only for given component(s)
+
+        --key-value <KEY_VALUES>
+            Set a key/value pair (key=value) in the application's default store. Any existing value
+            will be overwritten. Can be used multiple times
+
+    -L, --log-dir <APP_LOG_DIR>
+            Log directory for the stdout and stderr of components
+
+    -q, --quiet
+            Silence all component output to stdout/stderr
+
+        --runtime-config-file <RUNTIME_CONFIG_FILE>
+            Configuration file for config providers and wasmtime config
+            
+            [env: RUNTIME_CONFIG_FILE=]
+
+        --sqlite <SQLITE_STATEMENTS>
+            Run a SQLite statement such as a migration against the default database. To run from a
+            file, prefix the filename with @ e.g. spin up --sqlite @migration.sql
+
+        --state-dir <STATE_DIR>
+            Set the application state directory path. This is used in the default locations for
+            logs, key value stores, etc.
+            
+            For local apps, this defaults to `.spin/` relative to the `spin.toml` file. For remote
+            apps, this has no default (unset). Passing an empty value forces the value to be unset.
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 > **Please note:** If the `-f` or `--from` options do not accurately infer the intended registry or `.toml` file for your application, then you can explicitly specify either the `--from-registry` or  `--from-file` options to clarify this.
@@ -3145,6 +3912,31 @@ The following additional trigger options are available for the [spin up](#spin-u
 {{ blockEnd }}
 
 {{ startTab "v1.3"}}
+
+<!-- @selectiveCpy -->
+
+```console
+    --listen <ADDRESS>
+        IP address and port to listen on
+
+        [default: 127.0.0.1:3000]
+
+    --tls-cert <TLS_CERT>
+        The path to the certificate to use for https, if this is not set, normal http will be
+        used. The cert should be in PEM format
+
+        [env: SPIN_TLS_CERT=]
+
+    --tls-key <TLS_KEY>
+        The path to the certificate key to use for https, if this is not set, normal http will
+        be used. The key should be in PKCS#8 format
+
+        [env: SPIN_TLS_KEY=]
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
 
 <!-- @selectiveCpy -->
 
@@ -3264,6 +4056,36 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin watch --help
+
+spin-watch 
+Build and run the Spin application, rebuilding and restarting it when files change
+
+USAGE:
+    spin watch [OPTIONS] [UP_ARGS]...
+
+ARGS:
+    <UP_ARGS>...    Arguments to be passed through to spin up
+
+OPTIONS:
+    -c, --clear                       Clear the screen before each run
+    -d, --debounce <DEBOUNCE>         Set the timeout between detected change and re-execution, in
+                                      milliseconds [default: 100]
+    -f, --from <APP_MANIFEST_FILE>    The application to watch. This may be a manifest (spin.toml)
+                                      file, or a directory containing a spin.toml file. If omitted,
+                                      it defaults to "spin.toml" [default: spin.toml]
+    -h, --help                        Print help information
+        --skip-build                  Only run the Spin application, restarting it when build
+                                      artifacts change
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 ## Stability Table
@@ -3339,6 +4161,24 @@ CLI commands have four phases that indicate levels of stability:
 | <code>spin up</code>                                                                  | Stable       |
 | <code>spin cloud <deploy&vert;login></code>                                           | Stabilizing  |
 | <code>spin registry</code>                                                            | Stabilizing  |
+| <code>spin watch</code>                                                               | Experimental |
+| <code>spin bindle <prepare&vert;push></code>                                          | Deprecated   |
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
+
+| Command                                                                               | Stability    |
+| ------------------------------------------------------------------------------------- | ------------ |
+| <code>spin add</code>                                                                 | Stable       |
+| <code>spin build</code>                                                               | Stable       |
+| <code>spin new</code>                                                                 | Stable       |
+| <code>spin plugins <install&vert;list&vert;uninstall&vert;update&vert;upgrade></code> | Stable       |
+| <code>spin templates <install&vert;list&vert;uninstall&vert;upgrade></code>           | Stable       |
+| <code>spin up</code>                                                                  | Stable       |
+| <code>spin cloud <deploy&vert;login></code>                                           | Stabilizing  |
+| <code>spin registry</code>                                                            | Stabilizing  |
+| <code>spin doctor</code>                                                              | Experimental |
 | <code>spin watch</code>                                                               | Experimental |
 | <code>spin bindle <prepare&vert;push></code>                                          | Deprecated   |
 


### PR DESCRIPTION
Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)

<img width="1271" alt="Screenshot 2023-07-11 at 2 16 54 pm" src="https://github.com/fermyon/developer/assets/9831342/96b37699-c571-4dde-b4ff-6969572b877f">

- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)

![Screenshot 2023-07-11 at 2 17 24 pm](https://github.com/fermyon/developer/assets/9831342/43f72694-e96d-4c99-bf59-2f01ff10ee1c)

- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors

<img width="673" alt="Screenshot 2023-07-11 at 2 19 38 pm" src="https://github.com/fermyon/developer/assets/9831342/7125cc1f-c6b0-4da6-a37d-a7e86a3f1363">

- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
