### PR TITLE
Updating Spin Up Hub with sample_coffee_shop_in_dapr_k3d

### DIFF
--- a/content/api/hub/sample_coffee_shop_in_dapr_k3d.md
+++ b/content/api/hub/sample_coffee_shop_in_dapr_k3d.md
@@ -1,0 +1,27 @@
+title = "Polyglot Coffee Shop - WebAssembly (Spin), Docker container, Dapr, and Kubernetes (k3d) better together"
+template = "render_hub_content_body"
+date = "2023-09-14T00:00:00Z"
+content-type = "text/html"
+tags = ["rust", "http", "csharp", "dapr", "k3d"]
+
+[extra]
+author = "thangchung"
+type = "hub_document"
+category = "Sample"
+language = "Rust"
+created_at = "2023-09-14T00:00:00Z"
+last_updated = "2023-09-14T00:00:00Z"
+spin_version = ">v1.4"
+summary =  "A polyglot coffee shop application includes 3 spin apps and one Docker container app that runs on Dapr (leverages service invocation, pub-sub, and state management) and deploys to Kubernetes (k3d)."
+url = "https://github.com/thangchung/dapr-labs/tree/main/polyglot"
+keywords = "coffeeshop, dapr, kubernetes, polyglot-apps"
+
+---
+
+## Getting Started
+
+- [Demo scenario with coffeeshop application](https://dev.to/thangchung/webassembly-docker-container-dapr-and-kubernetes-better-together-part-1-demo-scenario-with-coffeeshop-application-28i2)
+- [Build and run the coffee shop backend services](https://dev.to/thangchung/webassembly-docker-container-dapr-and-kubernetes-better-together-part-2-build-and-run-the-coffee-shop-backend-services-3c0e)
+- [Daprize the coffee backend services](https://dev.to/thangchung/webassembly-docker-container-dapr-and-kubernetes-better-together-part-3-daprize-the-coffee-backend-services-239n)
+- [Package and deploy to Kubernetes](https://dev.to/thangchung/webassembly-docker-container-dapr-and-kubernetes-better-together-part-4-package-and-deploy-to-kubernetes-4bi8)
+


### PR DESCRIPTION
Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors
- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.

The content of the series blog posts:

- [Demo scenario with coffeeshop application](https://dev.to/thangchung/webassembly-docker-container-dapr-and-kubernetes-better-together-part-1-demo-scenario-with-coffeeshop-application-28i2)
- [Build and run the coffee shop backend services](https://dev.to/thangchung/webassembly-docker-container-dapr-and-kubernetes-better-together-part-2-build-and-run-the-coffee-shop-backend-services-3c0e)
- [Daprize the coffee backend services](https://dev.to/thangchung/webassembly-docker-container-dapr-and-kubernetes-better-together-part-3-daprize-the-coffee-backend-services-239n)
- [Package and deploy to Kubernetes](https://dev.to/thangchung/webassembly-docker-container-dapr-and-kubernetes-better-together-part-4-package-and-deploy-to-kubernetes-4bi8)
