### PR TITLE
Specify watch and workdir relationship in spin.toml

### DIFF
--- a/content/spin/running-apps.md
+++ b/content/spin/running-apps.md
@@ -104,6 +104,8 @@ command = "cargo build --target wasm32-wasi --release"
 watch = ["src/**/*.rs", "Cargo.toml"]
 ```
 
+Note that references to files in the `component.build.watch` section use the optional `component.build.workdir` section as the base directory for references. If not specified, it uses the directory of the `spin.toml` file. 
+
 If you would prefer Spin watch to only rerun the application (without a rebuild) when changes occur, you can use the `--skip-build` option when running the `spin watch` command.  In this case, Spin will ignore the `component.build.watch` section, and monitor only the `spin.toml`, `component.source` and `component.files`.
 
 Spin watch waits up to 100 milliseconds before responding to filesystem events, then processes all events that occurred in that interval together. This is so that if you make several changes close together (for example, using a Save All command), you get them all processed in one rebuild/reload cycle, rather than going through a cycle for each one. You can override the interval by passing in the `--debounce` option; e.g. `spin watch --debounce 1000` will make Spin watch respond to filesystem events at most once per second.


### PR DESCRIPTION
Clarification on how workdir impacts the watch specification in spin.toml.