### PR TITLE
add Qwik frontend template

### DIFF
--- a/content/api/hub/template_qwik_frontend.md
+++ b/content/api/hub/template_qwik_frontend.md
@@ -20,4 +20,6 @@ keywords = "qwik, js, javascript, typescript"
 
 This is a template for building and statically exporting your Qwik Frontend application and running it on Fermyon Spin.
 
+Demo: https://qwik.fermyon.app/
+
 This guide walks you through how to use it: [HTTP Components](https://developer.fermyon.com/spin/javascript-components#http-components)

--- a/content/api/hub/template_qwik_frontend.md
+++ b/content/api/hub/template_qwik_frontend.md
@@ -1,0 +1,23 @@
+title = "Spin Qwik Frontend"
+template = "render_hub_content_body"
+date = "2023-09-08T00:00:00Z"
+content-type = "text/html"
+tags = ["typescript", "javascript", "http"]
+
+[extra]
+author = "Van Vuong Ngo"
+type = "hub_document"
+category = "Template"
+language = "JS/TS"
+created_at = "2023-09-08T00:00:00Z"
+last_updated = "2023-09-08T00:00:00Z"
+spin_version = ">v1.4"
+summary = "A template to use Qwik with Spin"
+url = "https://github.com/vanvuongngo/qwik-wasm"
+keywords = "qwik, js, javascript, typescript"
+
+---
+
+This is a template for building and statically exporting your Qwik Frontend application and running it on Fermyon Spin.
+
+This guide walks you through how to use it: [HTTP Components](https://developer.fermyon.com/spin/javascript-components#http-components)


### PR DESCRIPTION
Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title, `template`, and `date` are all set
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Have tested with `npm run test` and resolved all errors
- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.

https://qwik.fermyon.app/

<img width="1280" alt="image" src="https://github.com/fermyon/developer/assets/20791239/26f828b4-c266-42b7-8670-1fbb7ef3e7c0">
