### PR TITLE
Document error behaviour of JS KV get/getJson

### DIFF
--- a/content/spin/kv-store-api-guide.md
+++ b/content/spin/kv-store-api-guide.md
@@ -96,8 +96,15 @@ export const handleRequest: HandleRequest = async function (request: HttpRequest
 **General Notes**
 - The spinSdk object is always available at runtime. Code checking and completion are available in TypeScript at design time if the module imports anything from the @fermyon/spin-sdk package. For example: 
 
+`get` **Operation**
+- The result is of the type `ArrayBuffer | null`
+- If the key does not exist, `get` returns `null` (no error is thrown)
+
 `set` **Operation**
-- The value argument is of the type `ArrayBuffer | string`
+- The value argument is of the type `ArrayBuffer | string`.
+
+`setJson` and `getJson` **Operation**
+- JavaScript and TypeScript applications can store JavaScript objects using `setJson`; these are serialized within the store as JSON. These serialized objects can be retrieved and deserialized using `getJson`. If you call `getJson` on a key that doesn't exist then an error is thrown (note that this is different behavior from `get`).
 
 {{ blockEnd }}
 


### PR DESCRIPTION
This captures how things behave at js2wasm 0.5.1 / spin-sdk 0.5.0.

@karthik2804 I don't know if the behaviour of `getJson` in particular is considered correct. If this doesn't seem right and you plan to change it, we can hold off on these docs.

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
