### PR TITLE
Fix old type name in Rust SQLite docs

### DIFF
--- a/content/spin/sqlite-api-guide.md
+++ b/content/spin/sqlite-api-guide.md
@@ -6,14 +6,24 @@ enable_shortcodes = true
 url = "https://github.com/fermyon/developer/blob/main/content/spin/sqlite-api-guide.md"
 
 ---
+- [Granting SQLite Database Permissions to Components](#granting-sqlite-database-permissions-to-components)
 - [Using SQLite Storage From Applications](#using-sqlite-storage-from-applications)
 - [Preparing an SQLite Database](#preparing-an-sqlite-database)
 - [Custom SQLite Databases](#custom-sqlite-databases)
-- [Granting SQLite Database Permissions to Components](#granting-sqlite-database-permissions-to-components)
+  - [Granting Access to Custom SQLite Databases](#granting-access-to-custom-sqlite-databases)
 
 Spin provides an interface for you to persist data in an SQLite database managed by Spin. This database allows Spin developers to persist relational data across application invocations.
 
 {{ details "Why do I need a Spin interface? Why can't I just use my own external database?" "You can absolutely still use your own external database either with the [MySQL or Postgres APIs](/spin/rdbms-storage). However, if you're interested in quick, local relational storage without any infrastructure set-up then Spin's SQLite database is a great option." }}
+
+## Granting SQLite Database Permissions to Components
+
+By default, a given component of an app will not have access to any SQLite databases. Access must be granted specifically to each component via the component manifest.  For example, a component could be given access to the default store using:
+
+```toml
+[component]
+sqlite_databases = ["default"]
+```
 
 ## Using SQLite Storage From Applications
 
@@ -174,16 +184,11 @@ You can provide the `--sqlite` flag more than once; Spin runs the statements (or
 
 Spin defines a database named `"default"` and provides automatic backing storage.  If you need to customize Spin with additional databases, or to change the backing storage for the default database, you can do so via the `--runtime-config-file` flag and the `runtime-config.toml` file.  See [SQLite Database Runtime Configuration](/spin/dynamic-configuration#sqlite-storage-runtime-configuration) for details.
 
-## Granting SQLite Database Permissions to Components
+### Granting Access to Custom SQLite Databases
 
-By default, a given component of an app will not have access to any SQLite databases. Access must be granted specifically to each component via the component manifest.  For example, a component could be given access to the default store using:
+As mentioned above, by default, a given component of an app will not have access to any SQLite databases. Access must be granted specifically to each component via the component manifest, using the `component.sqlite_databases` field in the manifest.
 
-```toml
-[component]
-sqlite_databases = ["default"]
-```
-
-Components can be given access to different databases:
+Components can be given access to different databases, and may be granted access to more than one database. For example:
 
 ```toml
 # c1 has no access to any databases

--- a/content/spin/sqlite-api-guide.md
+++ b/content/spin/sqlite-api-guide.md
@@ -41,7 +41,7 @@ use serde::Serialize;
 use spin_sdk::{
     http::{Request, Response},
     http_component,
-    sqlite::{DataTypeParam, Error, Connection},
+    sqlite::{Connection, Error, ValueParam},
 };
 
 #[http_component]
@@ -62,13 +62,13 @@ fn handle_request(req: Request) -> Result<Response> {
         &[]
     )?;
 
-    let todos = rowset.rows().map(|row|
+    let todos: Vec<_> = rowset.rows().map(|row|
         ToDo {
             id: row.get::<u32>("id").unwrap(),
             description: row.get::<&str>("description").unwrap().to_owned(),
             due: row.get::<&str>("due").unwrap().to_owned(),
         }
-    );
+    ).collect();
 
     let body = serde_json::to_vec(&todos)?;
     Ok(http::Response::builder().status(200).body(Some(body.into()))?)

--- a/content/spin/sqlite-api-guide.md
+++ b/content/spin/sqlite-api-guide.md
@@ -34,7 +34,7 @@ The set of operations is common across all SDKs:
 | Operation  | Parameters | Returns | Behavior |
 |------------|------------|---------|----------|
 | `open`  | name | connection  | Open the database with the specified name. If `name` is the string "default", the default database is opened, provided that the component that was granted access in the component manifest from `spin.toml`. Otherwise, `name` must refer to a store defined and configured in a [runtime configuration file](/spin/dynamic-configuration.md#sqlite-storage-runtime-configuration) supplied with the application.|
-| `execute` | connection, sql, parameters | database records | Executes the SQL statement and returns the results of the statement. SELECT statements typically return records or scalars. INSERT, UPDATE, and DELETE statements typically return empty result sets, but may return values in some cases. |
+| `execute` | connection, sql, parameters | database records | Executes the SQL statement and returns the results of the statement. SELECT statements typically return records or scalars. INSERT, UPDATE, and DELETE statements typically return empty result sets, but may return values in some cases. The `execute` operation recognizes the [SQLite dialect of SQL](https://www.sqlite.org/lang.html). |
 | `close` | connection | - | Close the specified `connection`. |
 
 The exact detail of calling these operations from your application depends on your language:
@@ -175,6 +175,8 @@ Or you can pass SQL statements directly on the command line as a (quoted) string
 ```bash
 spin up --sqlite "CREATE TABLE IF NOT EXISTS todos (id INTEGER PRIMARY KEY AUTOINCREMENT, description TEXT NOT NULL, due TEXT NOT NULL)"
 ```
+
+As with runtime operations, this flag uses the [SQLite dialect of SQL](https://www.sqlite.org/lang.html).
 
 You can provide the `--sqlite` flag more than once; Spin runs the statements (or files) in the order you provide them, and waits for each to complete before running the next.
 


### PR DESCRIPTION
Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)

<img width="666" alt="Screenshot 2023-07-25 at 3 18 32 pm" src="https://github.com/fermyon/developer/assets/9831342/13edac3b-0a1d-4420-b278-754e0057a7f6">

- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)

![Screenshot 2023-07-25 at 3 18 22 pm](https://github.com/fermyon/developer/assets/9831342/09e9cd50-4854-4cf7-9c99-d9272d1f9ce2)

- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors
- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
