### PR TITLE
Fix Python outbound HTTP fragment

### DIFF
--- a/content/spin/http-outbound.md
+++ b/content/spin/http-outbound.md
@@ -93,13 +93,14 @@ HTTP functions and classes are available in the `spin_http` module. The function
 from spin_http import Request, Response, http_send
 
 response = http_send(
-    Request("GET", "https://random-data-api.fermyon.app/animals/json", [], None))
+    Request("GET", "https://random-data-api.fermyon.app/animals/json", {}, None))
 ```
 
 **Notes**
 
 * For compatibility with idiomatic Python, types do not necessarily match the underlying Wasm interface. For example, `method` is a string.
 * Request and response bodies are `bytes`. (You can pass literal strings using the `b` prefix.)  Pass `None` for no body.
+* Request and response headers are dictionaries.
 * Errors are signalled through exceptions.
 
 You can find a complete example for using outbound HTTP in the [Python SDK repository on GitHub](https://github.com/fermyon/spin-python-sdk/tree/main/examples/outbound_http).


### PR DESCRIPTION
Fixes #741 

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
