### PR TITLE
Update selective copy

### DIFF
--- a/content/cloud/data-postgres.md
+++ b/content/cloud/data-postgres.md
@@ -63,8 +63,6 @@ HTTP path: /data
 
 ## CSharp
 
-<!-- @nocpy -->
-
 ```csharp
 using Fermyon.Spin.Sdk;
 using System.Net;

--- a/content/cloud/rest-api.md
+++ b/content/cloud/rest-api.md
@@ -18,8 +18,6 @@ The [Fermyon Cloud OpenAPI](https://github.com/fermyon/cloud-openapi) project co
 
 To use [the Rust client](https://github.com/fermyon/cloud-openapi/tree/main/clients/rust), go ahead and add a reference to the Fermyon Cloud OpenAPI in your project’s `Cargo.toml` file, as shown below:
 
-<!-- @nocpy -->
-
 ```toml
 cloud-openapi = { git = "https://github.com/fermyon/cloud-openapi" }
 ```

--- a/content/cloud/variables.md
+++ b/content/cloud/variables.md
@@ -78,7 +78,7 @@ Our application receives a password via the HTTP request body, compares it to an
 
 In reality, you'd have multiple usernames and password hashes in a database, but for this tutorial, we will configure the expected password using a Spin application variable. We'll name the variable `password` and set `required = true` since there is no reasonable default value. To do this, add a top-level `[variables]` section to the application manifest (`spin.toml`) and declare the variable within it:
 
-<!-- @selectiveCpy -->
+<!-- @nocpy -->
 
 ```toml
 # Add this above the [component] section
