### PR TITLE
add info for AKS lower spin version

### DIFF
--- a/content/spin/kubernetes.md
+++ b/content/spin/kubernetes.md
@@ -73,6 +73,7 @@ Azure AKS provides a straightforward and officially [documented](https://learn.m
 - The *os-type* for WASM/WASI node pools must be Linux.
 - You can't use the Azure portal to create WASM/WASI node pools.
 - AKS uses an older version of Spin for the shim, so you will need to change `spin_manifest_version` to `spin_version` in `spin.toml` if you are using a template-generated project from the Spin CLI
+- The RuntimeClass `wasmtime-spin-v0-5-1` on Azure maps to spin v1.0.0, and the `wasmtime-spin-v1` RuntimeClass uses an older shim corresponding to v0.3.0 spin.
 
 #### Note for Rust
 

--- a/content/spin/kubernetes.md
+++ b/content/spin/kubernetes.md
@@ -72,6 +72,10 @@ Azure AKS provides a straightforward and officially [documented](https://learn.m
 - The WASM/WASI node pools can't be used for system node pool.
 - The *os-type* for WASM/WASI node pools must be Linux.
 - You can't use the Azure portal to create WASM/WASI node pools.
+- AKS uses an older version of Spin for the shim, so you will need to change `spin_manifest_version` to `spin_version` in `spin.toml` if you are using a template-generated project from the Spin CLI
+
+#### Note for Rust
+In Cargo.toml, the `spin-sdk` dependency should be downgraded to `v1.0.0-rc.1` in order to match the lower version running on the AKS shim
 
 ### Setup
 

--- a/content/spin/kubernetes.md
+++ b/content/spin/kubernetes.md
@@ -75,6 +75,7 @@ Azure AKS provides a straightforward and officially [documented](https://learn.m
 - AKS uses an older version of Spin for the shim, so you will need to change `spin_manifest_version` to `spin_version` in `spin.toml` if you are using a template-generated project from the Spin CLI
 
 #### Note for Rust
+
 In Cargo.toml, the `spin-sdk` dependency should be downgraded to `v1.0.0-rc.1` in order to match the lower version running on the AKS shim
 
 ### Setup


### PR DESCRIPTION
after a ton of debugging i finally found out why my rust project won't run, and it's due to a lower version of Spin on AKS.

Repro:
Generate a spin rust http project with `spin new` and deploy it to AKS following the current guide

Every http request returns a 500 status code, and no logs are produced. Downgrading to the supported spin sdk version fixes this for rust

Content must go through a pre-merge checklist.

> #730  I notice that in this [article](https://developer.fermyon.com/spin/kubernetes), it uses the wasmtime-spin-v1 runtime class to refer to the AKS node's runtime handler. However, this runtime handler is using a older version of Spin v0.3.0. I would recommend to this to wasmtime-spin-v0-5-1 which uses the v0.5.1 spin shim binary that uses v1.0 spin.

ref: https://github.com/fermyon/spin/issues/1638

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors
- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
