### PR TITLE
Add check-for-update plugin to Spin Hub

### DIFF
--- a/content/api/hub/plugin_check_for_update.md
+++ b/content/api/hub/plugin_check_for_update.md
@@ -1,0 +1,37 @@
+title = "Check for Update"
+template = "render_hub_content_body"
+date = "2023-08-24T08:42:56Z"
+content-type = "text/plain"
+tags = ["cli", "tooling"]
+
+[extra]
+author = "ThorstenHans"
+type = "hub_document"
+category = "Plugin"
+language = "Rust"
+created_at = "2023-08-23T15:20:00Z"
+last_updated = "2023-08-23T15:20:00Z"
+spin_version = ">=0.4"
+summary = "A plugin to check if your local spin CLI installation is up-to-date"
+url = "https://github.com/ThorstenHans/spin-plugin-check-for-update"
+keywords = "plugins, tooling, cli, updates"
+
+---
+
+This Spin plugin determines if the local installation of `spin` CLI is up-to-date or not. On invocation, the plugin will request the version number of `spin` (only considering stable releases) and compare it to the version installed locally. If the local installation is outdated, installation instructions will be printed to `stdout`.
+
+## Installation
+
+```bash
+spin plugins install --url https://raw.githubusercontent.com/fermyon/spin-plugins/main/manifests/check-for-update/check-for-update.json
+```
+
+## Usage
+
+```bash
+spin check-for-update
+
+# ⠋⠉ Checking for latest spin CLI version...
+
+# Your spin CLI is up to date (version 1.4.1) ✅
+```


### PR DESCRIPTION
This PR adds the `check-for-update` plugin to the Spin Hub.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
