### PR TITLE
Add Spin Cloud SQLite Reference (v0.1.2)

### DIFF
--- a/content/cloud/cloud-command-reference.md
+++ b/content/cloud/cloud-command-reference.md
@@ -11,6 +11,10 @@ url = "https://github.com/fermyon/developer/blob/main/content/cloud/cloud-comman
 - [spin cloud deploy](#spin-cloud-deploy)
 - [spin cloud help](#spin-cloud-help)
 - [spin cloud login](#spin-cloud-login)
+- [spin cloud sqlite](#spin-cloud-sqlite)
+- [spin cloud sqlite delete](#spin-cloud-sqlite-delete)
+- [spin cloud sqlite help](#spin-cloud-sqlite-help)
+- [spin cloud sqlite list](#spin-cloud-sqlite-list)
 - [spin cloud variables](#spin-cloud-variables)
 - [spin cloud variables delete](#spin-cloud-variables-delete)
 - [spin cloud variables help](#spin-cloud-variables-help)
@@ -205,6 +209,148 @@ OPTIONS:
 {{ blockEnd }}
 
 {{ blockEnd }}
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin cloud sqlite
+
+{{ tabs "cloud-plugin-version" }}
+
+{{ startTab "v0.1.1"}}
+
+Spin compatibility: `>= v1.3`
+
+<!-- @selectiveCpy -->
+```console
+$ spin cloud sqlite --help 
+
+cloud-sqlite 0.1.1 
+Manage Fermyon Cloud SQLite databases
+
+USAGE:
+    spin cloud sqlite <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+SUBCOMMANDS:
+    delete    Delete a SQLite database
+    help      Print this message or the help of the given subcommand(s)
+    list      List all SQLite databases of a user
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }} 
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin cloud sqlite delete
+
+{{ tabs "cloud-plugin-version" }}
+
+{{ startTab "v0.1.1"}}
+
+Spin compatibility: `>= v1.3`
+
+<!-- @selectiveCpy -->
+```console
+$ spin cloud sqlite delete --help
+
+cloud-sqlite-delete 0.1.1 
+Delete a SQLite database
+
+USAGE:
+    spin cloud sqlite delete [OPTIONS] <NAME>
+
+ARGS:
+    <NAME>    Name of database to delete
+
+OPTIONS:
+        --environment-name <environment-name>
+            Deploy to the Fermyon instance saved under the specified name. If omitted, Spin deploys
+            to the default unnamed instance [env: FERMYON_DEPLOYMENT_ENVIRONMENT=]
+
+    -h, --help
+            Print help information
+
+    -V, --version
+            Print version information
+
+    -y, --yes
+            Skips prompt to confirm deletion of database
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }} 
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin cloud sqlite help 
+
+{{ tabs "cloud-plugin-version" }}
+
+{{ startTab "v0.1.1"}}
+
+Spin compatibility: `>= v1.3`
+
+<!-- @selectiveCpy -->
+```console
+$ spin cloud sqlite help     
+
+cloud-sqlite 0.1.1 
+Manage Fermyon Cloud SQLite databases
+
+USAGE:
+    spin cloud sqlite <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+SUBCOMMANDS:
+    delete    Delete a SQLite database
+    help      Print this message or the help of the given subcommand(s)
+    list      List all SQLite databases of a user
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }} 
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin cloud sqlite list
+
+{{ tabs "cloud-plugin-version" }}
+
+{{ startTab "v0.1.1"}}
+
+Spin compatibility: `>= v1.3`
+
+<!-- @selectiveCpy -->
+```console
+$ spin cloud sqlite list --help
+
+cloud-sqlite-list 0.1.1 
+List all SQLite databases of a user
+
+USAGE:
+    spin cloud sqlite list [OPTIONS]
+
+OPTIONS:
+        --environment-name <environment-name>
+            Deploy to the Fermyon instance saved under the specified name. If omitted, Spin deploys
+            to the default unnamed instance [env: FERMYON_DEPLOYMENT_ENVIRONMENT=]
+
+    -h, --help
+            Print help information
+
+    -V, --version
+            Print version information
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }} 
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin cloud variables

--- a/content/cloud/cloud-command-reference.md
+++ b/content/cloud/cloud-command-reference.md
@@ -13,6 +13,7 @@ url = "https://github.com/fermyon/developer/blob/main/content/cloud/cloud-comman
 - [spin cloud login](#spin-cloud-login)
 - [spin cloud sqlite](#spin-cloud-sqlite)
 - [spin cloud sqlite delete](#spin-cloud-sqlite-delete)
+- [spin cloud sqlite execute](#spin-cloud-sqlite-execute)
 - [spin cloud sqlite help](#spin-cloud-sqlite-help)
 - [spin cloud sqlite list](#spin-cloud-sqlite-list)
 - [spin cloud variables](#spin-cloud-variables)
@@ -56,6 +57,14 @@ SUBCOMMANDS:
     login        Login to Fermyon Cloud
     variables    Manage Spin application variables
 ```
+
+{{ blockEnd }}
+
+{{ startTab "v0.1.2"}}
+
+Spin compatibility: `>= v1.3`
+
+<!-- @selectiveCpy -->
 
 {{ blockEnd }}
 
@@ -122,6 +131,14 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v0.1.2"}}
+
+Spin compatibility: `>= v1.3`
+
+<!-- @selectiveCpy -->
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -151,6 +168,14 @@ SUBCOMMANDS:
     login        Login to Fermyon Cloud
     variables    Manage Spin application variables
 ```
+
+{{ blockEnd }}
+
+{{ startTab "v0.1.2"}}
+
+Spin compatibility: `>= v1.3`
+
+<!-- @selectiveCpy -->
 
 {{ blockEnd }}
 
@@ -208,6 +233,14 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v0.1.2"}}
+
+Spin compatibility: `>= v1.3`
+
+<!-- @selectiveCpy -->
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -215,15 +248,16 @@ OPTIONS:
 
 {{ tabs "cloud-plugin-version" }}
 
-{{ startTab "v0.1.1"}}
+{{ startTab "v0.1.2"}}
 
 Spin compatibility: `>= v1.3`
 
 <!-- @selectiveCpy -->
-```console
-$ spin cloud sqlite --help 
 
-cloud-sqlite 0.1.1 
+```console
+$ spin cloud sqlite --help
+
+cloud-sqlite 0.1.2
 Manage Fermyon Cloud SQLite databases
 
 USAGE:
@@ -234,29 +268,31 @@ OPTIONS:
     -V, --version    Print version information
 
 SUBCOMMANDS:
-    delete    Delete a SQLite database
-    help      Print this message or the help of the given subcommand(s)
-    list      List all SQLite databases of a user
+    delete     Delete a SQLite database
+    execute    Execute SQL against a SQLite database
+    help       Print this message or the help of the given subcommand(s)
+    list       List all SQLite databases of a user
 ```
 
 {{ blockEnd }}
 
-{{ blockEnd }} 
+{{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin cloud sqlite delete
 
 {{ tabs "cloud-plugin-version" }}
 
-{{ startTab "v0.1.1"}}
+{{ startTab "v0.1.2"}}
 
 Spin compatibility: `>= v1.3`
 
 <!-- @selectiveCpy -->
+
 ```console
 $ spin cloud sqlite delete --help
 
-cloud-sqlite-delete 0.1.1 
+cloud-sqlite-delete 0.1.2
 Delete a SQLite database
 
 USAGE:
@@ -282,22 +318,63 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ blockEnd }} 
+{{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
-## spin cloud sqlite help 
+## spin cloud sqlite execute
 
 {{ tabs "cloud-plugin-version" }}
 
-{{ startTab "v0.1.1"}}
+{{ startTab "v0.1.2"}}
 
 Spin compatibility: `>= v1.3`
 
 <!-- @selectiveCpy -->
-```console
-$ spin cloud sqlite help     
 
-cloud-sqlite 0.1.1 
+```console
+$ spin cloud sqlite execute --help
+
+cloud-sqlite-execute 0.1.2
+Execute SQL against a SQLite database
+
+USAGE:
+    spin cloud sqlite execute [OPTIONS] <NAME> <STATEMENT>
+
+ARGS:
+    <NAME>         Name of database to execute against
+    <STATEMENT>    Statement to execute
+
+OPTIONS:
+        --environment-name <environment-name>
+            Deploy to the Fermyon instance saved under the specified name. If omitted, Spin deploys
+            to the default unnamed instance [env: FERMYON_DEPLOYMENT_ENVIRONMENT=]
+
+    -h, --help
+            Print help information
+
+    -V, --version
+            Print version information
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin cloud sqlite help
+
+{{ tabs "cloud-plugin-version" }}
+
+{{ startTab "v0.1.2"}}
+
+Spin compatibility: `>= v1.3`
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin cloud sqlite help    
+
+cloud-sqlite 0.1.2
 Manage Fermyon Cloud SQLite databases
 
 USAGE:
@@ -308,29 +385,31 @@ OPTIONS:
     -V, --version    Print version information
 
 SUBCOMMANDS:
-    delete    Delete a SQLite database
-    help      Print this message or the help of the given subcommand(s)
-    list      List all SQLite databases of a user
+    delete     Delete a SQLite database
+    execute    Execute SQL against a SQLite database
+    help       Print this message or the help of the given subcommand(s)
+    list       List all SQLite databases of a user
 ```
 
 {{ blockEnd }}
 
-{{ blockEnd }} 
+{{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin cloud sqlite list
 
 {{ tabs "cloud-plugin-version" }}
 
-{{ startTab "v0.1.1"}}
+{{ startTab "v0.1.2"}}
 
 Spin compatibility: `>= v1.3`
 
 <!-- @selectiveCpy -->
+
 ```console
 $ spin cloud sqlite list --help
 
-cloud-sqlite-list 0.1.1 
+cloud-sqlite-list 0.1.2
 List all SQLite databases of a user
 
 USAGE:
@@ -350,7 +429,7 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ blockEnd }} 
+{{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin cloud variables
@@ -381,6 +460,14 @@ SUBCOMMANDS:
     list      List all variables of an application
     set       Set variable pairs
 ```
+
+{{ blockEnd }}
+
+{{ startTab "v0.1.2"}}
+
+Spin compatibility: `>= v1.3`
+
+<!-- @selectiveCpy -->
 
 {{ blockEnd }}
 
@@ -425,6 +512,14 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v0.1.2"}}
+
+Spin compatibility: `>= v1.3`
+
+<!-- @selectiveCpy -->
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -457,6 +552,14 @@ SUBCOMMANDS:
     list      List all variables of an application
     set       Set variables
 ```
+
+{{ blockEnd }}
+
+{{ startTab "v0.1.2"}}
+
+Spin compatibility: `>= v1.3`
+
+<!-- @selectiveCpy -->
 
 {{ blockEnd }}
 
@@ -495,6 +598,14 @@ OPTIONS:
     -V, --version
             Print version information
 ```
+
+{{ blockEnd }}
+
+{{ startTab "v0.1.2"}}
+
+Spin compatibility: `>= v1.3`
+
+<!-- @selectiveCpy -->
 
 {{ blockEnd }}
 
@@ -539,6 +650,14 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v0.1.2"}}
+
+Spin compatibility: `>= v1.3`
+
+<!-- @selectiveCpy -->
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 ## Subcommand Stability Table
@@ -561,6 +680,19 @@ Spin compatibility: `>= v1.3`
 | <code>cloud deploy</code>                                  | Stabilizing |
 | <code>cloud login</code>                                   | Stabilizing |
 | <code>cloud variables</code>                               | Stabilizing |
+
+{{ blockEnd }}
+
+{{ startTab "v0.1.2"}}
+
+Spin compatibility: `>= v1.3`
+
+| Command                                                    | Stability   |
+| ---------------------------------------------------------- | ----------- |
+| <code>cloud deploy</code>                                  |             |
+| <code>cloud login</code>                                   |             |
+| <code>cloud sqlite</code>                                  |             |
+| <code>cloud variables</code>                               |             |
 
 {{ blockEnd }}
 

--- a/content/cloud/cloud-command-reference.md
+++ b/content/cloud/cloud-command-reference.md
@@ -37,12 +37,8 @@ Fermyon provides a [`cloud` plugin](https://github.com/fermyon/cloud-plugin) for
 Spin compatibility: `>= v1.3`
 
 <!-- @selectiveCpy -->
-
 ```console
 $ spin cloud --help
-
-cloud-plugin 0.1.1
-Fermyon Engineering <engineering@fermyon.com>
 
 USAGE:
     cloud <SUBCOMMAND>
@@ -65,6 +61,24 @@ SUBCOMMANDS:
 Spin compatibility: `>= v1.3`
 
 <!-- @selectiveCpy -->
+```console
+$ spin cloud --help
+
+USAGE:
+    spin cloud <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+SUBCOMMANDS:
+    deploy       Package and upload an application to the Fermyon Cloud
+    help         Print this message or the help of the given subcommand(s)
+    login        Login to Fermyon Cloud
+    sqlite       Manage Fermyon Cloud SQLite databases
+    variables    Manage Spin application variables
+
+```
 
 {{ blockEnd }}
 
@@ -83,7 +97,6 @@ Spin compatibility: `>= v1.3`
 ```console
 $ spin cloud deploy --help
 
-cloud-deploy 0.1.1
 Package and upload an application to the Fermyon Cloud
 
 USAGE:
@@ -136,6 +149,53 @@ OPTIONS:
 Spin compatibility: `>= v1.3`
 
 <!-- @selectiveCpy -->
+```console
+$ spin cloud deploy --help
+
+Package and upload an application to the Fermyon Cloud
+
+USAGE:
+    spin cloud deploy [OPTIONS]
+
+OPTIONS:
+        --buildinfo <BUILDINFO>
+            Build metadata to append to the bindle version
+
+    -d, --staging-dir <STAGING_DIR>
+            Path to assemble the bindle before pushing (defaults to a temporary directory)
+
+    -e, --deploy-existing-bindle
+            Deploy existing bindle if it already exists on bindle server
+
+        --environment-name <environment-name>
+            Deploy to the Fermyon instance saved under the specified name. If omitted, Spin deploys
+            to the default unnamed instance [env: FERMYON_DEPLOYMENT_ENVIRONMENT=]
+
+    -f, --from <APP_MANIFEST_FILE>
+            The application to deploy. This may be a manifest (spin.toml) file, or a directory
+            containing a spin.toml file. If omitted, it defaults to "spin.toml" [default: spin.toml]
+
+    -h, --help
+            Print help information
+
+        --key-value <KEY_VALUES>
+            Set a key/value pair (key=value) in the deployed application's default store. Any
+            existing value will be overwritten. Can be used multiple times
+
+        --no-buildinfo
+            Disable attaching buildinfo [env: SPIN_DEPLOY_NO_BUILDINFO=]
+
+        --readiness-timeout <READINESS_TIMEOUT_SECS>
+            How long in seconds to wait for a deployed HTTP application to become ready. The default
+            is 60 seconds. Set it to 0 to skip waiting for readiness [default: 60]
+
+    -V, --version
+            Print version information
+
+        --variable <VARIABLES>
+            Set a variable (variable=value) in the deployed application. Any existing value will be
+            overwritten. Can be used multiple times
+```
 
 {{ blockEnd }}
 
@@ -151,9 +211,6 @@ Spin compatibility: `>= v1.3`
 <!-- @selectiveCpy -->
 ```console
 $ spin cloud help
-
-cloud-plugin 0.1.1
-Fermyon Engineering <engineering@fermyon.com>
 
 USAGE:
     cloud <SUBCOMMAND>
@@ -176,6 +233,23 @@ SUBCOMMANDS:
 Spin compatibility: `>= v1.3`
 
 <!-- @selectiveCpy -->
+```console
+$ spin cloud help
+
+USAGE:
+    spin cloud <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+SUBCOMMANDS:
+    deploy       Package and upload an application to the Fermyon Cloud
+    help         Print this message or the help of the given subcommand(s)
+    login        Login to Fermyon Cloud
+    sqlite       Manage Fermyon Cloud SQLite databases
+    variables    Manage Spin application variables
+```
 
 {{ blockEnd }}
 
@@ -194,7 +268,6 @@ Spin compatibility: `>= v1.3`
 ```console
 $ spin cloud login --help
 
-cloud-login 0.1.1
 Login to Fermyon Cloud
 
 USAGE:
@@ -238,6 +311,42 @@ OPTIONS:
 Spin compatibility: `>= v1.3`
 
 <!-- @selectiveCpy -->
+```console
+$ spin cloud login --help
+
+USAGE:
+    spin cloud login [OPTIONS]
+
+OPTIONS:
+        --auth-method <auth-method>
+            [env: AUTH_METHOD=] [possible values: github, token]
+
+        --environment-name <environment-name>
+            Save the login details under the specified name instead of making them the default. Use
+            named environments with `spin deploy --environment-name <name>` [env:
+            FERMYON_DEPLOYMENT_ENVIRONMENT=]
+
+    -h, --help
+            Print help information
+
+    -k, --insecure
+            Ignore server certificate errors
+
+        --list
+            List saved logins
+
+        --status
+            Display login status
+
+        --token <TOKEN>
+            Auth Token [env: SPIN_AUTH_TOKEN=]
+
+        --url <CLOUD_SERVER_URL>
+            URL of Fermyon Cloud Instance [env: CLOUD_URL=] [default: https://cloud.fermyon.com/]
+
+    -V, --version
+            Print version information
+```
 
 {{ blockEnd }}
 
@@ -253,7 +362,6 @@ Spin compatibility: `>= v1.3`
 Spin compatibility: `>= v1.3`
 
 <!-- @selectiveCpy -->
-
 ```console
 $ spin cloud sqlite --help
 
@@ -288,7 +396,6 @@ SUBCOMMANDS:
 Spin compatibility: `>= v1.3`
 
 <!-- @selectiveCpy -->
-
 ```console
 $ spin cloud sqlite delete --help
 
@@ -330,7 +437,6 @@ OPTIONS:
 Spin compatibility: `>= v1.3`
 
 <!-- @selectiveCpy -->
-
 ```console
 $ spin cloud sqlite execute --help
 
@@ -370,7 +476,6 @@ OPTIONS:
 Spin compatibility: `>= v1.3`
 
 <!-- @selectiveCpy -->
-
 ```console
 $ spin cloud sqlite help    
 
@@ -405,7 +510,6 @@ SUBCOMMANDS:
 Spin compatibility: `>= v1.3`
 
 <!-- @selectiveCpy -->
-
 ```console
 $ spin cloud sqlite list --help
 
@@ -444,7 +548,6 @@ Spin compatibility: `>= v1.3`
 ```console
 $ spin cloud variables --help
 
-cloud-variables 0.1.1
 Manage Spin application variables
 
 USAGE:
@@ -468,6 +571,24 @@ SUBCOMMANDS:
 Spin compatibility: `>= v1.3`
 
 <!-- @selectiveCpy -->
+```console
+$ spin cloud variables --help
+
+Manage Spin application variables
+
+USAGE:
+    spin cloud variables <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+SUBCOMMANDS:
+    delete    Delete variables
+    help      Print this message or the help of the given subcommand(s)
+    list      List all variables of an application
+    set       Set variables
+```
 
 {{ blockEnd }}
 
@@ -486,7 +607,6 @@ Spin compatibility: `>= v1.3`
 ```console
 $ spin cloud variables delete --help
 
-cloud-variables-delete 0.1.1
 Delete variables
 
 USAGE:
@@ -517,6 +637,31 @@ OPTIONS:
 Spin compatibility: `>= v1.3`
 
 <!-- @selectiveCpy -->
+```console
+$ spin cloud variables delete --help
+
+Delete variables
+
+USAGE:
+    spin cloud variables delete [OPTIONS] --app <app> [VARIABLES_TO_DELETE]...
+
+ARGS:
+    <VARIABLES_TO_DELETE>...    Variable pair to set
+
+OPTIONS:
+        --app <app>
+            Name of Spin app
+
+        --environment-name <environment-name>
+            Deploy to the Fermyon instance saved under the specified name. If omitted, Spin deploys
+            to the default unnamed instance [env: FERMYON_DEPLOYMENT_ENVIRONMENT=]
+
+    -h, --help
+            Print help information
+
+    -V, --version
+            Print version information
+```
 
 {{ blockEnd }}
 
@@ -532,7 +677,6 @@ Spin compatibility: `>= v1.3`
 Spin compatibility: `>= v1.3`
 
 <!-- @selectiveCpy -->
-
 ```console
 $ spin cloud variables help
 
@@ -560,6 +704,24 @@ SUBCOMMANDS:
 Spin compatibility: `>= v1.3`
 
 <!-- @selectiveCpy -->
+```console
+$ spin cloud variables help
+
+Manage Spin application variables
+
+USAGE:
+    spin cloud variables <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+SUBCOMMANDS:
+    delete    Delete variables
+    help      Print this message or the help of the given subcommand(s)
+    list      List all variables of an application
+    set       Set variables
+```
 
 {{ blockEnd }}
 
@@ -606,6 +768,28 @@ OPTIONS:
 Spin compatibility: `>= v1.3`
 
 <!-- @selectiveCpy -->
+```console
+$ spin cloud variables list --help
+
+List all variables of an application
+
+USAGE:
+    spin cloud variables list [OPTIONS] --app <app>
+
+OPTIONS:
+        --app <app>
+            Name of Spin app
+
+        --environment-name <environment-name>
+            Deploy to the Fermyon instance saved under the specified name. If omitted, Spin deploys
+            to the default unnamed instance [env: FERMYON_DEPLOYMENT_ENVIRONMENT=]
+
+    -h, --help
+            Print help information
+
+    -V, --version
+            Print version information
+```
 
 {{ blockEnd }}
 
@@ -655,6 +839,31 @@ OPTIONS:
 Spin compatibility: `>= v1.3`
 
 <!-- @selectiveCpy -->
+```console
+$ spin cloud variables set --help
+
+Set variables
+
+USAGE:
+    spin cloud variables set [OPTIONS] --app <app> [VARIABLES_TO_SET]...
+
+ARGS:
+    <VARIABLES_TO_SET>...    Variable pair to set
+
+OPTIONS:
+        --app <app>
+            Name of Spin app
+
+        --environment-name <environment-name>
+            Deploy to the Fermyon instance saved under the specified name. If omitted, Spin deploys
+            to the default unnamed instance [env: FERMYON_DEPLOYMENT_ENVIRONMENT=]
+
+    -h, --help
+            Print help information
+
+    -V, --version
+            Print version information
+```
 
 {{ blockEnd }}
 
@@ -689,10 +898,10 @@ Spin compatibility: `>= v1.3`
 
 | Command                                                    | Stability   |
 | ---------------------------------------------------------- | ----------- |
-| <code>cloud deploy</code>                                  |             |
-| <code>cloud login</code>                                   |             |
-| <code>cloud sqlite</code>                                  |             |
-| <code>cloud variables</code>                               |             |
+| <code>cloud deploy</code>                                  | Stabilizing |
+| <code>cloud login</code>                                   | Stabilizing |
+| <code>cloud sqlite</code>                                  | Stabilizing |
+| <code>cloud variables</code>                               | Stabilizing |
 
 {{ blockEnd }}
 

--- a/content/cloud/cloud-command-reference.md
+++ b/content/cloud/cloud-command-reference.md
@@ -365,7 +365,6 @@ Spin compatibility: `>= v1.3`
 ```console
 $ spin cloud sqlite --help
 
-cloud-sqlite 0.1.2
 Manage Fermyon Cloud SQLite databases
 
 USAGE:
@@ -399,7 +398,6 @@ Spin compatibility: `>= v1.3`
 ```console
 $ spin cloud sqlite delete --help
 
-cloud-sqlite-delete 0.1.2
 Delete a SQLite database
 
 USAGE:
@@ -440,7 +438,6 @@ Spin compatibility: `>= v1.3`
 ```console
 $ spin cloud sqlite execute --help
 
-cloud-sqlite-execute 0.1.2
 Execute SQL against a SQLite database
 
 USAGE:
@@ -479,7 +476,6 @@ Spin compatibility: `>= v1.3`
 ```console
 $ spin cloud sqlite help    
 
-cloud-sqlite 0.1.2
 Manage Fermyon Cloud SQLite databases
 
 USAGE:
@@ -513,7 +509,6 @@ Spin compatibility: `>= v1.3`
 ```console
 $ spin cloud sqlite list --help
 
-cloud-sqlite-list 0.1.2
 List all SQLite databases of a user
 
 USAGE:
@@ -680,7 +675,6 @@ Spin compatibility: `>= v1.3`
 ```console
 $ spin cloud variables help
 
-cloud-variables 0.1.1
 Manage Spin application variables
 
 USAGE:
@@ -740,7 +734,6 @@ Spin compatibility: `>= v1.3`
 ```console
 $ spin cloud variables list --help
 
-cloud-variables-list 0.1.1
 List all variables of an application
 
 USAGE:
@@ -808,7 +801,6 @@ Spin compatibility: `>= v1.3`
 ```console
 $ spin cloud variables set --help
 
-cloud-variables-set 0.1.1
 Set variables
 
 USAGE:

--- a/content/spin/cli-reference.md
+++ b/content/spin/cli-reference.md
@@ -228,12 +228,6 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.5"}}
-
-<!-- @selectiveCpy -->
-
-{{ blockEnd }}
-
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -377,12 +371,6 @@ OPTIONS:
     -u, --up
             Run the application after building
 ```
-
-{{ blockEnd }}
-
-{{ startTab "v1.5"}}
-
-<!-- @selectiveCpy -->
 
 {{ blockEnd }}
 
@@ -908,12 +896,6 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.5"}}
-
-<!-- @selectiveCpy -->
-
-{{ blockEnd }}
-
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -1090,12 +1072,6 @@ SUBCOMMANDS:
 
 * implemented via plugin
 ```
-
-{{ blockEnd }}
-
-{{ startTab "v1.5"}}
-
-<!-- @selectiveCpy -->
 
 {{ blockEnd }}
 
@@ -1288,12 +1264,6 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.5"}}
-
-<!-- @selectiveCpy -->
-
-{{ blockEnd }}
-
 {{ blockEnd }}
 
 **Please note: `spin new` vs `spin add`**.  These commands are similar except that:
@@ -1438,12 +1408,6 @@ SUBCOMMANDS:
     update       Fetch the latest Spin plugins from the spin-plugins repository
     upgrade      Upgrade one or all plugins
 ```
-
-{{ blockEnd }}
-
-{{ startTab "v1.5"}}
-
-<!-- @selectiveCpy -->
 
 {{ blockEnd }}
 
@@ -1659,12 +1623,6 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.5"}}
-
-<!-- @selectiveCpy -->
-
-{{ blockEnd }}
-
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -1769,12 +1727,6 @@ OPTIONS:
     -h, --help         Print help information
         --installed    List only installed plugins
 ```
-
-{{ blockEnd }}
-
-{{ startTab "v1.5"}}
-
-<!-- @selectiveCpy -->
 
 {{ blockEnd }}
 
@@ -1895,12 +1847,6 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.5"}}
-
-<!-- @selectiveCpy -->
-
-{{ blockEnd }}
-
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -2000,12 +1946,6 @@ USAGE:
 OPTIONS:
     -h, --help    Print help information
 ```
-
-{{ blockEnd }}
-
-{{ startTab "v1.5"}}
-
-<!-- @selectiveCpy -->
 
 {{ blockEnd }}
 
@@ -2237,12 +2177,6 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.5"}}
-
-<!-- @selectiveCpy -->
-
-{{ blockEnd }}
-
 {{ blockEnd }}
 
 **Note:** For additional information, please see the [Managing Plugins](/spin/managing-plugins) and/or [Creating Plugins](/spin/plugin-authoring) sections of the documentation.
@@ -2379,12 +2313,6 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.5"}}
-
-<!-- @selectiveCpy -->
-
-{{ blockEnd }}
-
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -2517,12 +2445,6 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.5"}}
-
-<!-- @selectiveCpy -->
-
-{{ blockEnd }}
-
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -2642,12 +2564,6 @@ OPTIONS:
     -h, --help        Print help information
     -k, --insecure    Ignore server certificate errors
 ```
-
-{{ blockEnd }}
-
-{{ startTab "v1.5"}}
-
-<!-- @selectiveCpy -->
 
 {{ blockEnd }}
 
@@ -2781,12 +2697,6 @@ OPTIONS:
     -h, --help                        Print help information
     -k, --insecure                    Ignore server certificate errors
 ```
-
-{{ blockEnd }}
-
-{{ startTab "v1.5"}}
-
-<!-- @selectiveCpy -->
 
 {{ blockEnd }}
 
@@ -2924,12 +2834,6 @@ SUBCOMMANDS:
     uninstall    Remove a template from your installation
     upgrade      Upgrade templates to match your current version of Spin
 ```
-
-{{ blockEnd }}
-
-{{ startTab "v1.5"}}
-
-<!-- @selectiveCpy -->
 
 {{ blockEnd }}
 
@@ -3120,12 +3024,6 @@ OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.5"}}
-
-<!-- @selectiveCpy -->
-
-{{ blockEnd }}
-
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -3235,12 +3133,6 @@ OPTIONS:
         --tag <TAGS>    Filter templates matching all provided tags
         --verbose       Whether to show additional template details in the list
 ```
-
-{{ blockEnd }}
-
-{{ startTab "v1.5"}}
-
-<!-- @selectiveCpy -->
 
 {{ blockEnd }}
 
@@ -3360,12 +3252,6 @@ ARGS:
 OPTIONS:
     -h, --help    Print help information
 ```
-
-{{ blockEnd }}
-
-{{ startTab "v1.5"}}
-
-<!-- @selectiveCpy -->
 
 {{ blockEnd }}
 
@@ -3548,12 +3434,6 @@ OPTIONS:
             which to upgrade.  Pass this flag to upgrade only the specified repository without
             prompting
 ```
-
-{{ blockEnd }}
-
-{{ startTab "v1.5"}}
-
-<!-- @selectiveCpy -->
 
 {{ blockEnd }}
 
@@ -3885,12 +3765,6 @@ TRIGGER OPTIONS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.5"}}
-
-<!-- @selectiveCpy -->
-
-{{ blockEnd }}
-
 {{ blockEnd }}
 
 > **Please note:** If the `-f` or `--from` options do not accurately infer the intended registry or `.toml` file for your application, then you can explicitly specify either the `--from-registry` or  `--from-file` options to clarify this.
@@ -4027,12 +3901,6 @@ The following additional trigger options are available for the [spin up](#spin-u
 
 {{ blockEnd }}
 
-{{ startTab "v1.5"}}
-
-<!-- @selectiveCpy -->
-
-{{ blockEnd }}
-
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -4155,12 +4023,6 @@ OPTIONS:
         --skip-build                  Only run the Spin application, restarting it when build
                                       artifacts change
 ```
-
-{{ blockEnd }}
-
-{{ startTab "v1.5"}}
-
-<!-- @selectiveCpy -->
 
 {{ blockEnd }}
 

--- a/content/spin/cli-reference.md
+++ b/content/spin/cli-reference.md
@@ -4019,15 +4019,15 @@ CLI commands have four phases that indicate levels of stability:
 
 | Command                                                    | Stability   |
 | ---------------------------------------------------------- | ----------- |
-| <code>spin add</code>                                                 | Stable      |
-| <code>spin build</code>                                               | Stable      |
-| <code>spin new</code>                                                 | Stable      |
-| <code>spin plugins <install&vert;list&vert;uninstall&vert;update&vert;upgrade></code> | Stable      |
-| <code>spin templates <install&vert;list&vert;uninstall&vert;upgrade></code>       | Stable      |
-| <code>spin up</code>                                                  | Stable      |
-| <code>spin cloud <deploy&vert;login></code>                               | Stabilizing |
-| <code>spin registry</code>                                            | Stabilizing |
-| <code>spin bindle <prepare&vert;push></code>                              | Deprecated  |
+| <code>spin add</code>                                      | Stable      |
+| <code>spin build</code>                                    | Stable      |
+| <code>spin new</code>                                      | Stable      |
+| <code>spin plugins</code>                                  | Stable      |
+| <code>spin templates </code>                               | Stable      |
+| <code>spin up</code>                                       | Stable      |
+| <code>spin cloud </code>                                   | Stabilizing |
+| <code>spin registry</code>                                 | Stabilizing |
+| <code>spin bindle</code>                                   | Deprecated  |
 
 {{ blockEnd }}
 
@@ -4038,13 +4038,13 @@ CLI commands have four phases that indicate levels of stability:
 | <code>spin add</code>                                                                 | Stable       |
 | <code>spin build</code>                                                               | Stable       |
 | <code>spin new</code>                                                                 | Stable       |
-| <code>spin plugins <install&vert;list&vert;uninstall&vert;update&vert;upgrade></code> | Stable       |
-| <code>spin templates <install&vert;list&vert;uninstall&vert;upgrade></code>           | Stable       |
+| <code>spin plugins</code>                                                             | Stable       |
+| <code>spin templates</code>                                                           | Stable       |
 | <code>spin up</code>                                                                  | Stable       |
-| <code>spin cloud <deploy&vert;login></code>                                           | Stabilizing  |
+| <code>spin cloud</code>                                                               | Stabilizing  |
 | <code>spin registry</code>                                                            | Stabilizing  |
 | <code>spin watch</code>                                                               | Experimental |
-| <code>spin bindle <prepare&vert;push></code>                                          | Deprecated   |
+| <code>spin bindle</code>                                                              | Deprecated   |
 
 {{ blockEnd }}
 
@@ -4055,13 +4055,13 @@ CLI commands have four phases that indicate levels of stability:
 | <code>spin add</code>                                                                 | Stable       |
 | <code>spin build</code>                                                               | Stable       |
 | <code>spin new</code>                                                                 | Stable       |
-| <code>spin plugins <install&vert;list&vert;uninstall&vert;update&vert;upgrade></code> | Stable       |
-| <code>spin templates <install&vert;list&vert;uninstall&vert;upgrade></code>           | Stable       |
+| <code>spin plugins</code>                                                             | Stable       |
+| <code>spin templates</code>                                                           | Stable       |
 | <code>spin up</code>                                                                  | Stable       |
-| <code>spin cloud <deploy&vert;login></code>                                           | Stabilizing  |
+| <code>spin cloud</code>                                                               | Stabilizing  |
 | <code>spin registry</code>                                                            | Stabilizing  |
 | <code>spin watch</code>                                                               | Experimental |
-| <code>spin bindle <prepare&vert;push></code>                                          | Deprecated   |
+| <code>spin bindle</code>                                                              | Deprecated   |
 
 {{ blockEnd }}
 
@@ -4072,13 +4072,13 @@ CLI commands have four phases that indicate levels of stability:
 | <code>spin add</code>                                                                 | Stable       |
 | <code>spin build</code>                                                               | Stable       |
 | <code>spin new</code>                                                                 | Stable       |
-| <code>spin plugins <install&vert;list&vert;uninstall&vert;update&vert;upgrade></code> | Stable       |
-| <code>spin templates <install&vert;list&vert;uninstall&vert;upgrade></code>           | Stable       |
+| <code>spin plugins</code>                                                             | Stable       |
+| <code>spin templates</code>                                                           | Stable       |
 | <code>spin up</code>                                                                  | Stable       |
-| <code>spin cloud <deploy&vert;login></code>                                           | Stabilizing  |
+| <code>spin cloud</code>                                                               | Stabilizing  |
 | <code>spin registry</code>                                                            | Stabilizing  |
 | <code>spin watch</code>                                                               | Experimental |
-| <code>spin bindle <prepare&vert;push></code>                                          | Deprecated   |
+| <code>spin bindle</code>                                                              | Deprecated   |
 
 {{ blockEnd }}
 
@@ -4089,13 +4089,13 @@ CLI commands have four phases that indicate levels of stability:
 | <code>spin add</code>                                                                 | Stable       |
 | <code>spin build</code>                                                               | Stable       |
 | <code>spin new</code>                                                                 | Stable       |
-| <code>spin plugins <install&vert;list&vert;uninstall&vert;update&vert;upgrade></code> | Stable       |
-| <code>spin templates <install&vert;list&vert;uninstall&vert;upgrade></code>           | Stable       |
+| <code>spin plugins</code>                                                             | Stable       |
+| <code>spin templates</code>                                                           | Stable       |
 | <code>spin up</code>                                                                  | Stable       |
-| <code>spin cloud <deploy&vert;login></code>                                           | Stabilizing  |
+| <code>spin cloud</code>                                                               | Stabilizing  |
 | <code>spin registry</code>                                                            | Stabilizing  |
 | <code>spin doctor</code>                                                              | Experimental |
 | <code>spin watch</code>                                                               | Experimental |
-| <code>spin bindle <prepare&vert;push></code>                                          | Deprecated   |
+| <code>spin bindle</code>                                                              | Deprecated   |
 
 {{ blockEnd }}

--- a/content/spin/cli-reference.md
+++ b/content/spin/cli-reference.md
@@ -228,6 +228,12 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -374,6 +380,12 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -460,6 +472,12 @@ The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](../cloud/c
 {{ blockEnd }}
 
 {{ startTab "v1.4"}}
+
+The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-command-reference).
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
 
 The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-command-reference).
 
@@ -621,6 +639,12 @@ The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](../
 {{ blockEnd }}
 
 {{ startTab "v1.4"}}
+
+The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-command-reference#spin-cloud-deploy).
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
 
 The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-command-reference#spin-cloud-deploy).
 
@@ -819,6 +843,12 @@ The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](../c
 
 {{ blockEnd }}
 
+{{ startTab "v1.5"}}
+
+The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-command-reference#spin-cloud-login).
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -833,6 +863,12 @@ The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](
 {{ blockEnd }}
 
 {{ startTab "v1.4"}}
+
+The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-command-reference#spin-cloud-variables).
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
 
 The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-command-reference#spin-cloud-variables).
 
@@ -869,6 +905,12 @@ OPTIONS:
                                       it defaults to "spin.toml" [default: spin.toml]
     -h, --help                        Print help information
 ```
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
 
 {{ blockEnd }}
 
@@ -1048,6 +1090,12 @@ SUBCOMMANDS:
 
 * implemented via plugin
 ```
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
 
 {{ blockEnd }}
 
@@ -1240,6 +1288,12 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 **Please note: `spin new` vs `spin add`**.  These commands are similar except that:
@@ -1384,6 +1438,12 @@ SUBCOMMANDS:
     update       Fetch the latest Spin plugins from the spin-plugins repository
     upgrade      Upgrade one or all plugins
 ```
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
 
 {{ blockEnd }}
 
@@ -1599,6 +1659,12 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -1703,6 +1769,12 @@ OPTIONS:
     -h, --help         Print help information
         --installed    List only installed plugins
 ```
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
 
 {{ blockEnd }}
 
@@ -1823,6 +1895,12 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -1922,6 +2000,12 @@ USAGE:
 OPTIONS:
     -h, --help    Print help information
 ```
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
 
 {{ blockEnd }}
 
@@ -2153,6 +2237,12 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 **Note:** For additional information, please see the [Managing Plugins](/spin/managing-plugins) and/or [Creating Plugins](/spin/plugin-authoring) sections of the documentation.
@@ -2289,6 +2379,12 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -2421,6 +2517,12 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -2540,6 +2642,12 @@ OPTIONS:
     -h, --help        Print help information
     -k, --insecure    Ignore server certificate errors
 ```
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
 
 {{ blockEnd }}
 
@@ -2676,6 +2784,12 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -2787,7 +2901,7 @@ SUBCOMMANDS:
 
 {{ blockEnd }}
 
-{{ startTab "v1.3"}}
+{{ startTab "v1.4"}}
 
 <!-- @selectiveCpy -->
 
@@ -2810,6 +2924,12 @@ SUBCOMMANDS:
     uninstall    Remove a template from your installation
     upgrade      Upgrade templates to match your current version of Spin
 ```
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
 
 {{ blockEnd }}
 
@@ -3000,6 +3120,12 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -3109,6 +3235,12 @@ OPTIONS:
         --tag <TAGS>    Filter templates matching all provided tags
         --verbose       Whether to show additional template details in the list
 ```
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
 
 {{ blockEnd }}
 
@@ -3228,6 +3360,12 @@ ARGS:
 OPTIONS:
     -h, --help    Print help information
 ```
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
 
 {{ blockEnd }}
 
@@ -3410,6 +3548,12 @@ OPTIONS:
             which to upgrade.  Pass this flag to upgrade only the specified repository without
             prompting
 ```
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
 
 {{ blockEnd }}
 
@@ -3741,6 +3885,12 @@ TRIGGER OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 > **Please note:** If the `-f` or `--from` options do not accurately infer the intended registry or `.toml` file for your application, then you can explicitly specify either the `--from-registry` or  `--from-file` options to clarify this.
@@ -3877,6 +4027,12 @@ The following additional trigger options are available for the [spin up](#spin-u
 
 {{ blockEnd }}
 
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -4002,6 +4158,12 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 ## Stability Table
@@ -4097,6 +4259,13 @@ CLI commands have four phases that indicate levels of stability:
 | <code>spin doctor</code>                                                              | Experimental |
 | <code>spin watch</code>                                                               | Experimental |
 | <code>spin bindle <prepare&vert;push></code>                                          | Deprecated   |
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+| Command                                                                               | Stability    |
+| ------------------------------------------------------------------------------------- | ------------ |
 
 {{ blockEnd }}
 

--- a/content/spin/cli-reference.md
+++ b/content/spin/cli-reference.md
@@ -465,12 +465,6 @@ The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](../cloud/c
 
 {{ blockEnd }}
 
-{{ startTab "v1.5"}}
-
-The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-command-reference).
-
-{{ blockEnd }}
-
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -627,12 +621,6 @@ The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](../
 {{ blockEnd }}
 
 {{ startTab "v1.4"}}
-
-The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-command-reference#spin-cloud-deploy).
-
-{{ blockEnd }}
-
-{{ startTab "v1.5"}}
 
 The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-command-reference#spin-cloud-deploy).
 
@@ -831,12 +819,6 @@ The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](../c
 
 {{ blockEnd }}
 
-{{ startTab "v1.5"}}
-
-The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-command-reference#spin-cloud-login).
-
-{{ blockEnd }}
-
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -851,12 +833,6 @@ The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](
 {{ blockEnd }}
 
 {{ startTab "v1.4"}}
-
-The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-command-reference#spin-cloud-variables).
-
-{{ blockEnd }}
-
-{{ startTab "v1.5"}}
 
 The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-command-reference#spin-cloud-variables).
 
@@ -4121,14 +4097,5 @@ CLI commands have four phases that indicate levels of stability:
 | <code>spin doctor</code>                                                              | Experimental |
 | <code>spin watch</code>                                                               | Experimental |
 | <code>spin bindle <prepare&vert;push></code>                                          | Deprecated   |
-
-{{ blockEnd }}
-
-{{ startTab "v1.5"}}
-
-| Command                                                                               | Stability    |
-| ------------------------------------------------------------------------------------- | ------------ |
-
-{{ blockEnd }}
 
 {{ blockEnd }}


### PR DESCRIPTION
Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [X] The `title, `template`, and `date` are all set
- [X] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [X] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)

<img width="526" alt="Screenshot 2023-07-26 at 12 21 03 pm" src="https://github.com/fermyon/developer/assets/9831342/e771dc14-29fc-41c4-b57f-3f8e3cf5c301">

<img width="493" alt="Screenshot 2023-07-26 at 12 20 57 pm" src="https://github.com/fermyon/developer/assets/9831342/68b5a65c-a953-4d80-85f4-c7b67ce5822b">

- [X] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)

![Screenshot 2023-07-26 at 12 22 00 pm](https://github.com/fermyon/developer/assets/9831342/9bb9fe88-ff55-4c43-aa64-d4ef6471ff49)

![Screenshot 2023-07-26 at 12 22 28 pm](https://github.com/fermyon/developer/assets/9831342/2f038c34-331f-49bd-b05a-6b04b8ca24bb)

- [X] Headings are using Title Case
- [X] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [X] Have tested with `npm run test` and resolved all errors

<img width="384" alt="Screenshot 2023-07-26 at 12 21 49 pm" src="https://github.com/fermyon/developer/assets/9831342/8d5f708f-84ad-418d-99b2-1e330f901812">

- [X] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.

**Embargo**

![embargo](https://github.com/fermyon/developer/assets/9831342/8ef78c12-1b5f-41f7-8851-7c190105e856)
