### PR TITLE
Fixed two tiny typos

### DIFF
--- a/content/api/hub/contributing.md
+++ b/content/api/hub/contributing.md
@@ -8,7 +8,7 @@ url = "https://github.com/fermyon/developer/blob/main/content/api/hub/contributi
 
 ---
 
-- [Contributiung Procedure](#contributiung-procedure)
+- [Contribution Procedure](#contribution-procedure)
   - [Fork the Repository](#fork-the-repository)
   - [Clone the Fork](#clone-the-fork)
   - [Create New Branch](#create-new-branch)
@@ -29,7 +29,7 @@ First, any contribution and interaction on any Fermyon project MUST follow our
 [code of conduct](https://www.fermyon.com/code-of-conduct). Thank you for being
 part of an inclusive and open community!
 
-## Contributiung Procedure
+## Contribution Procedure
 
 ### Fork the Repository
 
@@ -150,7 +150,7 @@ The following is a list of the types of content that a user can submit to the Sp
 
 ### Testing Locally
 
-After your file has been created, you can test it on localhost before commiting.
+After your file has been created, you can test it on localhost before committing.
 
 <!-- @selectiveCpy -->
 


### PR DESCRIPTION
Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors
- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
