### PR TITLE
Update serverless-ai-api-guide.md

### DIFF
--- a/content/spin/serverless-ai-api-guide.md
+++ b/content/spin/serverless-ai-api-guide.md
@@ -40,7 +40,7 @@ By default, the Spin framework will expect any already trained model files (whic
 code-generator-rs/.spin/ai_models/codellama-instruct
 ```
 
-See the [serverless AI Tutorial](/spin/serverless-ai-tutorial) documentation for more concrete examples of implementing the Fermyon Server AI API, in your favorite language.
+See the [serverless AI Tutorial](/spin/serverless-ai-tutorial) documentation for more concrete examples of implementing the Fermyon Serverless AI API, in your favorite language.
 
 > Embeddings models are slightly more complicated; it is expected that both a `tokenizer.json` and a `model.safetensors` are located in the directory named after the model. For example, for the `foo-bar-baz` model, Spin will look in the `.spin/ai-models/foo-bar-baz` directory for `tokenizer.json` and a `model.safetensors`.
 


### PR DESCRIPTION
minor typo

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
