### PR TITLE
Fix path reference in contrib guide for Spin Up Hub

### DIFF
--- a/content/api/hub/contributing.md
+++ b/content/api/hub/contributing.md
@@ -77,7 +77,7 @@ $ git remote add upstream https://github.com/fermyon/developer
 
 ### Creating Markdown
 
-Create a **`.md`** Markdown file in the **`content/hub`** folder in your fork. (Adhering to the naming convention of other files helps keep things tidy and manageable.)
+Create a **`.md`** Markdown file in the **`content/api/hub`** folder in your fork. (Adhering to the naming convention of other files helps keep things tidy and manageable.)
 
 Below is a copyable example to get you started:
 


### PR DESCRIPTION
Small correction to where to find the Spin Up Hub files.