### PR TITLE
added go env variable in the doc

### DIFF
--- a/content/spin/quickstart.md
+++ b/content/spin/quickstart.md
@@ -740,6 +740,7 @@ If the build fails, check:
 * Are you in the `hello_go` directory?
 * Did you successfully [install TinyGo](#install-the-tools)?
 * Are your versions of Go and TinyGo up to date?  The Spin SDK needs TinyGo 0.27 or above.
+* Set Environment Variable `CGO_ENABLED=1`. (Since the Go SDK is built using CGO, it requires the CGO_ENABLED=1 environment variable to be set.)
 
 If you would like to know what build command Spin runs for a component, you can find it in the manifest, in the `component.build` section:
 


### PR DESCRIPTION
Content must go through a pre-merge checklist.
## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.

Related content:
https://github.com/fermyon/developer/issues/520
https://github.com/fermyon/developer/issues/222
