### PR TITLE
Trigger index rebuild only when content changes

### DIFF
--- a/spin.toml
+++ b/spin.toml
@@ -14,7 +14,7 @@ files = [ "content/**/*" , "templates/*", "scripts/*", "config/*", "shortcodes/*
 route = "/..."
 [component.build]
 command = "npm run build-index && npm run build-hub-index"
-watch = [ "content/**/*", "templates/*", "scripts/*", "config/*", "shortcodes/*", "static/*"]
+watch = [ "content/**/*", "templates/*" ]
 
 [[component]]
 source = "modules/spin_static_fs.wasm"


### PR DESCRIPTION
The current `build.watch` configuration:

* Rebuilds the index files in `static`
* Depends on multiple directories including `static`

This causes `spin watch` to go into an infinite loop as the build updates the index files in static, which triggers a rebuild, which updates the index files in static, which...

The only actual inputs to the indexes are under `content`, so this is the only directory we need to watch _for rebuild_.

(Yes, other directories require a reload, i.e. restart `spin up`.  That will still happen because `spin watch` considers the `files`.  But these don't require a re-run of the index build commands.)

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
