### PR TITLE
Added the starting instructions on how to preview on localhost to contributing documentations page

### DIFF
--- a/content/cloud/fermyon-cloud.md
+++ b/content/cloud/fermyon-cloud.md
@@ -54,7 +54,6 @@ To package and distribute application to and within the cloud, we rely on Bindle
 
 Fermyon Cloud uses [Turso Database](https://docs.turso.tech/) to power its [NoOps SQL Database using SQLite](/cloud/noops-sql-db.md). Turso's low-latency performance characteristics and use of [libSQL](https://libsql.org/), an open-source fork of [SQLite](https://sqlite.org/), made it a natural fit for Fermyon Cloud's managed base offering.
 
-
 ### Web UI, API and CLI
 
 The Fermyon Cloud exposes a public [REST API](rest-api.md) which is used by the [web interface](https://cloud.fermyon.com) and the Spin CLI when logging in and deploying applications.

--- a/content/spin/contributing-docs.md
+++ b/content/spin/contributing-docs.md
@@ -26,6 +26,7 @@ keywords = "contribute contributing"
   - [6.4 The Edit On GitHub Button](#64-the-edit-on-github-button)
   - [6.5 How To Properly Edit CSS Styles](#65-how-to-properly-edit-css-styles)
   - [6.6 Checking Your Content - Using Bartholomew's CLI](#66-checking-your-content---using-bartholomews-cli)
+  - [6.7 Checking Your Content - Preview a Documentation Page on Localhost](#67-checking-your-content---preview-a-documentation-page-on-localhost)
   - [7. Checking Web Pages](#7-checking-web-pages)
   - [8. Add Changes](#8-add-changes)
   - [9. Commit Changes](#9-commit-changes)
@@ -408,6 +409,16 @@ SUBCOMMANDS:
 ```
 
 Let's take a quick look at how you can use the `bart` CLI to check any content that you are wanting to contribute.
+
+### 6.7 Checking Your Content - Preview a Documentation Page on Localhost
+
+You can host the technical documentation on the localhost to view changes by using the following command: 
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin up -e "PREVIEW_MODE=1"
+```
 
 ### 7. Checking Web Pages
 

--- a/content/spin/contributing-docs.md
+++ b/content/spin/contributing-docs.md
@@ -412,7 +412,7 @@ Let's take a quick look at how you can use the `bart` CLI to check any content t
 
 ### 6.7 Checking Your Content - Preview a Documentation Page on Localhost
 
-You can host the technical documentation on the localhost to view changes by using the following command: 
+You can host your changes to the developer documentation on your own machine (localhost) by using the following `spin` command: 
 
 <!-- @selectiveCpy -->
 

--- a/content/spin/contributing-docs.md
+++ b/content/spin/contributing-docs.md
@@ -420,6 +420,8 @@ You can host your changes to the developer documentation on your own machine (lo
 $ spin up -e "PREVIEW_MODE=1"
 ```
 
+> Please note: using the `PREVIEW_MODE=1` as part of a `spin` command is safe on localhost and allows you to view content (even if the `date` setting in the content's `.md` is set to a future date). It is often the case that you will be checking content before the publishing date via your system. The developer documentation's manifest file `spin.toml` has the `PREVIEW_MODE` set to `0` i.e. `environment = { PREVIEW_MODE = "0" }`. This `spin.toml` file is correct for a production environment and should always be `0` (so that the CMS adheres to the publishing `date` setting for content on the public site). Simply put, you can use `PREVIEW_MODE=1` safely in your command line on your locahost but you should never update the `spin.toml` file (in this regard).
+
 ### 7. Checking Web Pages
 
 The `bart check` command can be used to check the content. Simply pass in the content as a parameter. The developer documentation [uses shortcodes](/bartholomew/shortcodes), so always pass `--shortcodes ./shortcodes` as shown below:


### PR DESCRIPTION
Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [X] The `title, `template`, and `date` are all set
- [X] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [X] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [X] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
<img width="1420" alt="Screen Shot 2023-07-26 at 6 25 00 PM" src="https://github.com/fermyon/developer/assets/70303310/45b4d2f2-1512-47c8-9c77-384c3d14c6b9">
<img width="1412" alt="Screen Shot 2023-07-26 at 6 24 36 PM" src="https://github.com/fermyon/developer/assets/70303310/6dd8ea92-53f5-4815-95b2-21cd02619ba0">

- [X] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
<img width="1437" alt="Screen Shot 2023-07-26 at 6 30 22 PM" src="https://github.com/fermyon/developer/assets/70303310/9d0fea42-17c2-4e43-b517-5f08893a41f2">

- [X] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [X] Have tested with `npm run test` and resolved all errors
<img width="355" alt="Screen Shot 2023-07-26 at 6 23 48 PM" src="https://github.com/fermyon/developer/assets/70303310/21ff91a5-0fd6-4d9e-a6e4-353ab20cafbf">

- [X] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
