### PR TITLE
Revert instructions because installation script handles canary plugins now.

### DIFF
--- a/content/cloud/serverless-ai.md
+++ b/content/cloud/serverless-ai.md
@@ -25,7 +25,7 @@ Once you have access to the private beta, please ensure you have the `canary` ve
 $ curl -fsSL https://developer.fermyon.com/downloads/install.sh | bash -s -- -v canary
 ```
 
-Also, for TypeScript/JavaScript examples, please ensure you have the latest TypeScript/JavaScript SDK installed:
+Also, for TypeScript/JavaScript examples, please ensure you have the latest TypeScript/JavaScript template installed:
 
 <!-- @selectiveCpy -->
 

--- a/content/cloud/serverless-ai.md
+++ b/content/cloud/serverless-ai.md
@@ -25,20 +25,11 @@ Once you have access to the private beta, please ensure you have the `canary` ve
 $ curl -fsSL https://developer.fermyon.com/downloads/install.sh | bash -s -- -v canary
 ```
 
-If you want to deploy to Fermyon Cloud, you'll also need the latest version of the Cloud Plugin:
+Also, for TypeScript/JavaScript examples, please ensure you have the latest TypeScript/JavaScript SDK installed:
 
 <!-- @selectiveCpy -->
 
 ```bash
-$ spin plugins install -u https://github.com/fermyon/cloud-plugin/releases/download/canary/cloud.json - y
-```
-
-Also, for TypeScript/JavaScript examples, please ensure you have the latest TypeScript/JavaScript SDK and templates installed:
-
-<!-- @selectiveCpy -->
-
-```bash
-$ spin plugins install -u https://github.com/fermyon/spin-js-sdk/releases/download/canary/js2wasm.json -y
 $ spin templates install --git https://github.com/fermyon/spin-js-sdk --upgrade
 ```
 


### PR DESCRIPTION
Signed-off-by: tpmccallum tim.mccallum@fermyon.com

The [Update install script to install canary plugins](https://github.com/fermyon/developer/pull/863) PR now makes the Spin installation script install the required canary plugins automatically (when a user provides the `-v canary` option during their Spin installation).

Below is the output after using the newly updated Spin installation script (which attends to canary plugins automatically):

```bash
$ curl -fsSL https://developer.fermyon.com/downloads/install.sh | bash -s -- -v canary

// -- snip --

$ ./spin plugins list  
check-for-update 0.0.1
check-for-update 0.1.0
cloud 0.1.0
cloud 0.1.1
cloud 0.1.2
cloud 0.1.2post.1693590746 [installed]
js2wasm 0.1.0
js2wasm 0.2.0
js2wasm 0.3.0
js2wasm 0.4.0
js2wasm 0.5.0
js2wasm 0.5.1
js2wasm 0.6.0post.1693903439 [installed]
pluginify 0.6.0
py2wasm 0.1.0
py2wasm 0.1.1
py2wasm 0.2.0
py2wasm 0.3.0
py2wasm 0.3.0post.1693957212 [installed]
```
