### PR TITLE
Add hugo-spin template repository to Spin Up Hub

### DIFF
--- a/content/api/hub/sample_hugo.md
+++ b/content/api/hub/sample_hugo.md
@@ -1,4 +1,4 @@
-title = "Template repository for running Hugo sites"
+title = "Spin Hugo"
 template = "render_hub_content_body"
 date = "2023-08-31T10:52:54Z"
 content-type = "text/plain"

--- a/content/api/hub/sample_hugo.md
+++ b/content/api/hub/sample_hugo.md
@@ -1,0 +1,26 @@
+title = "Template repository for running Hugo sites"
+template = "render_hub_content_body"
+date = "2023-08-31T10:52:54Z"
+content-type = "text/plain"
+tags = ["Hugo", "spin-fileserver", "SSG", "Fermyon Cloud"]
+
+[extra]
+author = "ThorstenHans"
+type = "hub_document"
+category = "Examples"
+language = "Rust"
+created_at = "2023-08-31T10:52:54Z"
+last_updated = "2023-08-31T00:52:54Z"
+spin_version = ">v1.3"
+summary = "A template repository you can use for serving your Hugo site with Fermyon Spin and for deploying it to Fermyon Cloud"
+url = "https://github.com/ThorstenHans/hugo-spin"
+keywords = "Hugo, spin-fileserver, SSG, template, Fermyon Cloud"
+
+---
+
+### Getting started
+
+The [hugo-spin](https://github.com/ThorstenHans/hugo-spin) comes with all batteries included to serve your next [Hugo](https://gohugo.io) site leveraging the [`spin-fileserver`](https://github.com/fermyon/spin-fileserver). 
+
+To get started, open the [hugo-spin](https://github.com/ThorstenHans/hugo-spin) repository and click the "Use this template" button. Once you've created your own repository from the template, you can use the `make start` and `make deploy` to either build and the site locally, or to deploy it to Fermyon Cloud.
+


### PR DESCRIPTION
This PR adds the [`hugo-spin`](https://github.com/ThorstenHans/hugo-spin) template repository to the Spin Up Hub. 

fixes #803 

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