@@ -88,7 +88,7 @@ password = { required = true }
 
 To surface the variable to the `pw-checker` component, add a `[component.config]` section in the component and specify the variable within it. Instead of statically assigning the value of the config variable, we are referencing the dynamic variable with [mustache](https://mustache.github.io/)-inspired string templates. Only components that explicitly use the variables in their configuration section will get access to them. This enables only exposing variables and secrets to the desired components of an application:
 
-<!-- @selectiveCpy -->
+<!-- @nocpy -->
 
 ```toml
 # Add this below the [component.build] section
@@ -124,8 +124,6 @@ password = "\{{ password }}"
 ## Using Variables in a Spin Application
 
 Now that we have defined our variables and surfaced them to our component, we are ready to implement our Spin application. The application should get the user-provided password from the body of the HTTP request, compare it to the expected password set in our configuration variable, and authenticate accordingly. We will use the Spin `spin_config` module to retrieve the value of the `password` variable:
-
-<!-- @selectiveCpy -->
 
 ```py
 from spin_http import Response

--- a/content/spin/build.md
+++ b/content/spin/build.md
@@ -113,6 +113,8 @@ $ spin plugins install py2wasm --yes
 
 The build command then calls `spin py2wasm` on your application file:
 
+<!-- @nocpy -->
+
 ```toml
 [component.build]
 command = "spin py2wasm app -o app.wasm"
@@ -125,6 +127,8 @@ command = "spin py2wasm app -o app.wasm"
 For Go applications, you must use the TinyGo compiler, as the standard Go compiler does not yet support the WASI standard.  See the [TinyGo installation guide](https://tinygo.org/getting-started/install/).
 
 The build command calls TinyGo with the WASI backend and appropriate options:
+
+<!-- @nocpy -->
 
 ```toml
 [component.build]

--- a/content/spin/contributing-docs.md
+++ b/content/spin/contributing-docs.md
@@ -73,6 +73,8 @@ The resulting output would be as follows.
 
 If a document is relevant to two or more projects, the dynamic body feature of bartholomew is to be used. Create the document in one of the projects with the content. In the other project(s) create a file with only the frontmatter. Then add the following field to the frontmatter:
 
+<!-- @nocpy -->
+
 ```toml
 .
 .
@@ -83,6 +85,8 @@ body_source = "<path to the content>"
 ```
 
 The value for the `body_source` key, should be the path from which the content is being shared (relative to the repository's `content` folder). For example if the Spin project's `developer/content/spin/contributing-docs.md` holds the sharable content (as the single source of truth), then the Cloud project can display that same content by using the following frontmatter:
+
+<!-- @nocpy -->
 
 ```toml
 title = "Contributing to Docs"
@@ -153,6 +157,8 @@ $ git remote add upstream https://github.com/fermyon/developer
 
 It is highly recommended that you use either the `<!-- @selectiveCpy -->` or the `<!-- @nocpy -->` annotation before each of your code blocks, and that each code block defines the appropriate [syntax highlighting](https://rdmd.readme.io/docs/code-blocks#language-support). The annotation can be skipped for code blocks with example code snippets i.e. non-terminal or generic output examples.
 
+**Selective copy**
+
 The selective copy annotation (`<!-- @selectiveCpy -->`) is intended for use when communicating code and/or CLI commands for the reader to copy and paste. The selective copy annotation allows the reader to see the entire code block (both commands and results) but only copies the lines that start with `$` into the reader's clipboard (minus the `$`) when the user clicks the copy button. For example, copying the following code block will only copy `echo "hello"` into your clipboard, for pasting.
 
 <!-- @selectiveCpy -->
@@ -164,6 +170,8 @@ hello
 
 > Note: If the command, that starts with `$`, is deliberately spread over two lines (by escaping the newline character), then the copy mechanism will still copy the second line which is technically still part of that single command.
 
+**No copy**
+
 The no copy annotation (`<!-- @nocpy -->`) precedes a code block where no copy and pasting of code is intended. If using the no copy attribute please still be sure to add the appropriate syntax highlighting to your code block (for display purposes). For example:
 
 `<!-- @nocpy -->`
@@ -171,6 +179,12 @@ The no copy annotation (`<!-- @nocpy -->`) precedes a code block where no copy a
 ```bash
 Some generic code not intended for copying/pasting
 ```
+
+**Non-selective copy** - just a straight copy without any additional features.
+
+If you want the code in a code block to be copyable with no "smarts" to remove the `$` then you can just simply leave out the annotation altogether. A code block in markdown will be copyable without smarts just as is.
+
+**Multi-tab code blocks**
 
 Multi-tab code blocks [have recently been implemented](https://github.com/fermyon/developer/pull/239). Examples can be seen in the [Spin](/spin/install#installing-spin) installer documentation](/spin/install#installing-spin) and [Spin Key/Value documentation](/spin/kv-store-tutorial#the-spin-toml-file). The above examples demonstrate how tabs can either represent platforms i.e. `Windows`, `Linux` and `macOS` or represent specific programming languages i.e. `Rust`, `JavaScript` and `Golang` etc. Here is a brief example of how to implement multi-tab code blocks when writing technical documentation for this site, using markdown.
 

--- a/content/spin/http-trigger.md
+++ b/content/spin/http-trigger.md
@@ -155,8 +155,6 @@ The exact signature of the HTTP handler, and how a function is identified to be 
 
 In Rust, the handler is identified by the `#[spin_sdk::http_component]` attribute.  It takes a `spin_sdk::http::Request`, and returns a `spin_sdk::http::Response` (or error).  These types are instantiations of the standard `http::Request` and `http::Response` types and behave exactly like them:
 
-<!-- @nocpy -->
-
 ```rust
 use anyhow::Result;
 use spin_sdk::{
@@ -182,8 +180,6 @@ In JavaScript or TypeScript, the handler is identified by name.  It must be call
 
 In **JavaScript**, `handleRequest` is declared as `export async function`.  It takes a JsvaScript object representing the request, and returns a response object.  The fields of these objects are exactly the same as in TypeScript:
 
-<!-- @nocpy -->
-
 ```javascript
 export async function handleRequest(request) {
     return {
@@ -195,8 +191,6 @@ export async function handleRequest(request) {
 ```
 
 In **TypeScript**, `handleRequest` is declared as an `export const` of the `HandleRequest` function type - that is, a function literal rather than a function declaration.  It takes a `HttpRequest` object, and returns a `HttpResponse` object, both defined in the `@fermyon/spin-sdk` package:
-
-<!-- @nocpy -->
 
 ```javascript
 import { HandleRequest, HttpRequest, HttpResponse} from "@fermyon/spin-sdk"
@@ -216,8 +210,6 @@ export const handleRequest: HandleRequest = async function(request: HttpRequest)
 
 In Python, the handler is identified by name.  It must be called `handle_request`.  It takes a request object and must return an instance of `Response`, defined in the `spin_http` package:
 
-<!-- @nocpy -->
-
 ```python
 from spin_http import Response
 
@@ -234,8 +226,6 @@ def handle_request(request):
 In Go, you register the handler as a callback in your program's `init` function.  Call `spinhttp.Handle`, passing your handler as the sole argument.  Your handler takes a `http.Request` record, from the standard `net/http` package, and a `ResponseWriter` to construct the response.
 
 > The do-nothing `main` function is required by TinyGo but is not used; the action happens in the `init` function and handler callback.
-
-<!-- @nocpy -->
 
 ```go
 package main
@@ -434,8 +424,6 @@ print("hello world\n");
 Here is a working example, written in [Grain](https://grain-lang.org/),
 a programming language that natively targets WebAssembly and WASI but
 does not yet support the component model:
-
-<!-- @nocpy -->
 
 ```js
 import Process from "sys/process";

--- a/content/spin/javascript-components.md
+++ b/content/spin/javascript-components.md
@@ -179,8 +179,6 @@ Building a Spin HTTP component using the JS/TS SDK means writing a single functi
 that takes an HTTP request as a parameter, and returns an HTTP response — below
 is a complete implementation for such a component in TypeScript:
 
-<!-- @nocpy -->
-
 ```Javascript
 import { HandleRequest, HttpRequest, HttpResponse } from "@fermyon/spin-sdk"
 
@@ -223,8 +221,6 @@ If allowed, Spin components can send outbound HTTP requests.
 Let's see an example of a component that makes a request to
 [an API that returns random animal facts](https://random-data-api.fermyon.app/animals/json) and
 inserts a custom header into the response before returning:
-
-<!-- @nocpy -->
 
 ```javascript
 const encoder = new TextEncoder("utf-8")
@@ -313,8 +309,6 @@ proxies or URL shorteners.
 Using the Spin's JS SDK, you can use the Redis key/value store and to publish messages to Redis channels.
 
 Let's see how we can use the JS/TS SDK to connect to Redis:
-
-<!-- @nocpy -->
 
 ```javascript
 import { HandleRequest, HttpRequest, HttpResponse, Redis } from "@fermyon/spin-sdk"

--- a/content/spin/kv-store-tutorial.md
+++ b/content/spin/kv-store-tutorial.md
@@ -230,8 +230,6 @@ Now let's use the Spin SDK to:
 
 {{ startTab "Rust"}}
 
-<!-- @nocpy -->
-
 ```rust
 use anyhow::Result;
 use http::{Method, StatusCode};
@@ -285,8 +283,6 @@ fn handle_request(req: Request) -> Result<Response> {
 
 {{ startTab "TypeScript"}}
 
-<!-- @nocpy -->
-
 ```typescript
 import { HandleRequest, HttpRequest, HttpResponse, Kv } from "@fermyon/spin-sdk"
 
@@ -333,8 +329,6 @@ export const handleRequest: HandleRequest = async function (request: HttpRequest
 {{ blockEnd }}
 
 {{ startTab "TinyGo" }}
-
-<!-- @nocpy -->
 
 ```go
 package main
@@ -448,7 +442,7 @@ We can now use a `HEAD` request to confirm that our component is holding data fo
 <!-- @selectiveCpy -->
 
 ```bash
-curl -I HEAD localhost:3000/test -v                                                     
+$ curl -I HEAD localhost:3000/test -v                                                     
 
 Trying 127.0.0.1:3000...
 * Connected to localhost (127.0.0.1) port 3000

--- a/content/spin/managing-plugins.md
+++ b/content/spin/managing-plugins.md
@@ -29,7 +29,7 @@ To install plugins, use the `spin plugins install` command. You can install plug
 
 The Spin maintainers curate a catalogue of "known" plugins. You can install plugins from this catalogue by name:
 
-<!-- @nocpy -->
+<!-- @selectiveCpy -->
 
 ```bash
 $ spin plugins install js2wasm
@@ -73,7 +73,7 @@ $ spin plugins install --file ~/dev/spin-befunge-sdk/befunge2wasm.json
 
 You run plugins in the same way as built-in Spin subcommands. For example:
 
-<!-- @nocpy -->
+<!-- @selectiveCpy -->
 
 ```bash
 $ spin js2wasm --help
@@ -122,7 +122,7 @@ $ spin plugins uninstall befunge2wasm
 
 To upgrade a plugin to the latest version, run `spin plugins upgrade`. This has the same options as `spin plugins install`, according to whether the plugin comes from the catalogue, a URL, or a file:
 
-<!-- @nocpy -->
+<!-- @selectiveCpy -->
 
 ```bash
 $ spin plugins upgrade js2wasm

--- a/content/spin/managing-templates.md
+++ b/content/spin/managing-templates.md
@@ -28,7 +28,7 @@ To install templates, use the `spin templates install` command. You can install 
 
 To install templates from the Spin Git repository, run `spin templates install --git`.
 
-<!-- @nocpy -->
+<!-- @selectiveCpy -->
 
 ```bash
 $ spin templates install --git https://github.com/fermyon/spin

--- a/content/spin/python-components.md
+++ b/content/spin/python-components.md
@@ -118,8 +118,6 @@ In Spin, HTTP components are triggered by the occurrence of an HTTP request and 
 
 Building a Spin HTTP component using the Python SDK means writing a single function that takes an HTTP request as a parameter, and returns an HTTP response. Here is an example of the default Python code which the previous `spin new` created for us; a simple example of a request/response:
 
-<!-- @nocpy -->
-
 ```
 from spin_http import Response
 
@@ -175,9 +173,7 @@ Hello from the Python SDK
 
 This next example will create an outbound request, to obtain a random fact about animals, which will be returned to the calling code. If you would like to try this out, you can go ahead and update your existing `app.py` file from the previous step; using the following source code:
 
-<!-- @nocpy -->
-
-```
+```python
 from spin_http import Request, Response, http_send
 
 
@@ -195,7 +191,9 @@ def handle_request(request):
 
 The Spin framework protects your code from making outbound requests to just any URL. For example, if we try to run the above code **without any additional configuration**, we will correctly get the following error `AssertionError: HttpError::DestinationNotAllowed`. To allow our component to request the `random-data-api.fermyon.app` domain, all we have to do is add that domain to the specific component of the application that is making the request. Here is an example of an updated `spin.toml` file where we have added `allowed_http_hosts`:
 
-```
+<!-- @nocpy -->
+
+```toml
 spin_manifest_version = "1"
 authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 description = ""
@@ -268,9 +266,7 @@ command = "spin py2wasm app -o app.wasm"
 
 If you are still following along, please go ahead and update your `app.py` file one more time, as follows:
 
-<!-- @nocpy -->
-
-```
+```python
 from spin_http import Response
 from spin_redis import redis_del, redis_get, redis_incr, redis_set, redis_sadd, redis_srem, redis_smembers
 from spin_config import config_get

--- a/content/spin/quickstart.md
+++ b/content/spin/quickstart.md
@@ -313,8 +313,6 @@ takes an HTTP request as a parameter and returns an HTTP response, and it is
 annotated with the `http_component` macro which identifies it as the entry point
 for HTTP requests:
 
-<!-- @nocpy -->
-
 ```rust
 use anyhow::Result;
 use spin_sdk::{
@@ -406,8 +404,6 @@ JavaScript version looks slightly different, but is still a function with
 the same signature.)  The Spin `js2wasm` plugin looks for the `handleRequest` function
 by name when building your application into a Wasm module:
 
-<!-- @nocpy -->
-
 ```javascript
 import { HandleRequest, HttpRequest, HttpResponse} from "@fermyon/spin-sdk"
 
@@ -486,8 +482,6 @@ WebAssembly module.
 Now let's have a look at the code. Below is the complete source
 code for a Spin HTTP component written in Python — a regular function named `handle_request` that
 takes an HTTP request as a parameter and returns an HTTP response.  The Spin `py2wasm` plugin looks for the `handle_request` function by name when building your application into a Wasm module.
-
-<!-- @nocpy -->
 
 ```python
 from spin_http import Response
@@ -572,8 +566,6 @@ sets up a callback, and passes that callback to `spinhttp.Handle` to register it
 the handler for HTTP requests.  You can learn more about this structure
 in the [Go language guide](go-components).
 
-<!-- @nocpy -->
-
 ```go
 package main
 
@@ -605,8 +597,6 @@ The Spin template creates starter source code.  Now you need to turn that into a
 {{ tabs "sdk-type" }}
 
 {{ startTab "Rust"}}
-
-<!-- @selectiveCpy -->
 
 ```bash
 $ spin build

--- a/content/spin/redis-trigger.md
+++ b/content/spin/redis-trigger.md
@@ -69,8 +69,6 @@ The exact signature of the Redis handler, and how a function is identified to be
 
 In Rust, the handler is identified by the `#[spin_sdk::redis_component]` attribute.  It takes a `bytes::Bytes`, representing the raw payload of the Redis message, and returns an `anyhow::Result` indicating success or an error with details.  This example just logs the payload as a string:
 
-<!-- @nocpy -->
-
 ```rust
 use anyhow::Result;
 use bytes::Bytes;
@@ -106,8 +104,6 @@ In Go, you register the handler as a callback in your program's `init` function.
 > The do-nothing `main` function is required by TinyGo but is not used; the action happens in the `init` function and handler callback.
 
 This example just logs the payload as a string:
-
-<!-- @nocpy -->
 
 ```go
 package main

--- a/content/spin/running-apps.md
+++ b/content/spin/running-apps.md
@@ -97,6 +97,8 @@ If any of these change, Spin will rebuild the application if necessary, then res
 
 The following `spin.toml` configuration (belonging to a Spin `http-rust` application) is configured to ensure that the application is both **rebuilt** (via `cargo build --target wasm32-wasi --release`) and **rerun** whenever changes occur in any Rust source (`.rs`) files, the `Cargo.toml` file or the `spin.toml` file, itself. When changes occur in either the Wasm binary file (`target/wasm32-wasi/release/test.wasm`) or the text file (`my-files/changing-file.txt`) the application is only **rerun** using the initial `spin up` command:
 
+<!-- @nocpy -->
+
  ```toml
 [[component]]
 // -- snip

--- a/content/spin/rust-components.md
+++ b/content/spin/rust-components.md
@@ -20,7 +20,7 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/rust-componen
 - [AI Inferencing From Rust Components](#ai-inferencing-from-rust-components)
 - [Troubleshooting](#troubleshooting)
 - [Manually Creating New Projects With Cargo](#manually-creating-new-projects-with-cargo)
-- [Read the Rust Spin SDK documentation](#read-the-rust-spin-sdk-documentation)
+- [Read the Rust Spin SDK Documentation](#read-the-rust-spin-sdk-documentation)
 
 Spin aims to have best-in-class support for building components in Rust, and
 writing such components should be familiar for Rust developers.
@@ -85,8 +85,6 @@ Building a Spin HTTP component using the Rust SDK means writing a single functio
 that takes an HTTP request as a parameter, and returns an HTTP response — below
 is a complete implementation for such a component:
 
-<!-- @nocpy -->
-
 ```rust
 use anyhow::Result;
 use spin_sdk::{
@@ -125,8 +123,6 @@ new messages on the configured channels.
 > See the [Redis trigger](./redis-trigger.md) for details about the Redis trigger.
 
 Writing a Redis component in Rust also takes advantage of the SDK:
-
-<!-- @nocpy -->
 
 ```rust
 use anyhow::Result;
@@ -215,8 +211,6 @@ Let's see an example of a component that makes a request to
 [an API that returns random animal facts](https://random-data-api.fermyon.app/animals/json) and
 inserts a custom header into the response before returning:
 
-<!-- @nocpy -->
-
 ```rust
 use anyhow::Result;
 use spin_sdk::{
@@ -301,8 +295,6 @@ messages to Redis channels. This can be used from both HTTP and Redis triggered
 components.
 
 Let's see how we can use the Rust SDK to connect to Redis:
-
-<!-- @nocpy -->
 
 ```rust
 use anyhow::{anyhow, Result};

--- a/content/spin/serverless-ai-api-guide.md
+++ b/content/spin/serverless-ai-api-guide.md
@@ -19,6 +19,8 @@ The nature of AI and LLM workloads on already trained models lends itself very n
 
 By default, a given component of a Spin application will not have access to any Serverless AI models. Access must be provided explicitly via the Spin application's manifest (the `spin.toml` file).  For example, an individual component in a Spin application could be given access to the llama2-chat model by adding the following `ai_models` configuration inside the specific `[[component]]` section:
 
+<!-- @nocpy -->
+
 ```toml
 // -- snip --
 
@@ -61,6 +63,8 @@ The exact detail of calling these operations from your application depends on yo
 {{ startTab "Rust"}}
 
 To use Serverless AI functions, the `llm` module from the Spin SDK provides the methods. The following snippet is from the [Rust code generation example](https://github.com/fermyon/ai-examples/tree/main/code-generator-rs):
+
+<!-- @nocpy -->
 
 ```rust
 use spin_sdk::{

--- a/content/spin/serverless-ai-tutorial.md
+++ b/content/spin/serverless-ai-tutorial.md
@@ -232,8 +232,6 @@ Now let's use the Spin SDK to access the model from our app:
 
 {{ startTab "Rust"}}
 
-<!-- @selectiveCpy -->
-
 ```rust
 use std::str::FromStr;
 
@@ -414,8 +412,6 @@ impl FromStr for Sentiment {
 
 {{ startTab "TypeScript"}}
 
-<!-- @selectiveCpy -->
-
 ```typescript
 import {
   HandleRequest,
@@ -577,12 +573,14 @@ We create an `assets` directory where we can store files to serve statically (se
 <!-- @selectiveCpy -->
 
 ```bash
-mkdir assets
+$ mkdir assets
 ```
 
 ### Application Manifest
 
 As shown below, the Spin framework has done all of the scaffolding for us:
+
+<!-- @nocpy -->
 
 ```toml
 spin_manifest_version = "1"

--- a/content/spin/spin-application-structure.md
+++ b/content/spin/spin-application-structure.md
@@ -14,6 +14,8 @@ As mentioned in this [blog post](https://www.fermyon.com/blog/spin-application-s
 
 If we start with a blank canvas and use the `http-empty` template we will get a new Spin application:
 
+<!-- @selectiveCpy -->
+
 ```console
 $ spin new http-empty
 Enter a name for your new application: myapp
@@ -23,12 +25,16 @@ HTTP base: /
 
 The above command will provide an empty structure, as shown below:
 
+<!-- @nocpy -->
+
 ```console
 └── myapp
     └── spin.toml
 ```
 
 To add new components to the application, we simply move into the `myapp` directory and begin to add components using the `spin add` subcommand:
+
+<!-- @selectiveCpy -->
 
 ```console
 $ spin add http-rust
@@ -42,6 +48,8 @@ HTTP path: /second/...
 ```
 
 After adding two new components, we can see the visual representation of our application. Notice the symmetry; there is no hierarchy or nesting of components:
+
+<!-- @nocpy -->
 
 ```console
 .
@@ -84,6 +92,8 @@ fn handle_second_http_rust_component(req: Request) -> Result<Response> {
 
 As an additional example of adding more components, let's add a new static file server component:
 
+<!-- @selectiveCpy -->
+
 ```console
 $ spin add static-fileserver
 Enter a name for your new component: assets
@@ -92,6 +102,8 @@ Directory containing the files to serve: assets
 ```
 
 After the static file server component is added, we create the `assets` directory (our local directory containing the files to serve) and then add some static content into the `assets` directory to be served:
+
+<!-- @selectiveCpy -->
 
 ```console
 $ mkdir assets
@@ -104,6 +116,8 @@ $ cp ~/Desktop/new.txt assets
 
 Why stop there? We can add even more functionality to our application. Let's now add a `redirect` component to redirect requests made to `/static/old.txt` and forward those through to `/static/new.txt`:
 
+<!-- @selectiveCpy -->
+
 ```console
 $ spin add redirect
 Enter a name for your new component: additional-component-redirect
@@ -112,6 +126,8 @@ Redirect to: /static/new.txt
 ```
 
 We now have 4 separate components scaffolded for us by Spin. Note the application manifest (the `spin.toml` file) is correctly configured based on our `spin add` commands:
+
+<!-- @nocpy -->
 
 ```toml
 spin_manifest_version = "1"
@@ -160,6 +176,8 @@ executor = { type = "wagi" }
 ```
 
 Also, note that the application's folder structure, scaffolded for us by Spin via the spin add commands, is symmetrical and shows no nesting of components:
+
+<!-- @nocpy -->
 
 ```console
 ├── assets

--- a/content/spin/variables.md
+++ b/content/spin/variables.md
@@ -21,7 +21,8 @@ Variables are added to an application under the top-level `[variables]` section 
 
 For example, say an application needs to access a secret. A `[variables]` section could be added to an application's manifest with one entry for a variable named `secret`. Since there is no reasonable default value for a secret, the variable is set as required with `required = true`:
 
-<!-- @selectiveCpy -->
+<!-- @nocpy -->
+
 ```toml
 # Add this above the [component] section
 [variables]
@@ -29,6 +30,8 @@ secret = { required = true }
 ```
 
 Variables are surfaced to a specific component by adding a `[component.config]` section to the component and referencing them within it. The `[component.config]` section contains a mapping of component variables and values. Entries can be static (like `api_host` below) or reference an updatable application variable (like `password` below) using [mustache](https://mustache.github.io/)-inspired string templates. Only components that explicitly use variables in their configuration section will get access to them. This enables only exposing variables (such as secrets) to the desired components of an application.
+
+<!-- @nocpy -->
 
 ```toml
 # Add this below the [component.build] section
@@ -41,7 +44,8 @@ When a component configuration variable references an application variable, it's
 
 A complete application manifest with a `secret` variable and a component that uses it would look similar to the following, with the `[component.build]` section varying depending on the language used to build the `password_checker` component:
 
-<!-- @selectiveCpy -->
+<!-- @nocpy -->
+
 ```toml
 spin_manifest_version = "1"
 description = "A Spin app with a dynamically updatable secret"

--- a/content/spin/writing-apps.md
+++ b/content/spin/writing-apps.md
@@ -132,8 +132,6 @@ At the Wasm level, a Spin component is a Wasm module that exports a handler for 
 
 See the Language Guides section for how to do this in your preferred language. As an example, this is a component written in the Rust language. The `hello_world` function uses an attribute `#[http_component]` to identify the function as handling a Spin HTTP event. The function takes a `Request` and returns a `Result<Response>`:
 
-<!-- @nocpy -->
-
 ```rust
 #[http_component]​
 fn hello_world(_req: Request) -> Result<Response> {​
@@ -259,6 +257,8 @@ You can include files with a component.  This means that:
 
 To do this, use the `files` field in the component manifest:
 
+<!-- @nocpy -->
+
 ```toml
 [[component]]
 files = [ "images/**/*.jpg", { source = "styles/dist", destination = "/styles" } ]
@@ -278,6 +278,8 @@ If your files list would match some files or directories that you _don't_ want i
 Environment variables can be provided to components via the Spin application manifest.
 
 To do this, use the `environment` field in the component manifest:
+
+<!-- @nocpy -->
 
 ```toml
 [[component]]
@@ -303,6 +305,8 @@ fn handle_hello_rust(req: Request) -> Result<Response> {
 
 By default, Spin components are not allowed to make outgoing HTTP requests.  This follows the general Wasm rule that modules must be explicitly granted capabilities, which is important to sandboxing.  To grant a component permission to make HTTP requests to a particular host, use the `allowed_http_hosts` field in the component manifest:
 
+<!-- @nocpy -->
+
 ```toml
 [[component]]
 allowed_http_hosts = [ "dog-facts.example.com", "api.example.com:8080" ]
@@ -315,6 +319,8 @@ For development-time convenience, you can also pass the string `"insecure:allow-
 ## Granting Storage Permissions to Components
 
 By default, Spin components are not allowed to access Spin's storage services.  This follows the general Wasm rule that modules must be explicitly granted capabilities, which is important to sandboxing.  To grant a component permission to use a Spin-provided store, use the `key_value_stores` field in the component manifest:
+
+<!-- @nocpy -->
 
 ```toml
 [[component]]


### PR DESCRIPTION
Noticed a bunch of code blocks that were not using selective copy, no copy as intended.

Rule of thumb that I am following is:
- if a code block has `$` at the start of the commands and you just want the lines prefixed with `$` to be copied to the user’s clipboard (with the `$` magically removed so when the user pastes the commands they work in their terminal; i.e. no `$` persists) then use `<!-- @selectiveCpy —>` before the code block
- if a code block has content in it that you don’t want the user to easily “click” to copy i.e. some output like `befunged output is returned.` then use the `<!-- @nocpy —>`
- if a code block has usable code such as Rust or Javascript and you would like to make it possible for the user to “click” and obtain that code block’s content’s in their clipboard for pasting then don’t use either `<!-- @selectiveCpy —>` OR `<!-- @nocpy —>`. Instead just use nothing and start the code block using the normal markdown and language highlighting.

Fixes https://github.com/fermyon/developer/issues/879

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors
- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
