### PR TITLE
Add instructions for cloud plugin and js2wasm upgrades in serverless-ai docs

### DIFF
--- a/content/cloud/serverless-ai.md
+++ b/content/cloud/serverless-ai.md
@@ -25,11 +25,20 @@ Once you have access to the private beta, please ensure you have the `canary` ve
 $ curl -fsSL https://developer.fermyon.com/downloads/install.sh | bash -s -- -v canary
 ```
 
-Also, for TypeScript/JavaScript examples, please ensure you have the latest TypeScript/JavaScript SDK installed:
+If you want to deploy to Fermyon Cloud, you'll also need the latest version of the Cloud Plugin:
 
 <!-- @selectiveCpy -->
 
 ```bash
+$ spin plugins install -u https://github.com/fermyon/cloud-plugin/releases/download/canary/cloud.json - y
+```
+
+Also, for TypeScript/JavaScript examples, please ensure you have the latest TypeScript/JavaScript SDK and templates installed:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin plugins install -u https://github.com/fermyon/spin-js-sdk/releases/download/canary/js2wasm.json -y
 $ spin templates install --git https://github.com/fermyon/spin-js-sdk --upgrade
 ```
 


### PR DESCRIPTION
This adds to the serverless-ai docs for how to install the latest cloud and js2wasm plugins.

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
