### PR TITLE
Update spin_sidebar.hbs

### DIFF
--- a/templates/spin_sidebar.hbs
+++ b/templates/spin_sidebar.hbs
@@ -31,7 +31,7 @@
                             {{/if}} href="{{site.info.base_url}}/spin/spin-application-structure">Structuring Applications</a>
                     </li>
                     <li><a {{#if (active_content request.spin-path-info "/spin/build" )}} class="active" {{/if}}
-                            href="{{site.info.base_url}}/spin/build">Building Applications</a></li>
+                            href="{{site.info.base_url}}/spin/build">Compiling Applications</a></li>
                     <li><a {{#if (active_content request.spin-path-info "/spin/running-apps" )}} class="active" {{/if}}
                             href="{{site.info.base_url}}/spin/running-apps">Running Applications</a></li>
                     <li><a {{#if (active_content request.spin-path-info "/spin/distributing-apps" )}} class="active"

--- a/templates/spin_sidebar.hbs
+++ b/templates/spin_sidebar.hbs
@@ -31,7 +31,7 @@
                             {{/if}} href="{{site.info.base_url}}/spin/spin-application-structure">Structuring Applications</a>
                     </li>
                     <li><a {{#if (active_content request.spin-path-info "/spin/build" )}} class="active" {{/if}}
-                            href="{{site.info.base_url}}/spin/build">Building Application Code</a></li>
+                            href="{{site.info.base_url}}/spin/build">Building Applications</a></li>
                     <li><a {{#if (active_content request.spin-path-info "/spin/running-apps" )}} class="active" {{/if}}
                             href="{{site.info.base_url}}/spin/running-apps">Running Applications</a></li>
                     <li><a {{#if (active_content request.spin-path-info "/spin/distributing-apps" )}} class="active"


### PR DESCRIPTION
Signed-off-by: tpmccallum tim.mccallum@fermyon.com

- writing
- structuring
- building -running

This makes more sense now, whereas before the "structuring" menu item came along, it felt like saying "building" meant constructing (vs compiling).

The `build` command does build, so I guess "Building Applications" is technically correct.

Closes https://github.com/fermyon/developer/issues/435


