### PR TITLE
Remove copy symbols/icons from codeblocks, because copy does not work on Spin Hub.

### DIFF
--- a/content/api/hub/contributing.md
+++ b/content/api/hub/contributing.md
@@ -47,7 +47,7 @@ Copy the URL from the UI in readiness for running the `git clone` command.
 
 Go ahead and clone the new fork that you just created (the one which resides in your own GitHub account):
 
-<!-- @selectiveCpy -->
+<!-- @nocpy -->
 
 ```bash
 $ cd ~
@@ -59,7 +59,7 @@ $ cd developer
 
 Create a new branch that will house all of your changes for this specific contribution:
 
-<!-- @selectiveCpy -->
+<!-- @nocpy -->
 
 ```bash
 $ git checkout -b my_new_branch
@@ -69,7 +69,7 @@ $ git checkout -b my_new_branch
 
 Create a new remote for the upstream (a pointer to the original repository to which you are contributing):
 
-<!-- @selectiveCpy -->
+<!-- @nocpy -->
 
 ```bash
 $ git remote add upstream https://github.com/fermyon/developer
@@ -81,7 +81,7 @@ Create a **`.md`** Markdown file in the **`content/api/hub`** folder in your for
 
 Below is a copyable example to get you started:
 
-<!-- @selectiveCpy -->
+<!-- @nocpy -->
 
 ```toml
 title = "Rust HTTP trigger template"
@@ -152,7 +152,7 @@ The following is a list of the types of content that a user can submit to the Sp
 
 After your file has been created, you can test it on localhost before committing.
 
-<!-- @selectiveCpy -->
+<!-- @nocpy -->
 
 ```console
 $ npm install
@@ -165,7 +165,7 @@ Once your changes have been checked, go ahead and add your changes by moving to 
 
 Add your changes by running the following command, from the root of the developer repository:
 
-<!-- @selectiveCpy -->
+<!-- @nocpy -->
 
 ```bash
 $ git add .
@@ -177,12 +177,12 @@ Before committing, please ensure that your GitHub installation is configured suf
 
 If you need to set these values please use the following commands:
 
-<!-- @selectiveCpy -->
+<!-- @nocpy -->
 
 ```bash
 $ git config user.name "yourusername"
 ```
-<!-- @selectiveCpy -->
+<!-- @nocpy -->
 
 ```bash
 $ git config user.email "youremail@somemail.com"
@@ -192,7 +192,7 @@ More information can be found at this GitHub documentation page called [signing 
 
 Type the following commit command to ensure that you sign off (--signoff), sign the data (-S) - recommended, and also leave a short message (-m):
 
-<!-- @selectiveCpy -->
+<!-- @nocpy -->
 
 ```bash
 $ git commit -S --signoff -m "Updating Spin Up Hub"
@@ -204,13 +204,15 @@ $ git commit -S --signoff -m "Updating Spin Up Hub"
 
 At this stage, it is a good idea to just quickly check what GitHub thinks the origin is. For example, if we type `git remote -v` we can see that the origin is our repo; which we a) forked the original repo into and b) which we then cloned to our local disk so that we could edit:
 
-<!-- @selectiveCpy -->
+<!-- @nocpy -->
 
 ```bash
 $ git remote -v
 ```
 
 The above command will return output similar to the following:
+
+<!-- @nocpy -->
 
 ```bash
 origin	git@github.com:yourusername/developer.git (fetch)
@@ -221,7 +223,7 @@ upstream	https://github.com/fermyon/developer (push)
 
 Once you are satisfied go ahead and push your changes:
 
-<!-- @selectiveCpy -->
+<!-- @nocpy -->
 
 ```bash
 $ git push -u origin my_new_branch

--- a/content/spin/contributing-docs.md
+++ b/content/spin/contributing-docs.md
@@ -417,7 +417,6 @@ You can host your changes to the developer documentation on your own machine (lo
 <!-- @selectiveCpy -->
 
 ```bash
-$ cd developer
 $ npm install
 $ cd spin-up-hub
 $ npm install

--- a/content/spin/contributing-docs.md
+++ b/content/spin/contributing-docs.md
@@ -412,11 +412,17 @@ Let's take a quick look at how you can use the `bart` CLI to check any content t
 
 ### 6.7 Checking Your Content - Preview a Documentation Page on Localhost
 
-You can host your changes to the developer documentation on your own machine (localhost) by using the following `spin` command: 
+You can host your changes to the developer documentation on your own machine (localhost) by using the following `spin` commands: 
 
 <!-- @selectiveCpy -->
 
 ```bash
+$ cd developer
+$ npm install
+$ cd spin-up-hub
+$ npm install
+$ cd ../../developer
+$ spin build
 $ spin up -e "PREVIEW_MODE=1"
 ```
 

--- a/content/spin/contributing-docs.md
+++ b/content/spin/contributing-docs.md
@@ -421,7 +421,7 @@ $ cd developer
 $ npm install
 $ cd spin-up-hub
 $ npm install
-$ cd ../../developer
+$ cd ..
 $ spin build
 $ spin up -e "PREVIEW_MODE=1"
 ```


### PR DESCRIPTION
Signed-off-by: tpmccallum tim.mccallum@fermyon.com