### PR TITLE
Add link to the Rust Spin SDK documentation

### DIFF
--- a/content/spin/rust-components.md
+++ b/content/spin/rust-components.md
@@ -19,6 +19,7 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/rust-componen
 - [Using External Crates in Rust Components](#using-external-crates-in-rust-components)
 - [Troubleshooting](#troubleshooting)
 - [Manually Creating New Projects With Cargo](#manually-creating-new-projects-with-cargo)
+- [Read the Rust Spin SDK documentation](#read-the-rust-spin-sdk-documentation)
 
 Spin aims to have best-in-class support for building components in Rust, and
 writing such components should be familiar for Rust developers.
@@ -510,3 +511,7 @@ wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", re
 ```
 
 > `wit-bindgen` evolves rapidly to track draft standards.  Very recent versions of `wit-bindgen` are unlikely to work correctly with Spin.  So the dependency must be pinned to a specific `rev`.  Over time, Spin expects to track "peninsulas of stability" in the evolving standards.
+
+## Read the Rust Spin SDK documentation
+
+Although you learned a lot by following the concepts and samples shown here, you can dive even deeper and read the [Rust Spin SDK documentation](https://fermyon.github.io/rust-docs/spin/main/spin_sdk/index.html).

--- a/content/spin/rust-components.md
+++ b/content/spin/rust-components.md
@@ -512,6 +512,6 @@ wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", re
 
 > `wit-bindgen` evolves rapidly to track draft standards.  Very recent versions of `wit-bindgen` are unlikely to work correctly with Spin.  So the dependency must be pinned to a specific `rev`.  Over time, Spin expects to track "peninsulas of stability" in the evolving standards.
 
-## Read the Rust Spin SDK documentation
+## Read the Rust Spin SDK Documentation
 
 Although you learned a lot by following the concepts and samples shown here, you can dive even deeper and read the [Rust Spin SDK documentation](https://fermyon.github.io/rust-docs/spin/main/spin_sdk/index.html).


### PR DESCRIPTION
This PR adds a small note about the Rust Spin SDK documentation which is currently available at https://fermyon.github.io/rust-docs/spin/main/spin_sdk/index.html.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
