### PR TITLE
Remove unnecessary line of code from outbound http sample

### DIFF
--- a/content/spin/javascript-components.md
+++ b/content/spin/javascript-components.md
@@ -234,8 +234,6 @@ export async function handleRequest(request) {
 
     const animalFactBody = decoder.decode(await animalFact.arrayBuffer() || new Uint8Array())
 
-    const env = JSON.stringify(process.env)
-
     const body = `Here's an animal fact: ${animalFactBody}\n`
 
     return {


### PR DESCRIPTION
This PR removes an unnecessary line of code from the outbound HTTP sample for JavaScript.


Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
