### PR TITLE
Fix KV language and reference in language guides

### DIFF
--- a/content/spin/go-components.md
+++ b/content/spin/go-components.md
@@ -348,7 +348,7 @@ WASI can be used when implementing a Spin component.
 
 ## Storing Data in the Spin Key-Value Store
 
-Spin has a key-value store built in. For information about using it from Rust, see [the key-value store tutorial](kv-store-tutorial).
+Spin has a key-value store built in. For information about using it from TinyGo, see [the key-value store tutorial](kv-store-tutorial).
 
 ## Storing Data in SQLite
 

--- a/content/spin/javascript-components.md
+++ b/content/spin/javascript-components.md
@@ -385,7 +385,7 @@ export const handleRequest: HandleRequest = async function(request: HttpRequest)
 
 ## Storing Data in the Spin Key-Value Store
 
-Spin has a key-value store built in. For information about using it from Rust, see [the key-value store tutorial](kv-store-tutorial).
+Spin has a key-value store built in. For information about using it from TypeScript/JavaScript, see [the key-value store tutorial](kv-store-tutorial).
 
 ## Storing Data in SQLite
 

--- a/content/spin/python-components.md
+++ b/content/spin/python-components.md
@@ -333,7 +333,7 @@ redis-cli
 
 ## Storing Data in the Spin Key-Value Store
 
-Spin has a key-value store built in. For information about using it from Rust, see [the key-value store tutorial](kv-store-tutorial).
+Spin has a key-value store built in. For information about using it from Python, see [the key-value store API guide](kv-store-api-guide).
 
 ## Storing Data in SQLite
 


### PR DESCRIPTION
Fixes #807.

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
