### PR TITLE
Add a check to see if a `spin` item is in the way of the installer succeeding (before we even download the spin tarball)

### DIFF
--- a/downloads/install.sh
+++ b/downloads/install.sh
@@ -116,7 +116,7 @@ URL="https://github.com/fermyon/spin/releases/download/${VERSION}/${FILE}"
 current_dir=$(pwd)
 
 # Define a list of items to check for (this can be updated if the spin tarball is updated)
-items=("/spin" "/LICENSE" "/crt.pem" "spin.sig", "/README.md")
+items=("/spin")
 
 # Create a variable that can be called on to question if an exit 1 is required (due to items already existing)
 exit_due_to_existing_item=0

--- a/downloads/install.sh
+++ b/downloads/install.sh
@@ -114,7 +114,6 @@ URL="https://github.com/fermyon/spin/releases/download/${VERSION}/${FILE}"
 
 # Establish the location of current working environment
 current_dir=$(pwd)
-fancy_print 0 "Current working directory: ${current_dir}"
 
 # Establish the absolute Spin installation location
 spin_installation_location=${current_dir}"/spin"

--- a/downloads/install.sh
+++ b/downloads/install.sh
@@ -123,7 +123,7 @@ exit_due_to_existing_item=0
 
 # Iterate through the list of items
 for item in "${items[@]}"; do
-    if [ -e "${current_dir}${item}" ]; then
+    if [ -d "${current_dir}${item}" ]; then
         # Update the variable because the found existing item now warrants an exit 1 after this loop
         exit_due_to_existing_item=1
         fancy_print 1 "Error ${item} already exists, please delete ${current_dir}${item} and run the installer again."

--- a/downloads/install.sh
+++ b/downloads/install.sh
@@ -126,7 +126,7 @@ for item in "${items[@]}"; do
     if [ -d "${current_dir}${item}" ]; then
         # Update the variable because the found existing item now warrants an exit 1 after this loop
         exit_due_to_existing_item=1
-        fancy_print 1 "Error ${item} already exists, please delete ${current_dir}${item} and run the installer again."
+        fancy_print 1 "Error: ${item} already exists, please delete ${current_dir}${item} and run the installer again."
     fi
 done
 

--- a/downloads/install.sh
+++ b/downloads/install.sh
@@ -115,23 +115,11 @@ URL="https://github.com/fermyon/spin/releases/download/${VERSION}/${FILE}"
 # Establish the location of current working environment
 current_dir=$(pwd)
 
-# Define a list of items to check for (this can be updated if the spin tarball is updated)
-items=("/spin")
+# Define Spin directory name
+spin_directory_name=("/spin")
 
-# Create a variable that can be called on to question if an exit 1 is required (due to items already existing)
-exit_due_to_existing_item=0
-
-# Iterate through the list of items
-for item in "${items[@]}"; do
-    if [ -d "${current_dir}${item}" ]; then
-        # Update the variable because the found existing item now warrants an exit 1 after this loop
-        exit_due_to_existing_item=1
-        fancy_print 1 "Error: .${item} already exists, please delete ${current_dir}${item} and run the installer again."
-    fi
-done
-
-# Question the variable which indicates if an exit 1 must occur (due to pre-existing items)
-if [ "$exit_due_to_existing_item" -eq 1 ]; then
+if [ -d "${current_dir}${spin_directory_name}" ]; then
+    fancy_print 1 "Error: .${spin_directory_name} already exists, please delete ${current_dir}${spin_directory_name} and run the installer again."
     exit 1
 fi
 

--- a/downloads/install.sh
+++ b/downloads/install.sh
@@ -115,12 +115,24 @@ URL="https://github.com/fermyon/spin/releases/download/${VERSION}/${FILE}"
 # Establish the location of current working environment
 current_dir=$(pwd)
 
-# Establish the absolute Spin installation location
-spin_installation_location=${current_dir}"/spin"
+# Define a list of items to check for (this can be updated if the spin tarball is updated)
+items=("/spin" "/LICENSE" "/crt.pem" "spin.sig", "/README.md")
 
-# Check to see if an item called spin already exists (before expending resources downloading the file).
-if [ -e "$spin_installation_location" ]; then
-    fancy_print 1 "Error: ${spin_installation_location} already exists, please delete ${spin_installation_location} and run the installer again."; exit 1
+# Create a variable that can be called on to question if an exit 1 is required (due to items already existing)
+exit_due_to_existing_item=0
+
+# Iterate through the list of items
+for item in "${items[@]}"; do
+    if [ -e "${current_dir}${item}" ]; then
+        # Update the variable because the found existing item now warrants an exit 1 after this loop
+        exit_due_to_existing_item=1
+        fancy_print 1 "Error ${item} already exists, please delete ${current_dir}${item} and run the installer again."
+    fi
+done
+
+# Question the variable which indicates if an exit 1 must occur (due to pre-existing items)
+if [ "$exit_due_to_existing_item" -eq 1 ]; then
+    exit 1
 fi
 
 # Download file, exit if not found - e.g. version does not exist

--- a/downloads/install.sh
+++ b/downloads/install.sh
@@ -121,7 +121,7 @@ spin_installation_location=${current_dir}"/spin"
 
 # Check to see if an item called spin already exists (before expending resources downloading the file).
 if [ -e "$spin_installation_location" ]; then
-    fancy_print 1 "Error ${spin_installation_location} already exists, please delete ${spin_installation_location} and run the installer again."; exit 1
+    fancy_print 1 "Error: ${spin_installation_location} already exists, please delete ${spin_installation_location} and run the installer again."; exit 1
 fi
 
 # Download file, exit if not found - e.g. version does not exist

--- a/downloads/install.sh
+++ b/downloads/install.sh
@@ -112,6 +112,18 @@ fi
 FILE="spin-${VERSION}-${OS}-${ARC}.tar.gz"
 URL="https://github.com/fermyon/spin/releases/download/${VERSION}/${FILE}"
 
+# Establish the location of current working environment
+current_dir=$(pwd)
+fancy_print 0 "Current working directory: ${current_dir}"
+
+# Establish the absolute Spin installation location
+spin_installation_location=${current_dir}"/spin"
+
+# Check to see if an item called spin already exists (before expending resources downloading the file).
+if [ -e "$spin_installation_location" ]; then
+    fancy_print 1 "Error ${spin_installation_location} already exists, please delete ${spin_installation_location} and run the installer again."; exit 1
+fi
+
 # Download file, exit if not found - e.g. version does not exist
 fancy_print 0 "Step 1: Downloading: ${URL}"
 curl -fsOL $URL || (fancy_print 1 "Error downloading the file: ${FILE}"; exit 1)

--- a/downloads/install.sh
+++ b/downloads/install.sh
@@ -126,7 +126,7 @@ for item in "${items[@]}"; do
     if [ -d "${current_dir}${item}" ]; then
         # Update the variable because the found existing item now warrants an exit 1 after this loop
         exit_due_to_existing_item=1
-        fancy_print 1 "Error: ${item} already exists, please delete ${current_dir}${item} and run the installer again."
+        fancy_print 1 "Error: .${item} already exists, please delete ${current_dir}${item} and run the installer again."
     fi
 done
 


### PR DESCRIPTION
Signed-off-by: tpmccallum tim.mccallum@fermyon.com

I was finally able to reproduce an error that has been flagged in an issue. This update closes https://github.com/fermyon/developer/issues/748 by adding a new step in the installer, which checks to see if a `spin` item is in the way of the installer succeeding (before the user’s end expends any resources on downloading the tarball).
