### PR TITLE
Fix typo in ai-sentiment-analysis-api-tutorial.md

### DIFF
--- a/content/spin/ai-sentiment-analysis-api-tutorial.md
+++ b/content/spin/ai-sentiment-analysis-api-tutorial.md
@@ -168,15 +168,15 @@ tree .spin
     └── codellama-instruct
 ```
 
-**all-minikm-16-v2 example download**
+**all-minilm-l6-v2 example download**
 
 The following section fetches a specific version of the [sentence-transformers](https://www.sbert.net/index.html#) model:
 
 <!-- @selectiveCpy -->
 
 ```bash
-$ mkdir -p .spin/ai-models/all-minikm-16-v2
-$ cd .spin/ai-models/all-minikm-16-v2
+$ mkdir -p .spin/ai-models/all-minilm-l6-v2
+$ cd .spin/ai-models/all-minilm-l6-v2
 $ wget https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/7dbbc90392e2f80f3d3c277d6e90027e55de9125/tokenizer.json
 $ wget https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/0b6dc4ef7c29dba0d2e99a5db0c855c3102310d8/model.safetensors
 ```
@@ -187,7 +187,7 @@ $ wget https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/0b6
 tree .spin
 .spin
 └── ai-models
-    └── all-minikm-16-v2
+    └── all-minilm-l6-v2
         ├── model.safetensors
         └── tokenizer.json
 ```


### PR DESCRIPTION
Replaced `all-minikm-16-v2` with `all-minilm-l6-v2`
- notice the `k` turns into an `l`
- notice the `1` turns into an `l`

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
