### PR TITLE
Create v2 dir and update dates in frontmatter

### DIFF
--- a/content/spin/v2/ai-sentiment-analysis-api-tutorial.md
+++ b/content/spin/v2/ai-sentiment-analysis-api-tutorial.md
@@ -1,0 +1,952 @@
+title = "Sentiment Analysis With Serverless AI"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+enable_shortcodes = true
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/ai-sentiment-analysis-api-tutorial.md"
+
+---
+- [Tutorial Prerequisites](#tutorial-prerequisites)
+  - [Spin](#spin)
+  - [Dependencies](#dependencies)
+- [Licenses](#licenses)
+- [Serverless AI Inferencing With Spin Applications](#serverless-ai-inferencing-with-spin-applications)
+  - [Creating a New Spin Application](#creating-a-new-spin-application)
+  - [Supported AI Models](#supported-ai-models)
+  - [Model Optimization](#model-optimization)
+  - [Application Structure](#application-structure)
+  - [Application Configuration](#application-configuration)
+  - [Source Code](#source-code)
+  - [Additional Functionality](#additional-functionality)
+  - [Static Fileserver Component For The UI](#static-fileserver-component-for-the-ui)
+  - [Key Value Explorer](#key-value-explorer)
+  - [Application Manifest](#application-manifest)
+  - [Building and Deploying Your Spin Application](#building-and-deploying-your-spin-application)
+  - [Test Locally](#test-locally)
+  - [Deploy to Fermyon Cloud](#deploy-to-fermyon-cloud)
+  - [Testing in Fermyon Cloud](#testing-in-fermyon-cloud)
+  - [Visit Fermyon Cloud UI](#visit-fermyon-cloud-ui)
+- [Integrating Custom Domain and Storage](#integrating-custom-domain-and-storage)
+- [Conclusion](#conclusion)
+- [Next Steps](#next-steps)
+
+Artificial Intelligence (AI) Inferencing performs well on GPUs. However, GPU infrastructure is both scarce and expensive. This tutorial will show you how to use Fermyon Serverless AI to quickly build advanced AI-enabled serverless applications that can run on Fermyon Cloud. Your applications will benefit from 50 millisecond cold start times and operate 100x faster than other on-demand AI infrastructure services. Take a quick look at the video below to learn about executing inferencing on LLMs with no extra setup.
+
+<iframe width="854" height="480" src="https://www.youtube.com/embed/01oOh3D9cVQ?si=wORKmuOkeFMGYBsQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
+In this tutorial we will:
+
+* Update Spin (and dependencies) on your local machine
+* Create a Serverless AI application
+* Learn about the Serverless AI SDK (in Rust, TypeScript and Python)
+
+## Tutorial Prerequisites
+
+### Spin 
+
+You will need to [install the latest version of Spin](install#installing-spin). Serverless AI is supported on Spin versions 1.5 and above. 
+
+If you already have Spin installed, [check what version you are on and upgrade](upgrade#are-you-on-the-latest-version) if required.
+
+### Dependencies
+
+The above installation script automatically installs the latest SDKs for Rust (which will enable us to write Serverless AI applications in Rust). However, some of the Serverless AI examples are written using TypeScript/Javascript and Python. To enable Serverless AI functionality via TypeScript/Javascript and Python, please ensure you have the latest TypeScript/JavaScript and Python template installed:
+
+**TypeScript/Javascript**
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin templates install --git https://github.com/fermyon/spin-js-sdk --upgrade
+```
+
+**Python**
+
+Some of the Serverless AI examples are written using Python. To enable Serverless AI functionality via Python, please ensure you have the latest Python template installed:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin templates install --git https://github.com/fermyon/spin-python-sdk --upgrade
+```
+
+## Licenses
+
+> This tutorial uses [Meta AI](https://ai.meta.com/)'s Llama 2, Llama Chat and Code Llama models you will need to visit [Meta's Llama webpage](https://ai.meta.com/resources/models-and-libraries/llama-downloads/) and agree to Meta's License, Acceptable Use Policy, and to Meta’s privacy policy before fetching and using Llama models.
+
+## Serverless AI Inferencing With Spin Applications 
+
+Now, let's dive deep into a comprehensive tutorial and unlock your potential to use Fermyon Serverless AI.
+**Note:** The full source code with other examples can be found in our [Github repo](https://github.com/fermyon/ai-examples/tree/main)
+
+### Creating a New Spin Application
+
+{{ tabs "sdk-type" }}
+
+{{ startTab "Rust"}}
+
+The Rust code snippets below are taken from the [Fermyon Serverless AI Examples](https://github.com/fermyon/ai-examples/tree/main/sentiment-analysis-rs)
+
+> Note: please add `/api/...` when prompted for the path; this provides us with an API endpoint to query the sentiment analysis component.
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin new http-rust
+Enter a name for your new application: sentiment-analysis
+Description: A sentiment analysis API that demonstrates using LLM inferencing and KV stores together
+HTTP base: /
+HTTP path: /api/...
+```
+
+{{ blockEnd }}
+
+{{ startTab "TypeScript" }}
+
+The TypeScript code snippets below are taken from the [Fermyon Serverless AI Examples](https://github.com/fermyon/ai-examples/tree/main/sentiment-analysis-ts)
+
+> Note: please add `/api/...` when prompted for the path; this provides us with an API endpoint to query the sentiment analysis component.
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin new http-ts
+Enter a name for your new application: sentiment-analysis
+Description: A sentiment analysis API that demonstrates using LLM inferencing and KV stores together
+HTTP base: /
+HTTP path: /api/...
+```
+
+{{ blockEnd }}
+
+{{ startTab "Python" }}
+
+The Python code snippets below are taken from the [Fermyon Serverless AI Examples](https://github.com/fermyon/ai-examples/tree/main/sentiment-analysis-py)
+
+> Note: please add `/api/...` when prompted for the path; this provides us with an API endpoint to query the sentiment analysis component.
+<!-- @selectiveCpy -->
+
+```bash
+$ spin new http-py
+Enter a name for your new application: sentiment-analysis
+Description: A sentiment analysis API that demonstrates using LLM inferencing and KV stores together
+HTTP base: /
+HTTP path: /api/...
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+### Supported AI Models
+
+Fermyon's Spin and Serverless AI currently support:
+- Meta's open source Large Language Models (LLMs) [Llama](https://ai.meta.com/llama/), specifically the `llama2-chat` and `codellama-instruct` models (see Meta [Licenses](#licenses) section above).
+- SentenceTransformers' [embeddings](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2) models, specifically the `all-minilm-l6-v2` model.
+
+### Model Optimization
+
+The models need to be in a particular format for Spin to be able to use them (quantized, which is a form of optimization). The official download links for the models (in non-quantized format) are listed in the previous section. However, for your convenience, the code examples below fetch models which are already in the special quantized format.
+
+### Application Structure
+
+Next, we need to create the appropriate folder structure from within the application directory (alongside our `spin.toml` file). The code below demonstrates the variations in folder structure depending on which model is being used. Once the folder structure is in place, we then fetch the pre-trained AI model for our application:
+
+**llama2-chat example download**
+
+> Ensure you have read the Meta [Licenses](#licenses) section before continuing to use Llama models.
+
+<!-- @selectiveCpy -->
+
+```bash
+# llama2-chat
+$ mkdir -p .spin/ai-models
+$ cd .spin/ai-models
+$ wget https://huggingface.co/TheBloke/Llama-2-13B-chat-GGML/resolve/a17885f653039bd07ed0f8ff4ecc373abf5425fd/llama-2-13b-chat.ggmlv3.q3_K_L.bin
+$ mv llama-2-13b-chat.ggmlv3.q3_K_L.bin llama2-chat
+```
+
+<!-- @nocpy -->
+
+```bash
+tree .spin
+.spin
+└── ai-models
+    └── llama2-chat
+```
+
+**codellama-instruct example download**
+
+> Ensure you have read the Meta [Licenses](#licenses) section before continuing to use Llama models.
+
+<!-- @selectiveCpy -->
+
+```bash
+# codellama-instruct
+$ mkdir -p .spin/ai-models
+$ cd .spin/ai-models
+$ wget https://huggingface.co/TheBloke/CodeLlama-13B-Instruct-GGML/resolve/b3dc9d8df8b4143ee18407169f09bc12c0ae09ef/codellama-13b-instruct.ggmlv3.Q3_K_L.bin
+$ mv codellama-13b-instruct.ggmlv3.Q3_K_L.bin codellama-instruct
+```
+
+<!-- @nocpy -->
+
+```bash
+tree .spin
+.spin
+└── ai-models
+    └── codellama-instruct
+```
+
+**all-minilm-l6-v2 example download**
+
+The following section fetches a specific version of the [sentence-transformers](https://www.sbert.net/index.html#) model:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ mkdir -p .spin/ai-models/all-minilm-l6-v2
+$ cd .spin/ai-models/all-minilm-l6-v2
+$ wget https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/7dbbc90392e2f80f3d3c277d6e90027e55de9125/tokenizer.json
+$ wget https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/0b6dc4ef7c29dba0d2e99a5db0c855c3102310d8/model.safetensors
+```
+
+<!-- @nocpy -->
+
+```bash
+tree .spin
+.spin
+└── ai-models
+    └── all-minilm-l6-v2
+        ├── model.safetensors
+        └── tokenizer.json
+```
+
+> Note: Rather than be limited to a 1:1 relationship between a Spin applications and a downloaded model, if you would like more than just one Spin application to access a specific model (that you have already downloaded) you can create an arbitrary directory (i.e. `~/my-ai-models/`) to house your models, and then create a symbolic link to a specific Spin application (i.e. `~/application-one/.spin/ai-models`):
+
+<!-- @nocpy -->
+
+```bash
+ln -s ~/my-ai-models/ ~/application-one/.spin/ai-models
+```
+
+### Application Configuration
+
+Then, we configure the `[[component]]` section of our application's manifest (the `spin.toml` file); explicitly naming our model of choice. For example, in the case of the sentiment analysis application, we specify the `llama2-chat` value for our `ai_models` configuration:
+
+```toml
+ai_models = ["llama2-chat"]
+key_value_stores = ["default"]
+```
+
+Note the positioning, of the `ai_models` configuration, shown below:
+
+```toml
+[[component]]
+id = "sentiment-analysis"
+source = "target/spin-http-js.wasm"
+exclude_files = ["**/node_modules"]
+key_value_stores = ["default"]
+ai_models = ["llama2-chat"]
+[component.trigger]
+route = "/api/..."
+[component.build]
+command = "npm run build"
+watch = ["src/**/*", "package.json", "package-lock.json"]
+```
+
+### Source Code
+
+Now let's use the Spin SDK to access the model from our app:
+
+{{ tabs "sdk-type" }}
+
+{{ startTab "Rust"}}
+
+The Rust source code for this sentiment analysis example uses serde. There are a couple of ways to add the required serde dependencies:
+- Run `cargo add serde -F derive` and `cargo add serde_json` from your Rust application's home directory (which will automatically update your application's `Cargo.toml` file), or
+- Manually, edit your Rust application's `Cargo.toml` file by adding the following lines beneath the `Cargo.toml` file's `[dependencies]` section:
+
+```toml
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.85"
+```
+
+Once you have added serde, as explained above, modify your `src/lib.rs` file to match the following content:
+
+```rust
+use std::str::FromStr;
+
+use anyhow::Result;
+use spin_sdk::{
+    http::{Params, Request, Response, Router},
+    http_component,
+    key_value::Store,
+    llm::{infer_with_options, InferencingModel::Llama2Chat},
+};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+pub struct SentimentAnalysisRequest {
+    pub sentence: String,
+}
+
+#[derive(Serialize)]
+pub struct SentimentAnalysisResponse {
+    pub sentiment: String,
+}
+
+const PROMPT: &str = r#"\
+<<SYS>>
+You are a bot that generates sentiment analysis responses. Respond with a single positive, negative, or neutral.
+<</SYS>>
+<INST>
+Follow the pattern of the following examples:
+
+User: Hi, my name is Bob
+Bot: neutral
+
+User: I am so happy today
+Bot: positive
+
+User: I am so sad today
+Bot: negative
+</INST>
+
+User: {SENTENCE}
+"#;
+
+/// A Spin HTTP component that internally routes requests.
+#[http_component]
+fn handle_route(req: Request) -> Result<Response> {
+    let mut router = Router::new();
+    router.post("/api/sentiment-analysis", perform_sentiment_analysis);
+    router.any("/api/*", not_found);
+    router.handle(req)
+}
+
+fn not_found(_: Request, _: Params) -> Result<Response> {
+    Ok(http::Response::builder()
+        .status(404)
+        .body(Some("Not found".into()))?)
+}
+
+fn perform_sentiment_analysis(req: Request, _params: Params) -> Result<Response> {
+    let request = body_json_to_map(&req)?;
+    // Do some basic clean up on the input
+    let sentence = request.sentence.trim();
+    println!("Performing sentiment analysis on: {}", sentence);
+
+    // Prepare the KV store
+    let kv = Store::open_default()?;
+
+    // If the sentiment of the sentence is already in the KV store, return it
+    if kv.exists(sentence).unwrap_or(false) {
+        println!("Found sentence in KV store returning cached sentiment");
+        let sentiment = kv.get(sentence)?;
+        let resp = SentimentAnalysisResponse {
+            sentiment: String::from_utf8(sentiment)?,
+        };
+        let resp_str = serde_json::to_string(&resp)?;
+
+        return send_ok_response(200, resp_str)
+    }
+    println!("Sentence not found in KV store");
+
+    // Otherwise, perform sentiment analysis
+    println!("Running inference");
+    let inferencing_result = infer_with_options(
+        Llama2Chat,
+        &PROMPT.replace("{SENTENCE}", sentence),
+        spin_sdk::llm::InferencingParams {
+            max_tokens: 6,
+            ..Default::default()
+        },
+    )?;
+    println!("Inference result {:?}", inferencing_result);
+    let sentiment = inferencing_result
+        .text
+        .lines()
+        .next()
+        .unwrap_or_default()
+        .strip_prefix("Bot:")
+        .unwrap_or_default()
+        .parse::<Sentiment>();
+    println!("Got sentiment: {sentiment:?}");
+
+    if let Ok(sentiment) = sentiment {
+        println!("Caching sentiment in KV store");
+        let _ = kv.set(sentence, sentiment);
+    }
+    // Cache the result in the KV store
+    let resp = SentimentAnalysisResponse {
+        sentiment: sentiment
+            .as_ref()
+            .map(ToString::to_string)
+            .unwrap_or_default(),
+    };
+
+    let resp_str = serde_json::to_string(&resp)?;
+    send_ok_response(200, resp_str)
+}
+
+fn send_ok_response(code: u16, resp_str: String) -> Result<Response> {
+    Ok(http::Response::builder()
+    .status(code)
+    .body(Some(resp_str.into()))?)
+}
+
+fn body_json_to_map(req: &Request) -> Result<SentimentAnalysisRequest> {
+    let body = match req.body().as_ref() {
+        Some(bytes) => bytes,
+        None => anyhow::bail!("Request body was unexpectedly empty"),
+    };
+
+    Ok(serde_json::from_slice(&body)?)
+}
+
+#[derive(Copy, Clone, Debug)]
+enum Sentiment {
+    Positive,
+    Negative,
+    Neutral,
+}
+
+impl Sentiment {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::Positive => "positive",
+            Self::Negative => "negative",
+            Self::Neutral => "neutral",
+        }
+    }
+}
+
+impl std::fmt::Display for Sentiment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl AsRef<[u8]> for Sentiment {
+    fn as_ref(&self) -> &[u8] {
+        self.as_str().as_bytes()
+    }
+}
+
+impl FromStr for Sentiment {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        let sentiment = match s.trim() {
+            "positive" => Self::Positive,
+            "negative" => Self::Negative,
+            "neutral" => Self::Neutral,
+            _ => return Err(s.into()),
+        };
+        Ok(sentiment)
+    }
+}
+```
+
+{{ blockEnd }}
+
+{{ startTab "TypeScript"}}
+
+```typescript
+import {
+  HandleRequest,
+  HttpRequest,
+  HttpResponse,
+  Llm,
+  InferencingModels,
+  InferencingOptions,
+  Router,
+  Kv,
+} from "@fermyon/spin-sdk";
+
+interface SentimentAnalysisRequest {
+  sentence: string;
+}
+
+interface SentimentAnalysisResponse {
+  sentiment: "negative" | "neutral" | "positive";
+}
+
+const decoder = new TextDecoder();
+
+const PROMPT = `\
+You are a bot that generates sentiment analysis responses. Respond with a single positive, negative, or neutral.
+
+Hi, my name is Bob
+neutral
+
+I am so happy today
+positive
+
+I am so sad today
+negative
+
+<SENTENCE>
+`;
+
+async function performSentimentAnalysis(request: HttpRequest) {
+  // Parse sentence out of request
+  let data = request.json() as SentimentAnalysisRequest;
+  let sentence = data.sentence;
+  console.log("Performing sentiment analysis on: " + sentence);
+
+  // Prepare the KV store
+  let kv = Kv.openDefault();
+
+  // If the sentiment of the sentence is already in the KV store, return it
+  if (kv.exists(sentence)) {
+    console.log("Found sentence in KV store returning cached sentiment");
+    return {
+      status: 200,
+      body: JSON.stringify({
+        sentiment: decoder.decode(kv.get(sentence)),
+      } as SentimentAnalysisResponse),
+    };
+  }
+  console.log("Sentence not found in KV store");
+
+  // Otherwise, perform sentiment analysis
+  console.log("Running inference");
+  let options: InferencingOptions = { max_tokens: 10, temperature: 0.5 };
+  let inferenceResult = Llm.infer(
+    InferencingModels.Llama2Chat,
+    PROMPT.replace("<SENTENCE>", sentence),
+    options
+  );
+  console.log(
+    `Inference result (${inferenceResult.usage.generatedTokenCount} tokens): ${inferenceResult.text}`
+  );
+  let sentiment = inferenceResult.text.split(/\s+/)[0]?.trim();
+
+  // Clean up result from inference
+  if (
+    sentiment === undefined ||
+    !["negative", "neutral", "positive"].includes(sentiment)
+  ) {
+    sentiment = "neutral";
+    console.log("Invalid sentiment, marking it as neutral");
+  }
+
+  // Cache the result in the KV store
+  console.log("Caching sentiment in KV store");
+  kv.set(sentence, sentiment);
+
+  return {
+    status: 200,
+    body: JSON.stringify({
+      sentiment,
+    } as SentimentAnalysisResponse),
+  };
+}
+
+let router = Router();
+
+// Map the route to the handler
+router.post("/api/sentiment-analysis", async (_, req) => {
+  console.log(`${new Date().toISOString()} POST /sentiment-analysis`);
+  return await performSentimentAnalysis(req);
+});
+
+// Catch all 404 handler
+router.all("/api/*", async (_, req) => {
+  return {
+    status: 404,
+    body: "Not found",
+  };
+});
+
+// Entry point to the Spin handler
+export const handleRequest: HandleRequest = async function (
+  request: HttpRequest
+): Promise<HttpResponse> {
+  return await router.handleRequest(request, request);
+};
+```
+
+{{ blockEnd }}
+
+{{ startTab "Python"}}
+
+```python
+from spin_http import Response
+from spin_llm import llm_infer
+import json
+import re
+
+PROMPT="""<<SYS>>
+You are a bot that generates sentiment analysis responses. Respond with a single positive, negative, or neutral.
+<</SYS>>
+[INST]
+Follow the pattern of the following examples:
+User: Hi, my name is Bob
+Bot: neutral
+User: I am so happy today
+Bot: positive
+User: I am so sad today
+Bot: negative
+[/INST]
+User: """
+
+def handle_request(request):
+    request_body=json.loads(request.body)
+    sentence=request_body["sentence"].strip()
+    result=llm_infer("llama2-chat", PROMPT+sentence)
+    response_body=json.dumps({"sentence": re.sub("\\nBot\: ", "", result.text)})
+    return Response(200,
+                    {"content-type": "application/json"},
+                    bytes(response_body, "utf-8"))
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+### Additional Functionality
+
+This application also includes two more components, a key/value explorer and static-fileserver component. Let's quickly go ahead and create those (letting Spin do all of the scaffolding for us).
+
+### Static Fileserver Component For The UI
+
+We use the `spin add` command to add the new `static-fileserver` that we will name `ui`:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin add static-fileserver
+Enter a name for your new component: ui
+HTTP path: /...
+Directory containing the files to serve: assets
+
+```
+
+We create an `assets` directory where we can store files to serve statically (see the `spin.toml` file for more configuration information):
+
+<!-- @selectiveCpy -->
+
+```bash
+$ mkdir assets
+```
+
+### Add the Front-End 
+
+We can add a webpage that asks the user for some text and does the sentiment analysis on it. In your assets folder, create two files `dynamic.js` and `index.html`. 
+
+Here's the code snippet for `index.html`
+
+```html
+<!DOCTYPE html>
+<html data-theme="cupcake">
+  <head>
+    <title>Sentiment Analyzer</title>
+    <meta name="description" content="Perform sentiment analysis" />
+
+    <!-- Tailwind and Daisy UI -->
+    <link
+      href="https://cdn.jsdelivr.net/npm/daisyui@3.2.1/dist/full.css"
+      rel="stylesheet"
+      type="text/css"
+    />
+    <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+
+    <!-- Import script to make page dynamic -->
+    <script src="dynamic.js"></script>
+  </head>
+
+  <body class="bg-base-200">
+    <div id="alert" class="fixed top-20 inset-x-0 w-1/2 mx-auto"></div>
+    <div class="flex flex-col min-h-screen">
+      <div
+        class="sticky top-0 z-30 flex h-16 w-full justify-center bg-opacity-90 backdrop-blur transition-all duration-100 bg-base-100 text-base-content shadow-md"
+      >
+        <nav class="navbar w-full">
+          <div class="flex-1">
+            <a href="/" class="btn btn-ghost text-4xl font-bold"
+              >Sentiment Analyzer</a
+            >
+          </div>
+          <div class="flex-none">
+            <a href="" class="btn btn-warning">Restart</a>
+          </div>
+        </nav>
+      </div>
+      <main class="mx-auto my-10 prose">
+        <p>
+          This Sentiment Analyzer is a demonstration of how you can use Fermyon
+          Serverless AI to easily make an AI-powered API. When you type in a
+          sentence it is sent to a Spin app running in the Fermyon Cloud,
+          inferencing is performed using the Fermyon serverless AI feature, and
+          the response is cached in a Fermyon key/value store.
+        </p>
+        <p>
+          Note that LLM's are not perfect and the sentiment analysis performed
+          by this application is not guaranteed to be perfect.
+        </p>
+        <p>
+          To get started type a sentence below and press
+          <kbd class="kbd kbd-sm">enter</kbd>.
+        </p>
+
+        <div class="flex flex-col gap-8 w-full">
+          <input
+            id="sentence-input"
+            type="text"
+            placeholder="Type the sentence you want to analyze here"
+            class="input w-full"
+          />
+          <div>
+            <button class="btn btn-primary" onclick="newCard()">Analyze</button>
+          </div>
+        </div>
+      </main>
+    </div>
+  </body>
+</html>
+```
+
+Here's the code snippet for `dynamic.js` 
+
+```javascript
+// Listen for the Enter key being pressed
+document.addEventListener("keydown", function (event) {
+  if (event.keyCode === 13) {
+    newCard();
+  }
+});
+
+var globalCardCount = 0;
+var runningInference = false;
+
+function newCard() {
+  if (runningInference) {
+    console.log("Already running inference, please wait...");
+    setAlert("Already running inference, please wait...");
+    return;
+  }
+  var inputElement = document.getElementById("sentence-input");
+  var sentence = inputElement.value;
+  if (sentence === "") {
+    console.log("Please enter a sentence to analyze");
+    setAlert("Please enter a sentence to analyze");
+    return;
+  }
+  inputElement.value = "";
+
+  var cardIndex = globalCardCount;
+  globalCardCount++;
+  var newCard = document.createElement("div");
+  newCard.id = "card-" + cardIndex;
+  newCard.innerHTML = `
+    <div class="card bg-base-100 shadow-xl w-full">
+        <div class="m-4 flex flex-col gap-2">
+            <div>${sentence}</div>
+            <div class="flex flex-row justify-end">
+                <span class="loading loading-dots loading-sm"></span>
+            </div>
+        </div>
+    </div>
+    `;
+  document.getElementById("sentence-input").before(newCard);
+
+  console.log("Running inference on sentence: " + sentence);
+  runningInference = true;
+  fetch("/api/sentiment-analysis", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ sentence: sentence }),
+  })
+    .then((response) => response.json())
+    .then((data) => {
+      console.log(data);
+      updateCard(cardIndex, sentence, data.sentiment);
+    })
+    .catch((error) => {
+      console.log(error);
+    });
+}
+
+function updateCard(cardIndex, sentence, sentiment) {
+  badge = "";
+  if (sentiment === "positive") {
+    badge = `<span class="badge badge-success">Positive</span>`;
+  } else if (sentiment === "negative") {
+    badge = `<span class="badge badge-error">Negative</span>`;
+  } else if (sentiment === "neutral") {
+    badge = `<span class="badge badge-ghost">Neutral</span>`;
+  } else {
+    badge = `<span class="badge badge-ghost">Unsure</span>`;
+  }
+  var cardElement = document.getElementById("card-" + cardIndex);
+  cardElement.innerHTML = `
+    <div class="card bg-base-100 shadow-xl w-full">
+        <div class="m-4 flex flex-col gap-2">
+            <div>${sentence}</div>
+            <div class="flex flex-row justify-end">
+                ${badge}
+            </div>
+        </div>
+    </div>
+    `;
+  runningInference = false;
+}
+
+function setAlert(msg) {
+  var alertElement = document.getElementById("alert");
+  alertElement.innerHTML = `
+    <div class="alert alert-error">
+        <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+        <span class="text-error-content">${msg}</span>
+    </div>
+    `;
+  setTimeout(function () {
+    alertElement.innerHTML = "";
+  }, 3000);
+}
+```
+
+### Key Value Explorer
+
+For this, we install use a pre-made template by pointing to the templates GitHub repository:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin templates install --git https://github.com/radu-matei/spin-kv-explorer
+```
+
+Then, we again use `spin add` to add the new component. We will name the component  `kv-explorer`):
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin add kv-explorer --accept-defaults
+Enter a name for your new application: kv-explorer
+```
+
+We create an `assets` directory where we can store files to serve statically (see the `spin.toml` file for more configuration information):
+
+<!-- @selectiveCpy -->
+
+```bash
+$ mkdir assets
+```
+
+### Application Manifest
+
+As shown below, the Spin framework has done all of the scaffolding for us:
+
+<!-- @nocpy -->
+
+```toml
+spin_manifest_version = "1"
+authors = ["tpmccallum <tim.mccallum@fermyon.com>"]
+description = "A sentiment analysis API that demonstrates using LLM inference and KV stores together"
+name = "sentiment-analysis"
+trigger = { type = "http", base = "/" }
+version = "0.1.0"
+
+[[component]]
+id = "sentiment-analysis"
+source = "target/sentiment-analysis.wasm"
+exclude_files = ["**/node_modules"]
+ai_models = ["llama2-chat"]
+key_value_stores = ["default"]
+[component.trigger]
+route = "/api/..."
+[component.build]
+command = "npm run build"
+
+[[component]]
+source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.0.3/spin_static_fs.wasm", digest = "sha256:38bf971900228222f7f6b2ccee5051f399adca58d71692cdfdea98997965fd0d" }
+id = "ui"
+files = [ { source = "assets", destination = "/" } ]
+[component.trigger]
+route = "/..."
+
+[[component]]
+source = { url = "https://github.com/radu-matei/spin-kv-explorer/releases/download/v0.9.0/spin-kv-explorer.wasm", digest = "sha256:07f5f0b8514c14ae5830af0f21674fd28befee33cd7ca58bc0a68103829f2f9c" }
+id = "kv-explorer"
+# add or remove stores you want to explore here
+key_value_stores = ["default"]
+[component.trigger]
+route = "/internal/kv-explorer/..."
+```
+
+### Building and Deploying Your Spin Application
+
+**Note:** Running inferencing on localhost (your CPU) is not as optimal as deploying to Fermyon's Serverless AI (where inferencing is performed by high-powered GPUs). You can skip this `spin build --up` step and move straight to `spin cloud deploy` if you:
+
+- a) are using one of the 3 supported models above,
+- b) have configured your `spin.toml` file to explicitly configure the model (as shown above)
+
+Now, let's build and run our Spin Application locally. (**Note:** If you are following along with the TypeScript/JavaScript example, you will first need to run `npm install`. Otherwise, please continue to the following `spin` command.)
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin build --up
+```
+
+### Test Locally
+
+<!-- @selectiveCpy -->
+
+```bash
+# Create a new POST request to localhost
+$ curl -vXPOST 'localhost:3000/api/sentiment-analysis' -H'Content-Type: application/json' -d "{\"sentence\": \"Well this is very nice indeed\" }"
+
+{"sentiment":"positive"}
+```
+
+### Deploy to Fermyon Cloud
+
+Deploying to the Fermyon Cloud is one simple command. If you have not logged into your Fermyon Cloud account already, the CLI will prompt you to login. Follow the instructions to complete the authorization process.  
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin cloud deploy
+```
+
+### Testing in Fermyon Cloud
+
+<!-- @selectiveCpy -->
+
+```bash
+# Create a new POST request to your apps URL in Fermyon Cloud
+$ curl -vXPOST 'https://abcxyz.fermyon.app/api/sentiment-analysis' -H'Content-Type: application/json' -d "{\"sentence\": \"Well this is very nice indeed\" }"
+
+{"sentiment":"positive"}
+```
+
+### Visit Fermyon Cloud UI
+
+Visiting your apps URL will produce a User Interface (UI) similar to the following.
+
+![sentiment analysis ui blank](/static/image/docs/sentiment-analysis-ui-blank.png)
+
+You can type in a sentence, and the UI will respond with the sentiment analysis.
+
+![sentiment analysis ui positive](/static/image/docs/sentiment-analysis-ui-positive.png)
+
+## Integrating Custom Domain and Storage
+
+The groundbreaking Fermyon Serverless AI introduces a revolutionary addition to the full-stack developer's arsenal. You can now seamlessly integrate the Fermyon [NoOps SQL Database](https://www.fermyon.com/blog/announcing-noops-sql-db), [Key-Value Storage](https://www.fermyon.com/blog/introducing-fermyon-cloud-key-value-store), and even your [Fermyon Cloud Custom Domains](https://www.fermyon.com/blog/announcing-custom-domains) with the launch of your very own advanced AI-enabled serverless applications.
+
+## Conclusion
+
+We want to get feedback on the Serverless AI API. We are curious about what models you would like to use and what applications you are building using Serverless AI. Let us know what you need, and how Fermyon's Serverless AI could potentially help solve a problem for you. We would love to help you write your new Serverless AI application.
+
+## Next Steps
+
+- Try the numerous Serverless AI examples in our GitHub repository called [ai-examples](https://github.com/fermyon/ai-examples).
+- [Contribute](https://developer.fermyon.com/hub/contributing) your Serverless AI app to our [Spin Up Hub](https://developer.fermyon.com/hub).
+- Ask questions and share your thoughts in [our Discord community](https://discord.gg/AAFNfS7NGf).

--- a/content/spin/v2/api-guides-overview.md
+++ b/content/spin/v2/api-guides-overview.md
@@ -1,0 +1,24 @@
+title = "API Support Overview"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/api-guides-overview.md"
+
+---
+
+The following table shows the status of the interfaces Spin provides to applications.
+
+| Host Capabilities/Interfaces           | Stability  |    Cloud    |
+|----------------------------------------|----------|-------|
+| [HTTP Trigger](/spin/http-trigger)                          | Stable   | Yes   |
+| [Redis Trigger](/spin/redis-trigger)                         | Stable   | No  |
+| [Outbound HTTP](/spin/http-outbound)                          | Stable   | Yes   |
+| [Outbound Redis](/spin/redis-outbound)                         | Stable  | Yes   |
+| [Configuration Variables](/spin/variables)                      | Stable | Yes |
+| [PostgreSQL](/spin/rdbms-storage)                             | Experimental | Yes |
+| [MySQL](/spin/rdbms-storage)                                  | Experimental | Yes |
+| [Key-value Storage](/spin/kv-store-api-guide)                      | Stabilizing | Yes |
+| [Serverless AI](/spin/serverless-ai-api-guide)                      | Experimental | [Private Beta](/cloud/serverless-ai.md) |
+| [SQLite Storage](/spin/sqlite-api-guide)                      | Experimental | Yes |
+
+For more information about what is possible in the programming language of your choice, please see our [Language Support Overview](/spin/language-support-overview).

--- a/content/spin/v2/build.md
+++ b/content/spin/v2/build.md
@@ -1,0 +1,207 @@
+title = "Building Spin Application Code"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+enable_shortcodes = true
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/build.md"
+
+---
+
+- [Setting Up for `spin build`](#setting-up-for-spin-build)
+- [Running `spin build`](#running-spin-build)
+- [Running the Application After Build](#running-the-application-after-build)
+- [Overriding the Working Directory](#overriding-the-working-directory)
+- [Next Steps](#next-steps)
+
+A Spin application is made up of one or more components. Components are binary Wasm modules; _building_ refers to the process of converting your source code into those modules.
+
+> Even languages that don't require a compile step when used 'natively' may still require a build step to adapt them to work as Wasm modules.
+
+Because most compilers don't target Wasm by default, building Wasm modules often requires special command options, which you may not have at your fingertips.
+What's more, when developing a multi-component application, you may need to issue such commands for several components on each iteration.
+Doing this manually can be tedious and error-prone.
+
+To make the build process easier, the `spin build` command allows you to build all the components in one command.
+
+> You don't have to use `spin build` to manage your builds.  If you prefer to use a Makefile or other build system, you can!  `spin build` is just there to provide an 'out of the box' solution.
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## Setting Up for `spin build`
+
+To use `spin build`, each component that you want to build must specify the command used to build it in `spin.toml`, as part of its `component.build` table:
+
+```toml
+[[component]]
+id = "hello"
+[component.trigger]
+route = "/..."
+# This is the section you need for `spin build`
+[component.build]
+command = "npm run build"
+```
+
+If you generated the component from a Fermyon-supplied template, the `component.build` section should be set up correctly for you.  You don't need to change or add anything.
+
+> Different components may be built from different languages, and so each component can have its own build command.  In addition, some components may be precompiled into Wasm modules, and don't need a build command at all.  If a component doesn't have a build command, `spin build` just skips it.
+
+{{ tabs "sdk-type" }}
+
+{{ startTab "Rust"}}
+
+For Rust applications, you must have the `wasm32-wasi` target installed:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ rustup target add wasm32-wasi
+```
+
+The build command typically runs `cargo build` with the `wasm32-wasi` target and the `--release` option:
+
+<!-- @nocpy -->
+
+```toml
+[component.build]
+command = "cargo build --target wasm32-wasi --release"
+```
+
+{{ blockEnd }}
+
+{{ startTab "TypeScript" }}
+
+For JavaScript and TypeScript applications, you must have the `js2wasm` Spin plugin installed:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin plugins update
+$ spin plugins install js2wasm --yes
+```
+
+It's normally convenient to put the detailed build instructions in `package.json`:
+
+<!-- @nocpy -->
+
+```json
+{
+  "scripts": {
+    "build": "npx webpack --mode=production && mkdir -p target && spin js2wasm -o target/spin-http-js.wasm dist/spin.js"
+  }
+}
+```
+
+The build command can then call the NPM script:
+
+<!-- @nocpy -->
+
+```toml
+[component.build]
+command = "npm run build"
+```
+
+{{ blockEnd }}
+
+{{ startTab "Python" }}
+
+For Python applications, you must have the `py2wasm` Spin plugin installed:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin plugins update
+$ spin plugins install py2wasm --yes
+```
+
+The build command then calls `spin py2wasm` on your application file:
+
+<!-- @nocpy -->
+
+```toml
+[component.build]
+command = "spin py2wasm app -o app.wasm"
+```
+
+{{ blockEnd }}
+
+{{ startTab "TinyGo" }}
+
+For Go applications, you must use the TinyGo compiler, as the standard Go compiler does not yet support the WASI standard.  See the [TinyGo installation guide](https://tinygo.org/getting-started/install/).
+
+The build command calls TinyGo with the WASI backend and appropriate options:
+
+<!-- @nocpy -->
+
+```toml
+[component.build]
+command = "tinygo build -target=wasi -gc=leaking -no-debug -o main.wasm main.go"
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+> The output of the build command _must_ match the component's `source` path.  If you change the `build` or `source` attributes, make sure to keep them in sync.
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## Running `spin build`
+
+Once the build commands are set up, running `spin build` will execute, sequentially, each build command:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin build
+Building component hello with `cargo build --target wasm32-wasi --release`
+    Updating crates.io index
+    Updating git repository `https://github.com/fermyon/spin`
+
+    //--snip--
+
+    Compiling hello v0.1.0 (hello)
+    Finished release [optimized] target(s) in 39.05s
+Finished building all Spin components
+```
+
+> If your build doesn't work, and your source code looks okay, you can [run `spin doctor`](/spin/troubleshooting-application-dev.md) to check for problems with your Spin configuration and tools.
+
+## Running the Application After Build
+
+You can pass the `--up` option to `spin build` to start the application as soon as the build process completes successfully.
+
+This is equivalent to running `spin up` immediately after `spin build`.  It accepts all the same flags and options that `up` does.  See [Running Applications](running-apps) for details.
+
+## Overriding the Working Directory
+
+By default, the `command` to build a component is executed in the directory containing the `spin.toml` file. If a component's entire build source is under a subdirectory, it is often more convenient to build in that subdirectory rather than try to pass the path to the build command. You can do this by setting the `workdir` option in the `component.build` table.
+
+For example, consider this Rust component located in subdirectory `deep`:
+
+<!-- @nocpy -->
+
+```bash
+.
+├── deep
+│   ├── Cargo.toml
+│   └── src
+│       └── lib.rs
+└── spin.toml
+```
+
+To have the Rust build `command` run in directory `deep`, we can set the component's `workdir`:
+
+<!-- @nocpy -->
+
+```toml
+[component.build]
+# `command` is the normal build command for this language
+command = "cargo build --target wasm32-wasi --release"
+# This tells Spin to run it in the directory of the build file (in this case Cargo.toml)
+workdir = "deep"
+```
+
+> `workdir` must be a relative path, and it is relative to the directory containing `spin.toml`. Specifying an absolute path leads to an error.
+
+## Next Steps
+
+- Try [running your application locally](running-apps)
+- Try deploying a Spin application to the [Fermyon Cloud](/cloud/quickstart)

--- a/content/spin/v2/cache.md
+++ b/content/spin/v2/cache.md
@@ -1,0 +1,93 @@
+title = "Spin Internal Data Layout"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+enable_shortcodes = true
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/cache.md"
+
+---
+
+- [Base Directories](#base-directories)
+- [Plugins](#plugins)
+- [Templates](#templates)
+- [Application Cache](#application-cache)
+  - [Inside the Application Cache](#inside-the-application-cache)
+
+This page describes how Spin lays out its internal data on disk.
+
+> This document is provided as a reference for users wanting to diagnose problems or to reset Spin state. Don't modify the contents of these directories. Spin updates these directories as you issue the relevant commands on the command line.
+
+> No stability guarantees apply to the internal layout. It may change between Spin versions.
+
+## Base Directories
+
+Spin uses similar layouts across Linux, MacOS and Windows platforms, but the paths to various areas of the user's home directory differ across the platforms. On this page, the following terms have the following meanings:
+
+| Name          | Linux                                    | MacOS                                | Windows |
+|---------------------|------------------------------------------|--------------------------------------|-------------------|
+| `DATA_DIR`    | `$XDG_DATA_HOME` or `$HOME/.local/share` | `$HOME/Library/Application Support`, or `$HOMEBREW_PREFIX/etc/fermyon-spin` if installed using Homebrew  | `%LOCALAPPDATA%` or `%USERPROFILE%\AppData\Local` |
+| `CACHE_DIR`   | `$XDG_CACHE_HOME` or `$HOME/.cache`      | `$HOME/Library/Caches`               | `%LOCALAPPDATA%` or `%USERPROFILE%\AppData\Local` |
+
+These directories are based on the [XDG specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html), and specifically on the cross-platform implementation in the [Rust `dirs` crate](https://docs.rs/dirs/latest/dirs/).
+
+> If Spin cannot resolve a base directory as listed above, it falls back to `$HOME/.spin` (`%USERPROFILE%\.spin` on Windows).
+
+## Plugins
+
+Installed plugins are stored in `(DATA_DIR)/spin/plugins`.  A snapshot of the plugins registry is also stored under that directory at `(DATA_DIR)/spin/plugins/.spin-plugins`; this is structured as a Git repository.
+
+> Note: If you [install Spin](install) using Homebrew, the plugins are stored at `$HOMEBREW_PREFIX/fermyon-spin/plugins`.
+
+If you delete the plugins directory, you will no longer be able to run your plugins (until you reinstall them), but other Spin operations will be unaffected.
+
+## Templates
+
+Installed templates are stored in `(DATA_DIR)/spin/templates`.
+
+> Note: If you [install Spin](install) using Homebrew, the templates are stored at `$HOMEBREW_PREFIX/fermyon-spin/templates`.
+
+If you delete the templates directory, you will lose access to your installed templates (until you reinstall them), but other Spin operations will be unaffected.
+
+## Application Cache
+
+Downloaded application data, such as applications downloaded from registries or Wasm modules downloaded from URLs, are stored in `(CACHE_DIR)/spin/registry`.
+
+If you delete the application cache directory, Spin will automatically re-download the files as needed.  Spin operations will be otherwise unaffected.
+
+### Inside the Application Cache
+
+> **Reminder:** This information is provided for diagnostic and entertainment purposes only, and may change across Spin versions. The only operation a user can safely undertake is to delete the entire `registry` directory.
+
+The application cache is divided into three subdirectories, `data`, `manifests`, and `wasm`.
+
+The `data` directory contains all static assets referenced from applications distributed with remote registries. The `wasm` directory contains all component sources referenced either in applications distributed with remote registries, or component sources from HTTP endpoints, directly referenced in `spin.toml`.
+
+> The `data` and `wasm` directories are content addressable. This means that if multiple applications reference the same static file or component source, Spin will be able to determine if it has already been pulled (on that users operating system), based on its digest. This also means that if an application has an update, Spin will only pull the changes in the component sources and static assets.
+
+The `manifests` directory contains the registry manifests for entire apps distributed with remote registries. They are placed in subdirectories that identify the application based on the registry, repository, and digest (or tag).
+
+The following `tree` command shows a typical (abbreviated) cache directory:
+
+<!-- @selectiveCpy -->
+
+```console
+$ tree ~/Library/Caches/spin/registry/
+
+├── data
+│   ├── sha256:41a4649a8a8c176133792119cb45a7686767d3fa376ffd656e2ff76a6071fb07
+│   └── sha256:da3fda2db338a73483068072e22f7e7eef27afdbae3db824e130932adce703ba
+├── manifests
+│   └── ghcr.io
+│       └── radu-matei
+│           ├── hello-registries
+│           │   └── latest
+│           │       ├── config.json
+│           │       └── manifest.json
+│           └── spin-openai-demo
+│               └── v1
+│                   ├── config.json
+│                   └── manifest.json
+└── wasm
+    ├── sha256:0b985e7d43e719f34cbb54849759a2f8e7913c0f9b17bf7cb2b3d2458d33859e
+    └── sha256:d5f9e1f6b61b90f7404e3800285f7860fe2cfc7d0116023efc370adbb403fe87
+```

--- a/content/spin/v2/cli-reference.md
+++ b/content/spin/v2/cli-reference.md
@@ -1,0 +1,4830 @@
+title = "Spin Command Line Interface (CLI) Reference"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+enable_shortcodes = true
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/cli-reference.md"
+
+---
+- [spin add](#spin-add)
+- [spin build](#spin-build)
+- [spin cloud](#spin-cloud)
+- [spin cloud deploy](#spin-cloud-deploy)
+- [spin cloud login](#spin-cloud-login)
+- [spin cloud variables](#spin-cloud-variables)
+- [spin deploy](#spin-deploy)
+- [spin doctor](#spin-doctor)
+- [spin help](#spin-help)
+- [spin login](#spin-login)
+- [spin new](#spin-new)
+- [spin plugins](#spin-plugins)
+- [spin plugins install](#spin-plugins-install)
+- [spin plugins list](#spin-plugins-list)
+- [spin plugins uninstall](#spin-plugins-uninstall)
+- [spin plugins update](#spin-plugins-update)
+- [spin plugins upgrade](#spin-plugins-upgrade)
+- [spin registry](#spin-registry)
+- [spin registry login](#spin-registry-login)
+- [spin registry pull](#spin-registry-pull)
+- [spin registry push](#spin-registry-push)
+- [spin templates](#spin-templates)
+- [spin templates install](#spin-templates-install)
+- [spin templates list](#spin-templates-list)
+- [spin templates uninstall](#spin-templates-uninstall)
+- [spin templates upgrade](#spin-templates-upgrade)
+- [spin up](#spin-up)
+  - [spin up (HTTP Trigger)](#spin-up-http-trigger)
+- [spin watch](#spin-watch)
+- [Stability Table](#stability-table)
+
+This page documents the Spin Command Line Interface (CLI).
+
+> Please note: When using the `spin --help` command you may see additional commands (followed by an asterisk symbol). These additional commands that are visible on your machine will show up depending on what plugins you have installed locally.
+
+For information on command stability, see the [CLI stability table](#cli-stability-table).
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin add
+
+{{ tabs "spin-version" }}
+
+{{ startTab "v1.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin add --help
+
+spin-add 
+Scaffold a new component into an existing application
+
+USAGE:
+    spin add [OPTIONS] [ARGS]
+
+ARGS:
+    <TEMPLATE_ID>    The template from which to create the new application or component. Run
+                     `spin templates list` to see available options
+    <NAME>           The name of the new application or component
+
+OPTIONS:
+        --accept-defaults              An optional argument that allows to skip prompts for the
+                                       manifest file by accepting the defaults if available on the
+                                       template
+    -f, --file <APP_MANIFEST_FILE>     Path to spin.toml
+    -h, --help                         Print help information
+    -o, --output <OUTPUT_PATH>         The directory in which to create the new application or
+                                       component. The default is the name argument
+        --tag <TAGS>                   Filter templates to select by tags
+    -v, --value <VALUES>               Parameter values to be passed to the template (in name=value
+                                       format)
+        --values-file <VALUES_FILE>    A TOML file which contains parameter values in name = "value"
+                                       format. Parameters passed as CLI option overwrite parameters
+                                       specified in the file
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin add --help
+
+spin-add 
+Scaffold a new component into an existing application
+
+USAGE:
+    spin add [OPTIONS] [ARGS]
+
+ARGS:
+    <TEMPLATE_ID>    The template from which to create the new application or component. Run
+                     `spin templates list` to see available options
+    <NAME>           The name of the new application or component
+
+OPTIONS:
+        --accept-defaults              An optional argument that allows to skip prompts for the
+                                       manifest file by accepting the defaults if available on the
+                                       template
+    -f, --file <APP_MANIFEST_FILE>     Path to spin.toml
+    -h, --help                         Print help information
+    -o, --output <OUTPUT_PATH>         The directory in which to create the new application or
+                                       component. The default is the name argument
+        --tag <TAGS>                   Filter templates to select by tags
+    -v, --value <VALUES>               Parameter values to be passed to the template (in name=value
+                                       format)
+        --values-file <VALUES_FILE>    A TOML file which contains parameter values in name = "value"
+                                       format. Parameters passed as CLI option overwrite parameters
+                                       specified in the file
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.2"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin add --help
+
+spin-add 
+Scaffold a new component into an existing application
+
+USAGE:
+    spin add [OPTIONS] [ARGS]
+
+ARGS:
+    <TEMPLATE_ID>    The template from which to create the new application or component. Run
+                     `spin templates list` to see available options
+    <NAME>           The name of the new application or component
+
+OPTIONS:
+    -a, --accept-defaults              An optional argument that allows to skip prompts for the
+                                       manifest file by accepting the defaults if available on the
+                                       template
+    -f, --file <APP_MANIFEST_FILE>     Path to spin.toml
+    -h, --help                         Print help information
+    -o, --output <OUTPUT_PATH>         The directory in which to create the new application or
+                                       component. The default is the name argument
+        --tag <TAGS>                   Filter templates to select by tags
+    -v, --value <VALUES>               Parameter values to be passed to the template (in name=value
+                                       format)
+        --values-file <VALUES_FILE>    A TOML file which contains parameter values in name = "value"
+                                       format. Parameters passed as CLI option overwrite parameters
+                                       specified in the file
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin add --help
+
+spin-add 
+Scaffold a new component into an existing application
+
+USAGE:
+    spin add [OPTIONS] [ARGS]
+
+ARGS:
+    <TEMPLATE_ID>    The template from which to create the new application or component. Run
+                     `spin templates list` to see available options
+    <NAME>           The name of the new application or component
+
+OPTIONS:
+    -a, --accept-defaults              An optional argument that allows to skip prompts for the
+                                       manifest file by accepting the defaults if available on the
+                                       template
+    -f, --file <APP_MANIFEST_FILE>     Path to spin.toml
+    -h, --help                         Print help information
+    -o, --output <OUTPUT_PATH>         The directory in which to create the new application or
+                                       component. The default is the name argument
+        --tag <TAGS>                   Filter templates to select by tags
+    -v, --value <VALUES>               Parameter values to be passed to the template (in name=value
+                                       format)
+        --values-file <VALUES_FILE>    A TOML file which contains parameter values in name = "value"
+                                       format. Parameters passed as CLI option overwrite parameters
+                                       specified in the file
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin add --help
+
+spin-add 
+Scaffold a new component into an existing application
+
+USAGE:
+    spin add [OPTIONS] [ARGS]
+
+ARGS:
+    <TEMPLATE_ID>    The template from which to create the new application or component. Run
+                     `spin templates list` to see available options
+    <NAME>           The name of the new application or component
+
+OPTIONS:
+    -a, --accept-defaults              An optional argument that allows to skip prompts for the
+                                       manifest file by accepting the defaults if available on the
+                                       template
+    -f, --file <APP_MANIFEST_FILE>     Path to spin.toml
+    -h, --help                         Print help information
+    -o, --output <OUTPUT_PATH>         The directory in which to create the new application or
+                                       component. The default is the name argument
+        --tag <TAGS>                   Filter templates to select by tags
+    -v, --value <VALUES>               Parameter values to be passed to the template (in name=value
+                                       format)
+        --values-file <VALUES_FILE>    A TOML file which contains parameter values in name = "value"
+                                       format. Parameters passed as CLI option overwrite parameters
+                                       specified in the file
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin add --help
+
+spin-add 
+Scaffold a new component into an existing application
+
+
+USAGE:
+    spin add [OPTIONS] [ARGS]
+
+ARGS:
+    <TEMPLATE_ID>    The template from which to create the new application or component. Run
+                     `spin templates list` to see available options
+    <NAME>           The name of the new application or component
+
+OPTIONS:
+    -a, --accept-defaults              An optional argument that allows to skip prompts for the
+                                       manifest file by accepting the defaults if available on the
+                                       template
+    -f, --file <APP_MANIFEST_FILE>     Path to spin.toml
+    -h, --help                         Print help information
+    -o, --output <OUTPUT_PATH>         The directory in which to create the new application or
+                                       component. The default is the name argument
+        --tag <TAGS>                   Filter templates to select by tags
+    -v, --value <VALUES>               Parameter values to be passed to the template (in name=value
+                                       format)
+        --values-file <VALUES_FILE>    A TOML file which contains parameter values in name = "value"
+                                       format. Parameters passed as CLI option overwrite parameters
+                                       specified in the file
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin build
+
+{{ tabs "spin-version" }}
+
+{{ startTab "v1.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin build --help
+
+spin-build 
+Build the Spin application
+
+USAGE:
+    spin build [OPTIONS] [UP_ARGS]...
+
+ARGS:
+    <UP_ARGS>...    
+
+OPTIONS:
+    -f, --from <APP_MANIFEST_FILE>    Path to application manifest. The default is "spin.toml"
+    -h, --help                        Print help information
+    -u, --up                          Run the application after building
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin build --help
+
+spin-build 
+Build the Spin application
+
+USAGE:
+    spin build [OPTIONS] [UP_ARGS]...
+
+ARGS:
+    <UP_ARGS>...    
+
+OPTIONS:
+    -f, --from <APP_MANIFEST_FILE>    Path to application manifest. The default is "spin.toml"
+    -h, --help                        Print help information
+    -u, --up                          Run the application after building
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.2"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin build --help
+
+spin-build 
+Build the Spin application
+
+USAGE:
+    spin build [OPTIONS] [UP_ARGS]...
+
+ARGS:
+    <UP_ARGS>...    
+
+OPTIONS:
+    -f, --from <APP_MANIFEST_FILE>    The application to build. This may be a manifest (spin.toml)
+                                      file, or a directory containing a spin.toml file. If omitted,
+                                      it defaults to "spin.toml" [default: spin.toml]
+    -h, --help                        Print help information
+    -u, --up                          Run the application after building
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin build --help
+
+spin-build 
+Build the Spin application
+
+USAGE:
+    spin build [OPTIONS] [UP_ARGS]...
+
+ARGS:
+    <UP_ARGS>...    
+
+OPTIONS:
+    -c, --component-id <COMPONENT_ID>...
+            Component ID to build. This can be specified multiple times. The default is all
+            components
+    -f, --from <APP_MANIFEST_FILE>
+            The application to build. This may be a manifest (spin.toml) file, or a directory
+            containing a spin.toml file. If omitted, it defaults to "spin.toml" [default: spin.toml]
+    -h, --help
+            Print help information
+    -u, --up
+            Run the application after building
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin build --help
+
+spin-build 
+Build the Spin application
+
+USAGE:
+    spin build [OPTIONS] [--] [UP_ARGS]...
+
+ARGS:
+    <UP_ARGS>...    
+
+OPTIONS:
+    -c, --component-id <COMPONENT_ID>...
+            Component ID to build. This can be specified multiple times. The default is all
+            components
+
+    -f, --from <APP_MANIFEST_FILE>
+            The application to build. This may be a manifest (spin.toml) file, or a directory
+            containing a spin.toml file. If omitted, it defaults to "spin.toml" [default: spin.toml]
+
+    -h, --help
+            Print help information
+
+    -u, --up
+            Run the application after building
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+
+USAGE:
+    spin build [OPTIONS] [--] [UP_ARGS]...
+
+ARGS:
+    <UP_ARGS>...    
+
+OPTIONS:
+    -c, --component-id <COMPONENT_ID>...
+            Component ID to build. This can be specified multiple times. The default is all
+            components
+
+    -f, --from <APP_MANIFEST_FILE>
+            The application to build. This may be a manifest (spin.toml) file, or a directory
+            containing a spin.toml file. If omitted, it defaults to "spin.toml" [default: spin.toml]
+
+    -h, --help
+            Print help information
+
+    -u, --up
+            Run the application after building
+```
+
+{{ blockEnd }}
+{{ blockEnd }}
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin cloud
+
+{{ tabs "spin-version" }}
+
+{{ startTab "v1.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin cloud --help
+
+spin-cloud 
+Commands for publishing applications to the Fermyon Platform
+
+USAGE:
+    spin cloud <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    deploy    Package and upload an application to the Fermyon Platform
+    help      Print this message or the help of the given subcommand(s)
+    login     Log into the Fermyon Platform
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin cloud --help
+
+spin-cloud 
+Commands for publishing applications to the Fermyon Platform
+
+USAGE:
+    spin cloud <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    deploy    Package and upload an application to the Fermyon Platform
+    help      Print this message or the help of the given subcommand(s)
+    login     Log into the Fermyon Platform
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.2"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin cloud --help
+
+spin-cloud 
+Commands for publishing applications to the Fermyon Platform
+
+USAGE:
+    spin cloud <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    deploy    Package and upload an application to the Fermyon Platform
+    help      Print this message or the help of the given subcommand(s)
+    login     Log into the Fermyon Platform
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3"}}
+
+The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-command-reference).
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
+
+The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-command-reference).
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-command-reference).
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin cloud deploy
+
+{{ tabs "spin-version" }}
+
+{{ startTab "v1.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin cloud deploy --help
+
+spin-cloud-deploy 
+Package and upload an application to the Fermyon Platform
+
+USAGE:
+    spin cloud deploy [OPTIONS]
+
+OPTIONS:
+        --buildinfo <BUILDINFO>
+            Build metadata to append to the bindle version
+
+    -d, --staging-dir <STAGING_DIR>
+            Path to assemble the bindle before pushing (defaults to a temporary directory)
+
+    -e, --deploy-existing-bindle
+            Deploy existing bindle if it already exists on bindle server
+
+        --environment-name <environment-name>
+            Deploy to the Fermyon instance saved under the specified name. If omitted, Spin deploys
+            to the default unnamed instance [env: FERMYON_DEPLOYMENT_ENVIRONMENT=]
+
+    -f, --file <APP_MANIFEST_FILE>
+            Path to spin.toml [default: spin.toml]
+
+    -h, --help
+            Print help information
+
+        --key-value <KEY_VALUES>
+            Pass a key/value (key=value) to all components of the application. Can be used multiple
+            times
+
+        --no-buildinfo
+            Disable attaching buildinfo [env: SPIN_DEPLOY_NO_BUILDINFO=]
+
+        --readiness-timeout <READINESS_TIMEOUT_SECS>
+            How long in seconds to wait for a deployed HTTP application to become ready. The default
+            is 60 seconds. Set it to 0 to skip waiting for readiness [default: 60]
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin cloud deploy --help
+
+spin-cloud-deploy 
+Package and upload an application to the Fermyon Platform
+
+USAGE:
+    spin cloud deploy [OPTIONS]
+
+OPTIONS:
+        --buildinfo <BUILDINFO>
+            Build metadata to append to the bindle version
+
+    -d, --staging-dir <STAGING_DIR>
+            Path to assemble the bindle before pushing (defaults to a temporary directory)
+
+    -e, --deploy-existing-bindle
+            Deploy existing bindle if it already exists on bindle server
+
+        --environment-name <environment-name>
+            Deploy to the Fermyon instance saved under the specified name. If omitted, Spin deploys
+            to the default unnamed instance [env: FERMYON_DEPLOYMENT_ENVIRONMENT=]
+
+    -f, --file <APP_MANIFEST_FILE>
+            Path to spin.toml [default: spin.toml]
+
+    -h, --help
+            Print help information
+
+        --key-value <KEY_VALUES>
+            Pass a key/value (key=value) to all components of the application. Can be used multiple
+            times
+
+        --no-buildinfo
+            Disable attaching buildinfo [env: SPIN_DEPLOY_NO_BUILDINFO=]
+
+        --readiness-timeout <READINESS_TIMEOUT_SECS>
+            How long in seconds to wait for a deployed HTTP application to become ready. The default
+            is 60 seconds. Set it to 0 to skip waiting for readiness [default: 60]
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.2"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin cloud deploy --help
+
+spin-cloud-deploy 
+Package and upload an application to the Fermyon Platform
+
+USAGE:
+    spin cloud deploy [OPTIONS]
+
+OPTIONS:
+        --buildinfo <BUILDINFO>
+            Build metadata to append to the bindle version
+
+    -d, --staging-dir <STAGING_DIR>
+            Path to assemble the bindle before pushing (defaults to a temporary directory)
+
+    -e, --deploy-existing-bindle
+            Deploy existing bindle if it already exists on bindle server
+
+        --environment-name <environment-name>
+            Deploy to the Fermyon instance saved under the specified name. If omitted, Spin deploys
+            to the default unnamed instance [env: FERMYON_DEPLOYMENT_ENVIRONMENT=]
+
+    -f, --from <APP_MANIFEST_FILE>
+            The application to deploy. This may be a manifest (spin.toml) file, or a directory
+            containing a spin.toml file. If omitted, it defaults to "spin.toml" [default: spin.toml]
+
+    -h, --help
+            Print help information
+
+        --key-value <KEY_VALUES>
+            Set a key/value pair (key=value) in the deployed application's default store. Any
+            existing value will be overwritten. Can be used multiple times
+
+        --no-buildinfo
+            Disable attaching buildinfo [env: SPIN_DEPLOY_NO_BUILDINFO=]
+
+        --readiness-timeout <READINESS_TIMEOUT_SECS>
+            How long in seconds to wait for a deployed HTTP application to become ready. The default
+            is 60 seconds. Set it to 0 to skip waiting for readiness [default: 60]
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3"}}
+
+The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-command-reference#spin-cloud-deploy).
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
+
+The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-command-reference#spin-cloud-deploy).
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-command-reference#spin-cloud-deploy).
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin cloud login
+
+{{ tabs "spin-version" }}
+
+{{ startTab "v1.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin cloud login --help
+
+spin-cloud-login 
+Log into the Fermyon Platform
+
+USAGE:
+    spin cloud login [OPTIONS]
+
+OPTIONS:
+        --auth-method <auth-method>
+            [env: AUTH_METHOD=] [possible values: github, username, token]
+
+        --bindle-password <BINDLE_PASSWORD>
+            Basic http auth password for the bindle server [env: BINDLE_PASSWORD=]
+
+        --bindle-server <BINDLE_SERVER_URL>
+            URL of bindle server [env: BINDLE_URL=]
+
+        --bindle-username <BINDLE_USERNAME>
+            Basic http auth username for the bindle server [env: BINDLE_USERNAME=]
+
+        --environment-name <environment-name>
+            Save the login details under the specified name instead of making them the default. Use
+            named environments with `spin deploy --environment-name <name>` [env:
+            FERMYON_DEPLOYMENT_ENVIRONMENT=]
+
+    -h, --help
+            Print help information
+
+    -k, --insecure
+            Ignore server certificate errors from bindle and hippo
+
+        --list
+            List saved logins
+
+        --password <HIPPO_PASSWORD>
+            Hippo password [env: HIPPO_PASSWORD=]
+
+        --status
+            Display login status
+
+        --token <TOKEN>
+            Auth Token [env: SPIN_AUTH_TOKEN=]
+
+        --url <HIPPO_SERVER_URL>
+            URL of hippo server [env: HIPPO_URL=] [default: https://cloud.fermyon.com/]
+
+        --username <HIPPO_USERNAME>
+            Hippo username [env: HIPPO_USERNAME=]
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin cloud login --help
+
+spin-cloud-login 
+Log into the Fermyon Platform
+
+USAGE:
+    spin cloud login [OPTIONS]
+
+OPTIONS:
+        --auth-method <auth-method>
+            [env: AUTH_METHOD=] [possible values: github, username, token]
+
+        --bindle-password <BINDLE_PASSWORD>
+            Basic http auth password for the bindle server [env: BINDLE_PASSWORD=]
+
+        --bindle-server <BINDLE_SERVER_URL>
+            URL of bindle server [env: BINDLE_URL=]
+
+        --bindle-username <BINDLE_USERNAME>
+            Basic http auth username for the bindle server [env: BINDLE_USERNAME=]
+
+        --environment-name <environment-name>
+            Save the login details under the specified name instead of making them the default. Use
+            named environments with `spin deploy --environment-name <name>` [env:
+            FERMYON_DEPLOYMENT_ENVIRONMENT=]
+
+    -h, --help
+            Print help information
+
+    -k, --insecure
+            Ignore server certificate errors from bindle and hippo
+
+        --list
+            List saved logins
+
+        --password <HIPPO_PASSWORD>
+            Hippo password [env: HIPPO_PASSWORD=]
+
+        --status
+            Display login status
+
+        --token <TOKEN>
+            Auth Token [env: SPIN_AUTH_TOKEN=]
+
+        --url <HIPPO_SERVER_URL>
+            URL of hippo server [env: HIPPO_URL=] [default: https://cloud.fermyon.com/]
+
+        --username <HIPPO_USERNAME>
+            Hippo username [env: HIPPO_USERNAME=]
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.2"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin cloud login --help
+
+spin-cloud-login 
+Log into the Fermyon Platform
+
+USAGE:
+    spin cloud login [OPTIONS]
+
+OPTIONS:
+        --auth-method <auth-method>
+            [env: AUTH_METHOD=] [possible values: github, username, token]
+
+        --bindle-password <BINDLE_PASSWORD>
+            Basic http auth password for the bindle server [env: BINDLE_PASSWORD=]
+
+        --bindle-server <BINDLE_SERVER_URL>
+            URL of bindle server [env: BINDLE_URL=]
+
+        --bindle-username <BINDLE_USERNAME>
+            Basic http auth username for the bindle server [env: BINDLE_USERNAME=]
+
+        --environment-name <environment-name>
+            Save the login details under the specified name instead of making them the default. Use
+            named environments with `spin deploy --environment-name <name>` [env:
+            FERMYON_DEPLOYMENT_ENVIRONMENT=]
+
+    -h, --help
+            Print help information
+
+    -k, --insecure
+            Ignore server certificate errors from bindle and hippo
+
+        --list
+            List saved logins
+
+        --password <HIPPO_PASSWORD>
+            Hippo password [env: HIPPO_PASSWORD=]
+
+        --status
+            Display login status
+
+        --token <TOKEN>
+            Auth Token [env: SPIN_AUTH_TOKEN=]
+
+        --url <HIPPO_SERVER_URL>
+            URL of hippo server [env: HIPPO_URL=] [default: https://cloud.fermyon.com/]
+
+        --username <HIPPO_USERNAME>
+            Hippo username [env: HIPPO_USERNAME=]
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3"}}
+
+The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-command-reference#spin-cloud-login).
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
+
+The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-command-reference#spin-cloud-login).
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-command-reference#spin-cloud-login).
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin cloud variables
+
+{{ tabs "spin-version" }}
+
+{{ startTab "v1.3"}}
+
+The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-command-reference#spin-cloud-variables).
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
+
+The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-command-reference#spin-cloud-variables).
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](../cloud/cloud-command-reference#spin-cloud-variables).
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin deploy
+
+`spin deploy` is a shortcut to [`spin cloud deploy`](#spin-cloud-deploy).
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin doctor
+
+{{ tabs "spin-version" }}
+
+{{ startTab "v1.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin doctor --help
+
+spin-doctor 
+Detect and fix problems with Spin applications
+
+USAGE:
+    spin doctor [OPTIONS]
+
+OPTIONS:
+    -f, --from <APP_MANIFEST_FILE>    The application to check. This may be a manifest (spin.toml)
+                                      file, or a directory containing a spin.toml file. If omitted,
+                                      it defaults to "spin.toml" [default: spin.toml]
+    -h, --help                        Print help information
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin doctor --help
+
+spin-doctor 
+Detect and fix problems with Spin applications
+
+USAGE:
+    spin doctor [OPTIONS]
+
+OPTIONS:
+    -f, --from <APP_MANIFEST_FILE>    The application to check. This may be a manifest (spin.toml)
+                                      file, or a directory containing a spin.toml file. If omitted,
+                                      it defaults to "spin.toml" [default: spin.toml]
+    -h, --help                        Print help information                       Print help information
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin help
+
+{{ tabs "spin-version" }}
+
+{{ startTab "v1.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin help      
+
+spin 1.0.0 
+The Spin CLI
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+SUBCOMMANDS:
+    add          Scaffold a new component into an existing application
+    build        Build the Spin application
+    cloud        Commands for publishing applications to the Fermyon Platform
+    deploy       Package and upload an application to the Fermyon Platform
+    help         Print this message or the help of the given subcommand(s)
+    login        Log into the Fermyon Platform
+    new          Scaffold a new application based on a template
+    plugins      Install/uninstall Spin plugins
+    registry     Commands for working with OCI registries to distribute applications
+    templates    Commands for working with WebAssembly component templates
+    up           Start the Spin application
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin help      
+
+spin 1.1.0 
+The Spin CLI
+
+USAGE:
+    spin <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+SUBCOMMANDS:
+    add          Scaffold a new component into an existing application
+    build        Build the Spin application
+    cloud        Commands for publishing applications to the Fermyon Platform
+    deploy       Package and upload an application to the Fermyon Platform
+    help         Print this message or the help of the given subcommand(s)
+    login        Log into the Fermyon Platform
+    new          Scaffold a new application based on a template
+    plugins      Install/uninstall Spin plugins
+    registry     Commands for working with OCI registries to distribute applications
+    templates    Commands for working with WebAssembly component templates
+    up           Start the Spin application
+    watch        Rebuild and restart the Spin application when files changes
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.2"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin help      
+
+spin 1.2.0
+The Spin CLI
+
+USAGE:
+    spin <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+SUBCOMMANDS:
+    add          Scaffold a new component into an existing application
+    build        Build the Spin application
+    cloud        Commands for publishing applications to the Fermyon Platform
+    deploy       Package and upload an application to the Fermyon Platform
+    help         Print this message or the help of the given subcommand(s)
+    login        Log into the Fermyon Platform
+    new          Scaffold a new application based on a template
+    plugins      Install/uninstall Spin plugins
+    registry     Commands for working with OCI registries to distribute applications
+    templates    Commands for working with WebAssembly component templates
+    up           Start the Spin application
+    watch        Build and run the Spin application, rebuilding and restarting it when files
+                     change
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin help
+
+spin 1.3.0 (9fb8256 2023-06-12)
+The Spin CLI
+
+USAGE:
+    spin <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+SUBCOMMANDS:
+    add          Scaffold a new component into an existing application
+    build        Build the Spin application
+    cloud        Commands for publishing applications to the Fermyon Cloud.
+    deploy       Package and upload an application to the Fermyon Cloud.
+    help         Print this message or the help of the given subcommand(s)
+    login        Log into the Fermyon Cloud.
+    new          Scaffold a new application based on a template
+    plugins      Install/uninstall Spin plugins
+    registry     Commands for working with OCI registries to distribute applications
+    templates    Commands for working with WebAssembly component templates
+    up           Start the Spin application
+    watch        Build and run the Spin application, rebuilding and restarting it when files
+                     change
+
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin help
+
+The Spin CLI
+
+USAGE:
+    spin <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+SUBCOMMANDS:
+    add          Scaffold a new component into an existing application
+    build        Build the Spin application
+    cloud*       Commands for publishing applications to the Fermyon Cloud.
+    deploy       Package and upload an application to the Fermyon Cloud.
+    doctor       Detect and fix problems with Spin applications
+    help         Print this message or the help of the given subcommand(s)
+    login        Log into the Fermyon Cloud.
+    new          Scaffold a new application based on a template
+    plugins      Install/uninstall Spin plugins
+    registry     Commands for working with OCI registries to distribute applications
+    templates    Commands for working with WebAssembly component templates
+    up           Start the Spin application
+    watch        Build and run the Spin application, rebuilding and restarting it when files
+                     change
+
+* implemented via plugin
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+> Please note: Spin `help` is a convenient way to access help using a subcommand, instead of using the `--help` option. For example, `spin help cloud` will give you the same output as `spin cloud --help`. Similarly, `spin help build` will give you the same output as `spin build --help` and so forth.
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin login
+
+`spin login` is a shortcut to [`spin cloud login`](#spin-cloud-login).
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin new
+
+{{ tabs "spin-version" }}
+
+{{ startTab "v1.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin new --help  
+
+spin-new 
+Scaffold a new application based on a template
+
+USAGE:
+    spin new [OPTIONS] [ARGS]
+
+ARGS:
+    <TEMPLATE_ID>    The template from which to create the new application or component. Run
+                     `spin templates list` to see available options
+    <NAME>           The name of the new application or component
+
+OPTIONS:
+        --accept-defaults              An optional argument that allows to skip prompts for the
+                                       manifest file by accepting the defaults if available on the
+                                       template
+    -h, --help                         Print help information
+    -o, --output <OUTPUT_PATH>         The directory in which to create the new application or
+                                       component. The default is the name argument
+        --tag <TAGS>                   Filter templates to select by tags
+    -v, --value <VALUES>               Parameter values to be passed to the template (in name=value
+                                       format)
+        --values-file <VALUES_FILE>    A TOML file which contains parameter values in name = "value"
+                                       format. Parameters passed as CLI option overwrite parameters
+                                       specified in the file
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin new --help  
+
+spin-new 
+Scaffold a new application based on a template
+
+USAGE:
+    spin new [OPTIONS] [ARGS]
+
+ARGS:
+    <TEMPLATE_ID>    The template from which to create the new application or component. Run
+                     `spin templates list` to see available options
+    <NAME>           The name of the new application or component
+
+OPTIONS:
+        --accept-defaults              An optional argument that allows to skip prompts for the
+                                       manifest file by accepting the defaults if available on the
+                                       template
+    -h, --help                         Print help information
+    -o, --output <OUTPUT_PATH>         The directory in which to create the new application or
+                                       component. The default is the name argument
+        --tag <TAGS>                   Filter templates to select by tags
+    -v, --value <VALUES>               Parameter values to be passed to the template (in name=value
+                                       format)
+        --values-file <VALUES_FILE>    A TOML file which contains parameter values in name = "value"
+                                       format. Parameters passed as CLI option overwrite parameters
+                                       specified in the file
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.2"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin new --help  
+
+spin-new 
+Scaffold a new application based on a template
+
+USAGE:
+    spin new [OPTIONS] [ARGS]
+
+ARGS:
+    <TEMPLATE_ID>    The template from which to create the new application or component. Run
+                     `spin templates list` to see available options
+    <NAME>           The name of the new application or component
+
+OPTIONS:
+    -a, --accept-defaults              An optional argument that allows to skip prompts for the
+                                       manifest file by accepting the defaults if available on the
+                                       template
+    -h, --help                         Print help information
+    -o, --output <OUTPUT_PATH>         The directory in which to create the new application or
+                                       component. The default is the name argument
+        --tag <TAGS>                   Filter templates to select by tags
+    -v, --value <VALUES>               Parameter values to be passed to the template (in name=value
+                                       format)
+        --values-file <VALUES_FILE>    A TOML file which contains parameter values in name = "value"
+                                       format. Parameters passed as CLI option overwrite parameters
+                                       specified in the file
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin new --help  
+
+spin-new 
+Scaffold a new application based on a template
+
+USAGE:
+    spin new [OPTIONS] [ARGS]
+
+ARGS:
+    <TEMPLATE_ID>    The template from which to create the new application or component. Run
+                     `spin templates list` to see available options
+    <NAME>           The name of the new application or component
+
+OPTIONS:
+    -a, --accept-defaults              An optional argument that allows to skip prompts for the
+                                       manifest file by accepting the defaults if available on the
+                                       template
+    -h, --help                         Print help information
+    -o, --output <OUTPUT_PATH>         The directory in which to create the new application or
+                                       component. The default is the name argument
+        --tag <TAGS>                   Filter templates to select by tags
+    -v, --value <VALUES>               Parameter values to be passed to the template (in name=value
+                                       format)
+        --values-file <VALUES_FILE>    A TOML file which contains parameter values in name = "value"
+                                       format. Parameters passed as CLI option overwrite parameters
+                                       specified in the file
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin new --help  
+
+spin-new 
+Scaffold a new application based on a template
+
+USAGE:
+    spin new [OPTIONS] [ARGS]
+
+ARGS:
+    <TEMPLATE_ID>    The template from which to create the new application or component. Run
+                     `spin templates list` to see available options
+    <NAME>           The name of the new application or component
+
+OPTIONS:
+    -a, --accept-defaults              An optional argument that allows to skip prompts for the
+                                       manifest file by accepting the defaults if available on the
+                                       template
+    -h, --help                         Print help information
+    -o, --output <OUTPUT_PATH>         The directory in which to create the new application or
+                                       component. The default is the name argument
+        --tag <TAGS>                   Filter templates to select by tags
+    -v, --value <VALUES>               Parameter values to be passed to the template (in name=value
+                                       format)
+        --values-file <VALUES_FILE>    A TOML file which contains parameter values in name = "value"
+                                       format. Parameters passed as CLI option overwrite parameters
+                                       specified in the file
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin new --help  
+
+spin-new 
+Scaffold a new application based on a template
+
+USAGE:
+    spin new [OPTIONS] [ARGS]
+
+ARGS:
+    <TEMPLATE_ID>    The template from which to create the new application or component. Run
+                     `spin templates list` to see available options
+    <NAME>           The name of the new application or component
+
+OPTIONS:
+    -a, --accept-defaults              An optional argument that allows to skip prompts for the
+                                       manifest file by accepting the defaults if available on the
+                                       template
+    -h, --help                         Print help information
+    -o, --output <OUTPUT_PATH>         The directory in which to create the new application or
+                                       component. The default is the name argument
+        --tag <TAGS>                   Filter templates to select by tags
+    -v, --value <VALUES>               Parameter values to be passed to the template (in name=value
+                                       format)
+        --values-file <VALUES_FILE>    A TOML file which contains parameter values in name = "value"
+                                       format. Parameters passed as CLI option overwrite parameters
+                                       specified in the file
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+**Please note: `spin new` vs `spin add`**.  These commands are similar except that:
+
+* `spin new` creates a _new_ application - that is, a new directory with a new `spin.toml` file.
+* `spin add` _adds_ a component to an _existing_ application - that is, it modifies an existing `spin.toml` file.
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin plugins
+
+{{ tabs "spin-version" }}
+
+{{ startTab "v1.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins --help
+
+spin-plugins 
+Install/uninstall Spin plugins
+
+USAGE:
+    spin plugins <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    help         Print this message or the help of the given subcommand(s)
+    install      Install plugin from a manifest
+    list         List available or installed plugins
+    uninstall    Remove a plugin from your installation
+    update       Fetch the latest Spin plugins from the spin-plugins repository
+    upgrade      Upgrade one or all plugins
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins --help
+
+spin-plugins 
+Install/uninstall Spin plugins
+
+USAGE:
+    spin plugins <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    help         Print this message or the help of the given subcommand(s)
+    install      Install plugin from a manifest
+    list         List available or installed plugins
+    uninstall    Remove a plugin from your installation
+    update       Fetch the latest Spin plugins from the spin-plugins repository
+    upgrade      Upgrade one or all plugins
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.2"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins --help
+
+spin-plugins 
+Install/uninstall Spin plugins
+
+USAGE:
+    spin plugins <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    help         Print this message or the help of the given subcommand(s)
+    install      Install plugin from a manifest
+    list         List available or installed plugins
+    uninstall    Remove a plugin from your installation
+    update       Fetch the latest Spin plugins from the spin-plugins repository
+    upgrade      Upgrade one or all plugins
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins --help
+
+spin-plugins 
+Install/uninstall Spin plugins
+
+USAGE:
+    spin plugins <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    help         Print this message or the help of the given subcommand(s)
+    install      Install plugin from a manifest
+    list         List available or installed plugins
+    uninstall    Remove a plugin from your installation
+    update       Fetch the latest Spin plugins from the spin-plugins repository
+    upgrade      Upgrade one or all plugins
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins --help
+
+spin-plugins 
+Install/uninstall Spin plugins
+
+USAGE:
+    spin plugins <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    help         Print this message or the help of the given subcommand(s)
+    install      Install plugin from a manifest
+    list         List available or installed plugins
+    uninstall    Remove a plugin from your installation
+    update       Fetch the latest Spin plugins from the spin-plugins repository
+    upgrade      Upgrade one or all plugins
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins --help
+
+spin-plugins 
+Install/uninstall Spin plugins
+
+USAGE:
+    spin plugins <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    help         Print this message or the help of the given subcommand(s)
+    install      Install plugin from a manifest
+    list         List available or installed plugins
+    uninstall    Remove a plugin from your installation
+    update       Fetch the latest Spin plugins from the spin-plugins repository
+    upgrade      Upgrade one or all plugins
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin plugins install
+
+{{ tabs "spin-version" }}
+
+{{ startTab "v1.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins install --help
+
+spin-plugins-install 
+Install plugin from a manifest.
+
+The binary file and manifest of the plugin is copied to the local Spin plugins directory.
+
+USAGE:
+    spin plugins install [OPTIONS] [PLUGIN_NAME]
+
+ARGS:
+    <PLUGIN_NAME>
+            Name of Spin plugin
+
+OPTIONS:
+    -f, --file <LOCAL_PLUGIN_MANIFEST>
+            Path to local plugin manifest
+
+    -h, --help
+            Print help information
+
+        --override-compatibility-check
+            Overrides a failed compatibility check of the plugin with the current version of Spin
+
+    -u, --url <REMOTE_PLUGIN_MANIFEST>
+            URL of remote plugin manifest to install
+
+    -v, --version <VERSION>
+            Specific version of a plugin to be install from the centralized plugins repository
+
+    -y, --yes
+            Skips prompt to accept the installation of the plugin
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins install --help
+
+spin-plugins-install 
+Install plugin from a manifest.
+
+The binary file and manifest of the plugin is copied to the local Spin plugins directory.
+
+USAGE:
+    spin plugins install [OPTIONS] [PLUGIN_NAME]
+
+ARGS:
+    <PLUGIN_NAME>
+            Name of Spin plugin
+
+OPTIONS:
+    -f, --file <LOCAL_PLUGIN_MANIFEST>
+            Path to local plugin manifest
+
+    -h, --help
+            Print help information
+
+        --override-compatibility-check
+            Overrides a failed compatibility check of the plugin with the current version of Spin
+
+    -u, --url <REMOTE_PLUGIN_MANIFEST>
+            URL of remote plugin manifest to install
+
+    -v, --version <VERSION>
+            Specific version of a plugin to be install from the centralized plugins repository
+
+    -y, --yes
+            Skips prompt to accept the installation of the plugin
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.2"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins install --help
+
+spin-plugins-install 
+Install plugin from a manifest.
+
+The binary file and manifest of the plugin is copied to the local Spin plugins directory.
+
+USAGE:
+    spin plugins install [OPTIONS] [PLUGIN_NAME]
+
+ARGS:
+    <PLUGIN_NAME>
+            Name of Spin plugin
+
+OPTIONS:
+    -f, --file <LOCAL_PLUGIN_MANIFEST>
+            Path to local plugin manifest
+
+    -h, --help
+            Print help information
+
+        --override-compatibility-check
+            Overrides a failed compatibility check of the plugin with the current version of Spin
+
+    -u, --url <REMOTE_PLUGIN_MANIFEST>
+            URL of remote plugin manifest to install
+
+    -v, --version <VERSION>
+            Specific version of a plugin to be install from the centralized plugins repository
+
+    -y, --yes
+            Skips prompt to accept the installation of the plugin
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins install --help
+
+spin-plugins-install 
+Install plugin from a manifest.
+
+The binary file and manifest of the plugin is copied to the local Spin plugins directory.
+
+USAGE:
+    spin plugins install [OPTIONS] [PLUGIN_NAME]
+
+ARGS:
+    <PLUGIN_NAME>
+            Name of Spin plugin
+
+OPTIONS:
+    -f, --file <LOCAL_PLUGIN_MANIFEST>
+            Path to local plugin manifest
+
+    -h, --help
+            Print help information
+
+        --override-compatibility-check
+            Overrides a failed compatibility check of the plugin with the current version of Spin
+
+    -u, --url <REMOTE_PLUGIN_MANIFEST>
+            URL of remote plugin manifest to install
+
+    -v, --version <VERSION>
+            Specific version of a plugin to be install from the centralized plugins repository
+
+    -y, --yes
+            Skips prompt to accept the installation of the plugin
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins install --help
+
+spin-plugins-install 
+Install plugin from a manifest.
+
+The binary file and manifest of the plugin is copied to the local Spin plugins directory.
+
+USAGE:
+    spin plugins install [OPTIONS] [PLUGIN_NAME]
+
+ARGS:
+    <PLUGIN_NAME>
+            Name of Spin plugin
+
+OPTIONS:
+    -f, --file <LOCAL_PLUGIN_MANIFEST>
+            Path to local plugin manifest
+
+    -h, --help
+            Print help information
+
+        --override-compatibility-check
+            Overrides a failed compatibility check of the plugin with the current version of Spin
+
+    -u, --url <REMOTE_PLUGIN_MANIFEST>
+            URL of remote plugin manifest to install
+
+    -v, --version <VERSION>
+            Specific version of a plugin to be install from the centralized plugins repository
+
+    -y, --yes
+            Skips prompt to accept the installation of the plugin
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins install --help
+
+spin-plugins-install 
+Install plugin from a manifest.
+
+The binary file and manifest of the plugin is copied to the local Spin plugins directory.
+
+USAGE:
+    spin plugins install [OPTIONS] [PLUGIN_NAME]
+
+ARGS:
+    <PLUGIN_NAME>
+            Name of Spin plugin
+
+OPTIONS:
+    -f, --file <LOCAL_PLUGIN_MANIFEST>
+            Path to local plugin manifest
+
+    -h, --help
+            Print help information
+
+        --override-compatibility-check
+            Overrides a failed compatibility check of the plugin with the current version of Spin
+
+    -u, --url <REMOTE_PLUGIN_MANIFEST>
+            URL of remote plugin manifest to install
+
+    -v, --version <VERSION>
+            Specific version of a plugin to be install from the centralized plugins repository
+
+    -y, --yes
+            Skips prompt to accept the installation of the plugin
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin plugins list
+
+{{ tabs "spin-version" }}
+
+{{ startTab "v1.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins list --help   
+
+spin-plugins-list 
+List available or installed plugins
+
+USAGE:
+    spin plugins list [OPTIONS]
+
+OPTIONS:
+    -h, --help         Print help information
+        --installed    List only installed plugins
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins list --help   
+
+spin-plugins-list 
+List available or installed plugins
+
+USAGE:
+    spin plugins list [OPTIONS]
+
+OPTIONS:
+    -h, --help         Print help information
+        --installed    List only installed plugins
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.2"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins list --help   
+
+spin-plugins-list 
+List available or installed plugins
+
+USAGE:
+    spin plugins list [OPTIONS]
+
+OPTIONS:
+    -h, --help         Print help information
+        --installed    List only installed plugins
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins list --help   
+
+spin-plugins-list 
+List available or installed plugins
+
+USAGE:
+    spin plugins list [OPTIONS]
+
+OPTIONS:
+    -h, --help         Print help information
+        --installed    List only installed plugins
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins list --help   
+
+spin-plugins-list 
+List available or installed plugins
+
+USAGE:
+    spin plugins list [OPTIONS]
+
+OPTIONS:
+    -h, --help         Print help information
+        --installed    List only installed plugins
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins list --help   
+
+spin-plugins-list 
+List available or installed plugins
+
+USAGE:
+    spin plugins list [OPTIONS]
+
+OPTIONS:
+    -h, --help         Print help information
+        --installed    List only installed plugins
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin plugins uninstall
+
+{{ tabs "spin-version" }}
+
+{{ startTab "v1.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins uninstall --help
+
+spin-plugins-uninstall 
+Remove a plugin from your installation
+
+USAGE:
+    spin plugins uninstall <NAME>
+
+ARGS:
+    <NAME>    Name of Spin plugin
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins uninstall --help
+
+spin-plugins-uninstall 
+Remove a plugin from your installation
+
+USAGE:
+    spin plugins uninstall <NAME>
+
+ARGS:
+    <NAME>    Name of Spin plugin
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.2"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins uninstall --help
+
+spin-plugins-uninstall 
+Remove a plugin from your installation
+
+USAGE:
+    spin plugins uninstall <NAME>
+
+ARGS:
+    <NAME>    Name of Spin plugin
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins uninstall --help
+
+spin-plugins-uninstall 
+Remove a plugin from your installation
+
+USAGE:
+    spin plugins uninstall <NAME>
+
+ARGS:
+    <NAME>    Name of Spin plugin
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins uninstall --help
+
+spin-plugins-uninstall 
+Remove a plugin from your installation
+
+USAGE:
+    spin plugins uninstall <NAME>
+
+ARGS:
+    <NAME>    Name of Spin plugin
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins uninstall --help
+
+spin-plugins-uninstall 
+Remove a plugin from your installation
+
+USAGE:
+    spin plugins uninstall <NAME>
+
+ARGS:
+    <NAME>    Name of Spin plugin
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin plugins update
+
+{{ tabs "spin-version" }}
+
+{{ startTab "v1.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins update --help   
+
+spin-plugins-update 
+Fetch the latest Spin plugins from the spin-plugins repository
+
+USAGE:
+    spin plugins update
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins update --help   
+
+spin-plugins-update 
+Fetch the latest Spin plugins from the spin-plugins repository
+
+USAGE:
+    spin plugins update
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.2"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins update --help   
+
+spin-plugins-update 
+Fetch the latest Spin plugins from the spin-plugins repository
+
+USAGE:
+    spin plugins update
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins update --help   
+
+spin-plugins-update 
+Fetch the latest Spin plugins from the spin-plugins repository
+
+USAGE:
+    spin plugins update
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins update --help   
+
+spin-plugins-update 
+Fetch the latest Spin plugins from the spin-plugins repository
+
+USAGE:
+    spin plugins update
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins update --help   
+
+spin-plugins-update 
+Fetch the latest Spin plugins from the spin-plugins repository
+
+USAGE:
+    spin plugins update
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin plugins upgrade
+
+{{ tabs "spin-version" }}
+
+{{ startTab "v1.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins upgrade --help
+
+spin-plugins-upgrade 
+Upgrade one or all plugins
+
+USAGE:
+    spin plugins upgrade [OPTIONS] [PLUGIN_NAME]
+
+ARGS:
+    <PLUGIN_NAME>    Name of Spin plugin to upgrade
+
+OPTIONS:
+    -a, --all
+            Upgrade all plugins
+
+    -d, --downgrade
+            Allow downgrading a plugin's version
+
+    -f, --file <LOCAL_PLUGIN_MANIFEST>
+            Path to local plugin manifest
+
+    -h, --help
+            Print help information
+
+        --override-compatibility-check
+            Overrides a failed compatibility check of the plugin with the current version of Spin
+
+    -u, --url <REMOTE_PLUGIN_MANIFEST>
+            Path to remote plugin manifest
+
+    -v, --version <VERSION>
+            Specific version of a plugin to be install from the centralized plugins repository
+
+    -y, --yes
+            Skips prompt to accept the installation of the plugin[s]
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins upgrade --help
+
+spin-plugins-upgrade 
+Upgrade one or all plugins
+
+USAGE:
+    spin plugins upgrade [OPTIONS] [PLUGIN_NAME]
+
+ARGS:
+    <PLUGIN_NAME>    Name of Spin plugin to upgrade
+
+OPTIONS:
+    -a, --all
+            Upgrade all plugins
+
+    -d, --downgrade
+            Allow downgrading a plugin's version
+
+    -f, --file <LOCAL_PLUGIN_MANIFEST>
+            Path to local plugin manifest
+
+    -h, --help
+            Print help information
+
+        --override-compatibility-check
+            Overrides a failed compatibility check of the plugin with the current version of Spin
+
+    -u, --url <REMOTE_PLUGIN_MANIFEST>
+            Path to remote plugin manifest
+
+    -v, --version <VERSION>
+            Specific version of a plugin to be install from the centralized plugins repository
+
+    -y, --yes
+            Skips prompt to accept the installation of the plugin[s]
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.2"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins upgrade --help
+
+spin-plugins-upgrade 
+Upgrade one or all plugins
+
+USAGE:
+    spin plugins upgrade [OPTIONS] [PLUGIN_NAME]
+
+ARGS:
+    <PLUGIN_NAME>    Name of Spin plugin to upgrade
+
+OPTIONS:
+    -a, --all
+            Upgrade all plugins
+
+    -d, --downgrade
+            Allow downgrading a plugin's version
+
+    -f, --file <LOCAL_PLUGIN_MANIFEST>
+            Path to local plugin manifest
+
+    -h, --help
+            Print help information
+
+        --override-compatibility-check
+            Overrides a failed compatibility check of the plugin with the current version of Spin
+
+    -u, --url <REMOTE_PLUGIN_MANIFEST>
+            Path to remote plugin manifest
+
+    -v, --version <VERSION>
+            Specific version of a plugin to be install from the centralized plugins repository
+
+    -y, --yes
+            Skips prompt to accept the installation of the plugin[s]
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins upgrade --help
+
+spin-plugins-upgrade 
+Upgrade one or all plugins
+
+USAGE:
+    spin plugins upgrade [OPTIONS] [PLUGIN_NAME]
+
+ARGS:
+    <PLUGIN_NAME>    Name of Spin plugin to upgrade
+
+OPTIONS:
+    -a, --all
+            Upgrade all plugins
+
+    -d, --downgrade
+            Allow downgrading a plugin's version
+
+    -f, --file <LOCAL_PLUGIN_MANIFEST>
+            Path to local plugin manifest
+
+    -h, --help
+            Print help information
+
+        --override-compatibility-check
+            Overrides a failed compatibility check of the plugin with the current version of Spin
+
+    -u, --url <REMOTE_PLUGIN_MANIFEST>
+            Path to remote plugin manifest
+
+    -v, --version <VERSION>
+            Specific version of a plugin to be install from the centralized plugins repository
+
+    -y, --yes
+            Skips prompt to accept the installation of the plugin[s]
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins upgrade --help
+
+spin-plugins-upgrade 
+Upgrade one or all plugins
+
+USAGE:
+    spin plugins upgrade [OPTIONS] [PLUGIN_NAME]
+
+ARGS:
+    <PLUGIN_NAME>    Name of Spin plugin to upgrade
+
+OPTIONS:
+    -a, --all
+            Upgrade all plugins
+
+    -d, --downgrade
+            Allow downgrading a plugin's version
+
+    -f, --file <LOCAL_PLUGIN_MANIFEST>
+            Path to local plugin manifest
+
+    -h, --help
+            Print help information
+
+        --override-compatibility-check
+            Overrides a failed compatibility check of the plugin with the current version of Spin
+
+    -u, --url <REMOTE_PLUGIN_MANIFEST>
+            Path to remote plugin manifest
+
+    -v, --version <VERSION>
+            Specific version of a plugin to be install from the centralized plugins repository
+
+    -y, --yes
+            Skips prompt to accept the installation of the plugin[s]
+
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins upgrade --help
+
+spin-plugins-upgrade 
+Upgrade one or all plugins
+
+USAGE:
+    spin plugins upgrade [OPTIONS] [PLUGIN_NAME]
+
+ARGS:
+    <PLUGIN_NAME>    Name of Spin plugin to upgrade
+
+OPTIONS:
+    -a, --all
+            Upgrade all plugins
+
+    -d, --downgrade
+            Allow downgrading a plugin's version
+
+    -f, --file <LOCAL_PLUGIN_MANIFEST>
+            Path to local plugin manifest
+
+    -h, --help
+            Print help information
+
+        --override-compatibility-check
+            Overrides a failed compatibility check of the plugin with the current version of Spin
+
+    -u, --url <REMOTE_PLUGIN_MANIFEST>
+            Path to remote plugin manifest
+
+    -v, --version <VERSION>
+            Specific version of a plugin to be install from the centralized plugins repository
+
+    -y, --yes
+            Skips prompt to accept the installation of the plugin[s]
+
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+**Note:** For additional information, please see the [Managing Plugins](/spin/managing-plugins) and/or [Creating Plugins](/spin/plugin-authoring) sections of the documentation.
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin registry
+
+{{ tabs "spin-version" }}
+
+{{ startTab "v1.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry --help
+
+spin-registry 
+Commands for working with OCI registries to distribute applications. Currently, the OCI commands are reusing the
+credentials from ~/.docker/config.json to authenticate to registries
+
+USAGE:
+    spin registry <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    help     Print this message or the help of the given subcommand(s)
+    login    Log in to a registry
+    pull     Pull a Spin application from a registry
+    push     Push a Spin application to a registry
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry --help
+
+spin-registry 
+Commands for working with OCI registries to distribute applications. Currently, the OCI commands are reusing the
+credentials from ~/.docker/config.json to authenticate to registries
+
+USAGE:
+    spin registry <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    help     Print this message or the help of the given subcommand(s)
+    login    Log in to a registry
+    pull     Pull a Spin application from a registry
+    push     Push a Spin application to a registry
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.2"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry --help
+
+spin-registry 
+Commands for working with OCI registries to distribute applications
+
+USAGE:
+    spin registry <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    help     Print this message or the help of the given subcommand(s)
+    login    Log in to a registry
+    pull     Pull a Spin application from a registry
+    push     Push a Spin application to a registry
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry --help
+
+spin-registry 
+Commands for working with OCI registries to distribute applications
+
+USAGE:
+    spin registry <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    help     Print this message or the help of the given subcommand(s)
+    login    Log in to a registry
+    pull     Pull a Spin application from a registry
+    push     Push a Spin application to a registry
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry --help
+
+spin-registry 
+Commands for working with OCI registries to distribute applications
+
+USAGE:
+    spin registry <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    help     Print this message or the help of the given subcommand(s)
+    login    Log in to a registry
+    pull     Pull a Spin application from a registry
+    push     Push a Spin application to a registry
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry --help
+
+spin-registry 
+Commands for working with OCI registries to distribute applications
+
+USAGE:
+    spin registry <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    help     Print this message or the help of the given subcommand(s)
+    login    Log in to a registry
+    pull     Pull a Spin application from a registry
+    push     Push a Spin application to a registry
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin registry login
+
+{{ tabs "spin-version" }}
+
+{{ startTab "v1.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry login --help
+
+spin-registry-login 
+Log in to a registry
+
+USAGE:
+    spin registry login [OPTIONS] <SERVER>
+
+ARGS:
+    <SERVER>    
+
+OPTIONS:
+    -h, --help                   Print help information
+    -p, --password <PASSWORD>    Password for the registry
+        --password-stdin         Take the password from stdin
+    -u, --username <USERNAME>    Username for the registry
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry login --help
+
+spin-registry-login 
+Log in to a registry
+
+USAGE:
+    spin registry login [OPTIONS] <SERVER>
+
+ARGS:
+    <SERVER>    
+
+OPTIONS:
+    -h, --help                   Print help information
+    -p, --password <PASSWORD>    Password for the registry
+        --password-stdin         Take the password from stdin
+    -u, --username <USERNAME>    Username for the registry
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.2"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry login --help
+
+spin-registry-login 
+Log in to a registry
+
+USAGE:
+    spin registry login [OPTIONS] <SERVER>
+
+ARGS:
+    <SERVER>    
+
+OPTIONS:
+    -h, --help                   Print help information
+    -p, --password <PASSWORD>    Password for the registry
+        --password-stdin         Take the password from stdin
+    -u, --username <USERNAME>    Username for the registry
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry login --help
+
+spin-registry-login 
+Log in to a registry
+
+USAGE:
+    spin registry login [OPTIONS] <SERVER>
+
+ARGS:
+    <SERVER>    
+
+OPTIONS:
+    -h, --help                   Print help information
+    -p, --password <PASSWORD>    Password for the registry
+        --password-stdin         Take the password from stdin
+    -u, --username <USERNAME>    Username for the registry
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry login --help
+
+spin-registry-login 
+Log in to a registry
+
+USAGE:
+    spin registry login [OPTIONS] <SERVER>
+
+ARGS:
+    <SERVER>    
+
+OPTIONS:
+    -h, --help                   Print help information
+    -p, --password <PASSWORD>    Password for the registry
+        --password-stdin         Take the password from stdin
+    -u, --username <USERNAME>    Username for the registry
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry login --help
+
+spin-registry-login 
+Log in to a registry
+
+USAGE:
+    spin registry login [OPTIONS] <SERVER>
+
+ARGS:
+    <SERVER>    
+
+OPTIONS:
+    -h, --help                   Print help information
+    -p, --password <PASSWORD>    Password for the registry
+        --password-stdin         Take the password from stdin
+    -u, --username <USERNAME>    Username for the registry
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin registry pull
+
+{{ tabs "spin-version" }}
+
+{{ startTab "v1.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry pull --help
+
+spin-registry-pull 
+Pull a Spin application from a registry
+
+USAGE:
+    spin registry pull [OPTIONS] <REFERENCE>
+
+ARGS:
+    <REFERENCE>    Reference of the Spin application
+
+OPTIONS:
+    -h, --help        Print help information
+    -k, --insecure    Ignore server certificate errors
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry pull --help
+
+spin-registry-pull 
+Pull a Spin application from a registry
+
+USAGE:
+    spin registry pull [OPTIONS] <REFERENCE>
+
+ARGS:
+    <REFERENCE>    Reference of the Spin application
+
+OPTIONS:
+    -h, --help        Print help information
+    -k, --insecure    Ignore server certificate errors
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.2"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry pull --help
+
+spin-registry-pull 
+Pull a Spin application from a registry
+
+USAGE:
+    spin registry pull [OPTIONS] <REFERENCE>
+
+ARGS:
+    <REFERENCE>    Reference of the Spin application
+
+OPTIONS:
+    -h, --help        Print help information
+    -k, --insecure    Ignore server certificate errors
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry pull --help
+
+spin-registry-pull 
+Pull a Spin application from a registry
+
+USAGE:
+    spin registry pull [OPTIONS] <REFERENCE>
+
+ARGS:
+    <REFERENCE>    Reference of the Spin application
+
+OPTIONS:
+    -h, --help        Print help information
+    -k, --insecure    Ignore server certificate errors
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry pull --help
+
+spin-registry-pull 
+Pull a Spin application from a registry
+
+USAGE:
+    spin registry pull [OPTIONS] <REFERENCE>
+
+ARGS:
+    <REFERENCE>    Reference of the Spin application
+
+OPTIONS:
+    -h, --help        Print help information
+    -k, --insecure    Ignore server certificate errors
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry pull --help
+
+spin-registry-pull 
+Pull a Spin application from a registry
+
+USAGE:
+    spin registry pull [OPTIONS] <REFERENCE>
+
+ARGS:
+    <REFERENCE>    Reference of the Spin application
+
+OPTIONS:
+    -h, --help        Print help information
+    -k, --insecure    Ignore server certificate error
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin registry push
+
+{{ tabs "spin-version" }}
+
+{{ startTab "v1.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry push --help 
+
+spin-registry-push 
+Push a Spin application to a registry
+
+USAGE:
+    spin registry push [OPTIONS] <REFERENCE>
+
+ARGS:
+    <REFERENCE>    Reference of the Spin application
+
+OPTIONS:
+    -f, --file <APP_MANIFEST_FILE>    Path to spin.toml
+    -h, --help                        Print help information
+    -k, --insecure                    Ignore server certificate errors
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry push --help 
+
+spin-registry-push 
+Push a Spin application to a registry
+
+USAGE:
+    spin registry push [OPTIONS] <REFERENCE>
+
+ARGS:
+    <REFERENCE>    Reference of the Spin application
+
+OPTIONS:
+    -f, --file <APP_MANIFEST_FILE>    Path to spin.toml
+    -h, --help                        Print help information
+    -k, --insecure                    Ignore server certificate errors
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.2"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry push --help 
+
+spin-registry-push 
+Push a Spin application to a registry
+
+USAGE:
+    spin registry push [OPTIONS] <REFERENCE>
+
+ARGS:
+    <REFERENCE>    Reference of the Spin application
+
+OPTIONS:
+    -f, --from <APP_MANIFEST_FILE>    The application to push. This may be a manifest (spin.toml)
+                                      file, or a directory containing a spin.toml file. If omitted,
+                                      it defaults to "spin.toml" [default: spin.toml]
+    -h, --help                        Print help information
+    -k, --insecure                    Ignore server certificate errors
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3" }}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry push --help
+
+spin-registry-push
+Push a Spin application to a registry
+
+USAGE:
+    spin registry push [OPTIONS] <REFERENCE>
+
+ARGS:
+    <REFERENCE>    Reference of the Spin application
+
+OPTIONS:
+    -f, --from <APP_MANIFEST_FILE>    The application to push. This may be a manifest (spin.toml)
+                                      file, or a directory containing a spin.toml file. If omitted,
+                                      it defaults to "spin.toml" [default: spin.toml]
+    -h, --help                        Print help information
+    -k, --insecure                    Ignore server certificate errors
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.4" }}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry push --help
+
+spin-registry-push
+Push a Spin application to a registry
+
+USAGE:
+    spin registry push [OPTIONS] <REFERENCE>
+
+ARGS:
+    <REFERENCE>    Reference of the Spin application
+
+OPTIONS:
+    -f, --from <APP_MANIFEST_FILE>    The application to push. This may be a manifest (spin.toml)
+                                      file, or a directory containing a spin.toml file. If omitted,
+                                      it defaults to "spin.toml" [default: spin.toml]
+    -h, --help                        Print help information
+    -k, --insecure                    Ignore server certificate errors
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.5" }}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry push --help
+
+spin-registry-push
+Push a Spin application to a registry
+
+USAGE:
+    spin registry push [OPTIONS] <REFERENCE>
+
+ARGS:
+    <REFERENCE>    Reference of the Spin application
+
+OPTIONS:
+    -f, --from <APP_MANIFEST_FILE>    The application to push. This may be a manifest (spin.toml)
+                                      file, or a directory containing a spin.toml file. If omitted,
+                                      it defaults to "spin.toml" [default: spin.toml]
+    -h, --help                        Print help information
+    -k, --insecure                    Ignore server certificate errors
+
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin templates
+
+{{ tabs "spin-version" }}
+
+{{ startTab "v1.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates --help    
+
+spin-templates 
+Commands for working with WebAssembly component templates
+
+USAGE:
+    spin templates <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    help         Print this message or the help of the given subcommand(s)
+    install      Install templates from a Git repository or local directory
+    list         List the installed templates
+    uninstall    Remove a template from your installation
+    upgrade      Upgrade templates to match your current version of Spin
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates --help    
+
+spin-templates 
+Commands for working with WebAssembly component templates
+
+USAGE:
+    spin templates <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    help         Print this message or the help of the given subcommand(s)
+    install      Install templates from a Git repository or local directory
+    list         List the installed templates
+    uninstall    Remove a template from your installation
+    upgrade      Upgrade templates to match your current version of Spin
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.2"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates --help    
+
+spin-templates 
+Commands for working with WebAssembly component templates
+
+USAGE:
+    spin templates <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    help         Print this message or the help of the given subcommand(s)
+    install      Install templates from a Git repository or local directory
+    list         List the installed templates
+    uninstall    Remove a template from your installation
+    upgrade      Upgrade templates to match your current version of Spin
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates --help    
+
+spin-templates 
+Commands for working with WebAssembly component templates
+
+USAGE:
+    spin templates <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    help         Print this message or the help of the given subcommand(s)
+    install      Install templates from a Git repository or local directory
+    list         List the installed templates
+    uninstall    Remove a template from your installation
+    upgrade      Upgrade templates to match your current version of Spin
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates --help    
+
+spin-templates 
+Commands for working with WebAssembly component templates
+
+USAGE:
+    spin templates <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    help         Print this message or the help of the given subcommand(s)
+    install      Install templates from a Git repository or local directory
+    list         List the installed templates
+    uninstall    Remove a template from your installation
+    upgrade      Upgrade templates to match your current version of Spin
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates --help    
+
+spin-templates 
+Commands for working with WebAssembly component templates
+
+USAGE:
+    spin templates <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    help         Print this message or the help of the given subcommand(s)
+    install      Install templates from a Git repository or local directory
+    list         List the installed templates
+    uninstall    Remove a template from your installation
+    upgrade      Upgrade templates to match your current version of Spin
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin templates install
+
+{{ tabs "spin-version" }}
+
+{{ startTab "v1.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates install --help
+
+spin-templates-install 
+Install templates from a Git repository or local directory.
+
+The files of the templates are copied to the local template store: a directory in your data or home
+directory.
+
+USAGE:
+    spin templates install [OPTIONS]
+
+OPTIONS:
+        --branch <BRANCH>
+            The optional branch of the git repository
+
+        --dir <FROM_DIR>
+            Local directory containing the template(s) to install
+
+        --git <FROM_GIT>
+            The URL of the templates git repository. The templates must be in a git repository in a
+            "templates" directory
+
+    -h, --help
+            Print help information
+
+        --upgrade
+            If present, updates existing templates instead of skipping
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates install --help
+
+spin-templates-install 
+Install templates from a Git repository or local directory.
+
+The files of the templates are copied to the local template store: a directory in your data or home
+directory.
+
+USAGE:
+    spin templates install [OPTIONS]
+
+OPTIONS:
+        --branch <BRANCH>
+            The optional branch of the git repository
+
+        --dir <FROM_DIR>
+            Local directory containing the template(s) to install
+
+        --git <FROM_GIT>
+            The URL of the templates git repository. The templates must be in a git repository in a
+            "templates" directory
+
+    -h, --help
+            Print help information
+
+        --upgrade
+            If present, updates existing templates instead of skipping
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.2"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates install --help
+
+spin-templates-install 
+Install templates from a Git repository or local directory.
+
+The files of the templates are copied to the local template store: a directory in your data or home
+directory.
+
+USAGE:
+    spin templates install [OPTIONS]
+
+OPTIONS:
+        --branch <BRANCH>
+            The optional branch of the git repository
+
+        --dir <FROM_DIR>
+            Local directory containing the template(s) to install
+
+        --git <FROM_GIT>
+            The URL of the templates git repository. The templates must be in a git repository in a
+            "templates" directory
+
+    -h, --help
+            Print help information
+
+        --upgrade
+            If present, updates existing templates instead of skipping
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates install --help
+
+spin-templates-install 
+Install templates from a Git repository or local directory.
+
+The files of the templates are copied to the local template store: a directory in your data or home
+directory.
+
+USAGE:
+    spin templates install [OPTIONS]
+
+OPTIONS:
+        --branch <BRANCH>
+            The optional branch of the git repository
+
+        --dir <FROM_DIR>
+            Local directory containing the template(s) to install
+
+        --git <FROM_GIT>
+            The URL of the templates git repository. The templates must be in a git repository in a
+            "templates" directory
+
+    -h, --help
+            Print help information
+
+        --upgrade
+            If present, updates existing templates instead of skipping
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates install --help
+
+spin-templates-install 
+Install templates from a Git repository or local directory.
+
+The files of the templates are copied to the local template store: a directory in your data or home
+directory.
+
+USAGE:
+    spin templates install [OPTIONS]
+
+OPTIONS:
+        --branch <BRANCH>
+            The optional branch of the git repository
+
+        --dir <FROM_DIR>
+            Local directory containing the template(s) to install
+
+        --git <FROM_GIT>
+            The URL of the templates git repository. The templates must be in a git repository in a
+            "templates" directory
+
+    -h, --help
+            Print help information
+
+        --upgrade
+            If present, updates existing templates instead of skipping
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates install --help
+
+spin-templates-install 
+Install templates from a Git repository or local directory.
+
+The files of the templates are copied to the local template store: a directory in your data or home
+directory.
+
+USAGE:
+    spin templates install [OPTIONS]
+
+OPTIONS:
+        --branch <BRANCH>
+            The optional branch of the git repository
+
+        --dir <FROM_DIR>
+            Local directory containing the template(s) to install
+
+        --git <FROM_GIT>
+            The URL of the templates git repository. The templates must be in a git repository in a
+            "templates" directory
+
+    -h, --help
+            Print help information
+
+        --upgrade
+            If present, updates existing templates instead of skipping
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin templates list
+
+{{ tabs "spin-version" }}
+
+{{ startTab "v1.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates list --help   
+
+spin-templates-list 
+List the installed templates
+
+USAGE:
+    spin templates list [OPTIONS]
+
+OPTIONS:
+    -h, --help          Print help information
+        --tag <TAGS>    Filter templates matching all provided tags
+        --verbose       Whether to show additional template details in the list
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates list --help   
+
+spin-templates-list 
+List the installed templates
+
+USAGE:
+    spin templates list [OPTIONS]
+
+OPTIONS:
+    -h, --help          Print help information
+        --tag <TAGS>    Filter templates matching all provided tags
+        --verbose       Whether to show additional template details in the list
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.2"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates list --help   
+
+spin-templates-list 
+List the installed templates
+
+USAGE:
+    spin templates list [OPTIONS]
+
+OPTIONS:
+    -h, --help          Print help information
+        --tag <TAGS>    Filter templates matching all provided tags
+        --verbose       Whether to show additional template details in the list
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates list --help   
+
+spin-templates-list 
+List the installed templates
+
+USAGE:
+    spin templates list [OPTIONS]
+
+OPTIONS:
+    -h, --help          Print help information
+        --tag <TAGS>    Filter templates matching all provided tags
+        --verbose       Whether to show additional template details in the list
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates list --help   
+
+spin-templates-list 
+List the installed templates
+
+USAGE:
+    spin templates list [OPTIONS]
+
+OPTIONS:
+    -h, --help          Print help information
+        --tag <TAGS>    Filter templates matching all provided tags
+        --verbose       Whether to show additional template details in the list
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates list --help   
+
+spin-templates-list 
+List the installed templates
+
+USAGE:
+    spin templates list [OPTIONS]
+
+OPTIONS:
+    -h, --help          Print help information
+        --tag <TAGS>    Filter templates matching all provided tags
+        --verbose       Whether to show additional template details in the list
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin templates uninstall
+
+<!-- @selectiveCpy -->
+
+{{ tabs "spin-version" }}
+
+{{ startTab "v1.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates uninstall --help
+
+spin-templates-uninstall 
+Remove a template from your installation
+
+USAGE:
+    spin templates uninstall <TEMPLATE_ID>
+
+ARGS:
+    <TEMPLATE_ID>    The template to uninstall
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates uninstall --help
+
+spin-templates-uninstall 
+Remove a template from your installation
+
+USAGE:
+    spin templates uninstall <TEMPLATE_ID>
+
+ARGS:
+    <TEMPLATE_ID>    The template to uninstall
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.2"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates uninstall --help
+
+spin-templates-uninstall 
+Remove a template from your installation
+
+USAGE:
+    spin templates uninstall <TEMPLATE_ID>
+
+ARGS:
+    <TEMPLATE_ID>    The template to uninstall
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates uninstall --help
+
+spin-templates-uninstall 
+Remove a template from your installation
+
+USAGE:
+    spin templates uninstall <TEMPLATE_ID>
+
+ARGS:
+    <TEMPLATE_ID>    The template to uninstall
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates uninstall --help
+
+spin-templates-uninstall 
+Remove a template from your installation
+
+USAGE:
+    spin templates uninstall <TEMPLATE_ID>
+
+ARGS:
+    <TEMPLATE_ID>    The template to uninstall
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates uninstall --help
+
+spin-templates-uninstall 
+Remove a template from your installation
+
+USAGE:
+    spin templates list [OPTIONS]
+
+OPTIONS:
+    -h, --help          Print help information
+        --tag <TAGS>    Filter templates matching all provided tags
+        --verbose       Whether to show additional template details in the list
+tpmccallum@192-168-1-16 developer % spin templates uninstall --help
+spin-templates-uninstall 
+Remove a template from your installation
+
+USAGE:
+    spin templates uninstall <TEMPLATE_ID>
+
+ARGS:
+    <TEMPLATE_ID>    The template to uninstall
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin templates upgrade
+
+{{ tabs "spin-version" }}
+
+{{ startTab "v1.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates upgrade --help  
+
+spin-templates-upgrade 
+Upgrade templates to match your current version of Spin.
+
+The files of the templates are copied to the local template store: a directory in your data or home
+directory.
+
+USAGE:
+    spin templates upgrade [OPTIONS]
+
+OPTIONS:
+        --all
+            By default, Spin displays the list of installed repositories and prompts you to choose
+            which to upgrade.  Pass this flag to upgrade all repositories without prompting
+
+        --branch <BRANCH>
+            The optional branch of the git repository, if a specific repository is given
+
+    -h, --help
+            Print help information
+
+        --repo <GIT_URL>
+            By default, Spin displays the list of installed repositories and prompts you to choose
+            which to upgrade.  Pass this flag to upgrade only the specified repository without
+            prompting
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates upgrade --help
+
+spin-templates-upgrade 
+Upgrade templates to match your current version of Spin.
+
+The files of the templates are copied to the local template store: a directory in your data or home
+directory.
+
+USAGE:
+    spin templates upgrade [OPTIONS]
+
+OPTIONS:
+        --all
+            By default, Spin displays the list of installed repositories and prompts you to choose
+            which to upgrade.  Pass this flag to upgrade all repositories without prompting
+
+        --branch <BRANCH>
+            The optional branch of the git repository, if a specific repository is given
+
+    -h, --help
+            Print help information
+
+        --repo <GIT_URL>
+            By default, Spin displays the list of installed repositories and prompts you to choose
+            which to upgrade.  Pass this flag to upgrade only the specified repository without
+            prompting
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.2"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates upgrade --help  
+
+spin-templates-upgrade 
+Upgrade templates to match your current version of Spin.
+
+The files of the templates are copied to the local template store: a directory in your data or home
+directory.
+
+USAGE:
+    spin templates upgrade [OPTIONS]
+
+OPTIONS:
+        --all
+            By default, Spin displays the list of installed repositories and prompts you to choose
+            which to upgrade.  Pass this flag to upgrade all repositories without prompting
+
+        --branch <BRANCH>
+            The optional branch of the git repository, if a specific repository is given
+
+    -h, --help
+            Print help information
+
+        --repo <GIT_URL>
+            By default, Spin displays the list of installed repositories and prompts you to choose
+            which to upgrade.  Pass this flag to upgrade only the specified repository without
+            prompting
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates upgrade --help  
+
+spin-templates-upgrade 
+Upgrade templates to match your current version of Spin.
+
+The files of the templates are copied to the local template store: a directory in your data or home
+directory.
+
+USAGE:
+    spin templates upgrade [OPTIONS]
+
+OPTIONS:
+        --all
+            By default, Spin displays the list of installed repositories and prompts you to choose
+            which to upgrade.  Pass this flag to upgrade all repositories without prompting
+
+        --branch <BRANCH>
+            The optional branch of the git repository, if a specific repository is given
+
+    -h, --help
+            Print help information
+
+        --repo <GIT_URL>
+            By default, Spin displays the list of installed repositories and prompts you to choose
+            which to upgrade.  Pass this flag to upgrade only the specified repository without
+            prompting
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates upgrade --help  
+
+spin-templates-upgrade 
+Upgrade templates to match your current version of Spin.
+
+The files of the templates are copied to the local template store: a directory in your data or home
+directory.
+
+USAGE:
+    spin templates upgrade [OPTIONS]
+
+OPTIONS:
+        --all
+            By default, Spin displays the list of installed repositories and prompts you to choose
+            which to upgrade.  Pass this flag to upgrade all repositories without prompting
+
+        --branch <BRANCH>
+            The optional branch of the git repository, if a specific repository is given
+
+    -h, --help
+            Print help information
+
+        --repo <GIT_URL>
+            By default, Spin displays the list of installed repositories and prompts you to choose
+            which to upgrade.  Pass this flag to upgrade only the specified repository without
+            prompting
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates upgrade --help  
+
+spin-templates-upgrade 
+Upgrade templates to match your current version of Spin.
+
+The files of the templates are copied to the local template store: a directory in your data or home
+directory.
+
+USAGE:
+    spin templates upgrade [OPTIONS]
+
+OPTIONS:
+        --all
+            By default, Spin displays the list of installed repositories and prompts you to choose
+            which to upgrade.  Pass this flag to upgrade all repositories without prompting
+
+        --branch <BRANCH>
+            The optional branch of the git repository, if a specific repository is given
+
+    -h, --help
+            Print help information
+
+        --repo <GIT_URL>
+            By default, Spin displays the list of installed repositories and prompts you to choose
+            which to upgrade.  Pass this flag to upgrade only the specified repository without
+            prompting
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+**Note:** For additional information, please see the [Managing Templates](/spin/managing-templates) and/or [Creating Templates](/spin/template-authoring) sections of the documentation.
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin up
+
+The following options are available in relation to running your Spin application.
+
+Note: There are three trigger options which only applies to the [HTTP trigger](#spin-up-http-triggers) (`--listen`, `--tls-cert` and `--tls-key`).
+
+{{ tabs "spin-version" }}
+
+{{ startTab "v1.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin up --help
+
+spin-up 
+Start the Spin application
+USAGE:
+    spin up [OPTIONS]
+
+OPTIONS:
+        --direct-mounts         For local apps with directory mounts and no excluded files, mount
+                                them directly instead of using a temporary directory
+    -e, --env <ENV>             Pass an environment variable (key=value) to all components of the
+                                application
+    -f, --from <APPLICATION>    The application to run. This may be a manifest (spin.toml) file, a
+                                directory containing a spin.toml file, or a remote registry
+                                reference. If omitted, it defaults to "spin.toml"
+    -h, --help                  
+    -k, --insecure              Ignore server certificate errors from bindle server or registry
+        --temp <TMP>            Temporary directory for the static assets of the components
+
+TRIGGER OPTIONS:
+        --allow-transient-write
+            Set the static assets of the components in the temporary directory as writable
+
+        --cache <WASMTIME_CACHE_FILE>
+            Wasmtime cache configuration file
+            
+            [env: WASMTIME_CACHE_FILE=]
+
+        --disable-cache
+            Disable Wasmtime cache
+            
+            [env: DISABLE_WASMTIME_CACHE=]
+
+        --follow <FOLLOW_ID>
+            Print output to stdout/stderr only for given component(s)
+
+    -L, --log-dir <APP_LOG_DIR>
+            Log directory for the stdout and stderr of components     
+
+    -q, --quiet
+            Silence all component output to stdout/stderr
+
+        --runtime-config-file <RUNTIME_CONFIG_FILE>
+            Configuration file for config providers and wasmtime config
+            
+            [env: RUNTIME_CONFIG_FILE=]
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin up --help
+
+spin-up 
+Start the Spin application
+USAGE:
+    spin up [OPTIONS]
+
+OPTIONS:
+        --direct-mounts         For local apps with directory mounts and no excluded files, mount
+                                them directly instead of using a temporary directory
+    -e, --env <ENV>             Pass an environment variable (key=value) to all components of the
+                                application
+    -f, --from <APPLICATION>    The application to run. This may be a manifest (spin.toml) file, a
+                                directory containing a spin.toml file, or a remote registry
+                                reference. If omitted, it defaults to "spin.toml"
+    -h, --help                  
+    -k, --insecure              Ignore server certificate errors from bindle server or registry
+        --temp <TMP>            Temporary directory for the static assets of the components
+
+TRIGGER OPTIONS:
+        --allow-transient-write
+            Set the static assets of the components in the temporary directory as writable
+
+        --cache <WASMTIME_CACHE_FILE>
+            Wasmtime cache configuration file
+            
+            [env: WASMTIME_CACHE_FILE=]
+
+        --disable-cache
+            Disable Wasmtime cache
+            
+            [env: DISABLE_WASMTIME_CACHE=]
+
+        --follow <FOLLOW_ID>
+            Print output to stdout/stderr only for given component(s)
+
+    -L, --log-dir <APP_LOG_DIR>
+            Log directory for the stdout and stderr of components
+
+    -q, --quiet
+            Silence all component output to stdout/stderr
+
+        --runtime-config-file <RUNTIME_CONFIG_FILE>
+            Configuration file for config providers and wasmtime config
+            
+            [env: RUNTIME_CONFIG_FILE=]
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.2"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin up --help
+
+spin-up 
+Start the Spin application
+
+USAGE:
+    spin up [OPTIONS]
+
+OPTIONS:
+        --direct-mounts         For local apps with directory mounts and no excluded files, mount
+                                them directly instead of using a temporary directory
+    -e, --env <ENV>             Pass an environment variable (key=value) to all components of the
+                                application
+    -f, --from <APPLICATION>    The application to run. This may be a manifest (spin.toml) file, a
+                                directory containing a spin.toml file, or a remote registry
+                                reference. If omitted, it defaults to "spin.toml"
+    -h, --help                  
+    -k, --insecure              Ignore server certificate errors from bindle server or registry
+        --temp <TMP>            Temporary directory for the static assets of the components
+
+TRIGGER OPTIONS:
+        --allow-transient-write
+            Set the static assets of the components in the temporary directory as writable
+
+        --cache <WASMTIME_CACHE_FILE>
+            Wasmtime cache configuration file
+            
+            [env: WASMTIME_CACHE_FILE=]
+
+        --disable-cache
+            Disable Wasmtime cache
+            
+            [env: DISABLE_WASMTIME_CACHE=]
+
+        --follow <FOLLOW_ID>
+            Print output to stdout/stderr only for given component(s)
+
+        --key-value <KEY_VALUES>
+            Set a key/value pair (key=value) in the application's default store. Any existing value
+            will be overwritten. Can be used multiple times
+
+    -L, --log-dir <APP_LOG_DIR>
+            Log directory for the stdout and stderr of components
+
+    -q, --quiet
+            Silence all component output to stdout/stderr
+
+        --runtime-config-file <RUNTIME_CONFIG_FILE>
+            Configuration file for config providers and wasmtime config
+            
+            [env: RUNTIME_CONFIG_FILE=]
+
+        --state-dir <STATE_DIR>
+            Set the application state directory path. This is used in the default locations for
+            logs, key value stores, etc.
+            
+            For local apps, this defaults to `.spin/` relative to the `spin.toml` file. For remote
+            apps, this has no default (unset). Passing an empty value forces the value to be unset.
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin up --help
+
+spin-up 
+Start the Spin application
+
+USAGE:
+    spin up [OPTIONS]
+
+OPTIONS:
+        --direct-mounts         For local apps with directory mounts and no excluded files, mount
+                                them directly instead of using a temporary directory
+    -e, --env <ENV>             Pass an environment variable (key=value) to all components of the
+                                application
+    -f, --from <APPLICATION>    The application to run. This may be a manifest (spin.toml) file, a
+                                directory containing a spin.toml file, or a remote registry
+                                reference. If omitted, it defaults to "spin.toml"
+    -h, --help                  
+    -k, --insecure              Ignore server certificate errors from bindle server or registry
+        --temp <TMP>            Temporary directory for the static assets of the components
+
+TRIGGER OPTIONS:
+        --allow-transient-write
+            Set the static assets of the components in the temporary directory as writable
+
+        --cache <WASMTIME_CACHE_FILE>
+            Wasmtime cache configuration file
+            
+            [env: WASMTIME_CACHE_FILE=]
+
+        --disable-cache
+            Disable Wasmtime cache
+            
+            [env: DISABLE_WASMTIME_CACHE=]
+
+        --follow <FOLLOW_ID>
+            Print output to stdout/stderr only for given component(s)
+
+        --key-value <KEY_VALUES>
+            Set a key/value pair (key=value) in the application's default store. Any existing value
+            will be overwritten. Can be used multiple times
+
+    -L, --log-dir <APP_LOG_DIR>
+            Log directory for the stdout and stderr of components
+
+    -q, --quiet
+            Silence all component output to stdout/stderr
+
+        --runtime-config-file <RUNTIME_CONFIG_FILE>
+            Configuration file for config providers and wasmtime config
+            
+            [env: RUNTIME_CONFIG_FILE=]
+
+        --state-dir <STATE_DIR>
+            Set the application state directory path. This is used in the default locations for
+            logs, key value stores, etc.
+            
+            For local apps, this defaults to `.spin/` relative to the `spin.toml` file. For remote
+            apps, this has no default (unset). Passing an empty value forces the value to be unset.
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin up --help
+
+spin-up 
+Start the Spin application
+
+USAGE:
+    spin up [OPTIONS]
+
+OPTIONS:
+        --direct-mounts         For local apps with directory mounts and no excluded files, mount
+                                them directly instead of using a temporary directory
+    -e, --env <ENV>             Pass an environment variable (key=value) to all components of the
+                                application
+    -f, --from <APPLICATION>    The application to run. This may be a manifest (spin.toml) file, a
+                                directory containing a spin.toml file, or a remote registry
+                                reference. If omitted, it defaults to "spin.toml"
+    -h, --help                  
+    -k, --insecure              Ignore server certificate errors from bindle server or registry
+        --temp <TMP>            Temporary directory for the static assets of the components
+
+TRIGGER OPTIONS:
+        --allow-transient-write
+            Set the static assets of the components in the temporary directory as writable
+
+        --cache <WASMTIME_CACHE_FILE>
+            Wasmtime cache configuration file
+            
+            [env: WASMTIME_CACHE_FILE=]
+
+        --disable-cache
+            Disable Wasmtime cache
+            
+            [env: DISABLE_WASMTIME_CACHE=]
+
+        --follow <FOLLOW_ID>
+            Print output to stdout/stderr only for given component(s)
+
+        --key-value <KEY_VALUES>
+            Set a key/value pair (key=value) in the application's default store. Any existing value
+            will be overwritten. Can be used multiple times
+
+    -L, --log-dir <APP_LOG_DIR>
+            Log directory for the stdout and stderr of components
+
+    -q, --quiet
+            Silence all component output to stdout/stderr
+
+        --runtime-config-file <RUNTIME_CONFIG_FILE>
+            Configuration file for config providers and wasmtime config
+            
+            [env: RUNTIME_CONFIG_FILE=]
+
+        --sqlite <SQLITE_STATEMENTS>
+            Run a SQLite statement such as a migration against the default database. To run from a
+            file, prefix the filename with @ e.g. spin up --sqlite @migration.sql
+
+        --state-dir <STATE_DIR>
+            Set the application state directory path. This is used in the default locations for
+            logs, key value stores, etc.
+            
+            For local apps, this defaults to `.spin/` relative to the `spin.toml` file. For remote
+            apps, this has no default (unset). Passing an empty value forces the value to be unset.
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+> From Spin 1.5 onwards, `spin up` will auto-create the working directory (`workdir`) specified in spin.toml if the directory specified in spin.toml does not already exist.
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin up --help
+
+spin-up 
+Start the Spin application
+
+USAGE:
+    spin up [OPTIONS]
+
+OPTIONS:
+        --direct-mounts         For local apps with directory mounts and no excluded files, mount
+                                them directly instead of using a temporary directory
+    -e, --env <ENV>             Pass an environment variable (key=value) to all components of the
+                                application
+    -f, --from <APPLICATION>    The application to run. This may be a manifest (spin.toml) file, a
+                                directory containing a spin.toml file, or a remote registry
+                                reference. If omitted, it defaults to "spin.toml"
+    -h, --help                  
+    -k, --insecure              Ignore server certificate errors from bindle server or registry
+        --temp <TMP>            Temporary directory for the static assets of the components
+
+TRIGGER OPTIONS:
+        --allow-transient-write
+            Set the static assets of the components in the temporary directory as writable
+
+        --cache <WASMTIME_CACHE_FILE>
+            Wasmtime cache configuration file
+            
+            [env: WASMTIME_CACHE_FILE=]
+
+        --disable-cache
+            Disable Wasmtime cache
+            
+            [env: DISABLE_WASMTIME_CACHE=]
+
+        --disable-pooling
+            Enable Wasmtime's pooling instance allocator
+
+        --follow <FOLLOW_ID>
+            Print output to stdout/stderr only for given component(s)
+
+        --key-value <KEY_VALUES>
+            Set a key/value pair (key=value) in the application's default store. Any existing value
+            will be overwritten. Can be used multiple times
+
+    -L, --log-dir <APP_LOG_DIR>
+            Log directory for the stdout and stderr of components
+
+    -q, --quiet
+            Silence all component output to stdout/stderr
+
+        --runtime-config-file <RUNTIME_CONFIG_FILE>
+            Configuration file for config providers and wasmtime config
+            
+            [env: RUNTIME_CONFIG_FILE=]
+
+        --sqlite <SQLITE_STATEMENTS>
+            Run a SQLite statement such as a migration against the default database. To run from a
+            file, prefix the filename with @ e.g. spin up --sqlite @migration.sql
+
+        --state-dir <STATE_DIR>
+            Set the application state directory path. This is used in the default locations for
+            logs, key value stores, etc.
+            
+            For local apps, this defaults to `.spin/` relative to the `spin.toml` file. For remote
+            apps, this has no default (unset). Passing an empty value forces the value to be unset.
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+> **Please note:** If the `-f` or `--from` options do not accurately infer the intended registry or `.toml` file for your application, then you can explicitly specify either the `--from-registry` or  `--from-file` options to clarify this.
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+### spin up (HTTP Trigger)
+
+The following additional trigger options are available for the [spin up](#spin-up) command, when using the HTTP trigger. E.g. `spin up --listen`
+
+{{ tabs "spin-version" }}
+
+{{ startTab "v1.0"}}
+
+<!-- @selectiveCpy -->
+
+```console
+    --listen <ADDRESS>
+        IP address and port to listen on
+
+        [default: 127.0.0.1:3000]
+
+    --tls-cert <TLS_CERT>
+        The path to the certificate to use for https, if this is not set, normal http will be
+        used. The cert should be in PEM format
+
+        [env: SPIN_TLS_CERT=]
+
+    --tls-key <TLS_KEY>
+        The path to the certificate key to use for https, if this is not set, normal http will
+        be used. The key should be in PKCS#8 format
+
+        [env: SPIN_TLS_KEY=]
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+    --listen <ADDRESS>
+        IP address and port to listen on
+
+        [default: 127.0.0.1:3000]
+
+    --tls-cert <TLS_CERT>
+        The path to the certificate to use for https, if this is not set, normal http will be
+        used. The cert should be in PEM format
+
+        [env: SPIN_TLS_CERT=]
+
+    --tls-key <TLS_KEY>
+        The path to the certificate key to use for https, if this is not set, normal http will
+        be used. The key should be in PKCS#8 format
+
+        [env: SPIN_TLS_KEY=]
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.2"}}
+
+<!-- @selectiveCpy -->
+
+```console
+    --listen <ADDRESS>
+        IP address and port to listen on
+
+        [default: 127.0.0.1:3000]
+
+    --tls-cert <TLS_CERT>
+        The path to the certificate to use for https, if this is not set, normal http will be
+        used. The cert should be in PEM format
+
+        [env: SPIN_TLS_CERT=]
+
+    --tls-key <TLS_KEY>
+        The path to the certificate key to use for https, if this is not set, normal http will
+        be used. The key should be in PKCS#8 format
+
+        [env: SPIN_TLS_KEY=]
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3"}}
+
+<!-- @selectiveCpy -->
+
+```console
+    --listen <ADDRESS>
+        IP address and port to listen on
+
+        [default: 127.0.0.1:3000]
+
+    --tls-cert <TLS_CERT>
+        The path to the certificate to use for https, if this is not set, normal http will be
+        used. The cert should be in PEM format
+
+        [env: SPIN_TLS_CERT=]
+
+    --tls-key <TLS_KEY>
+        The path to the certificate key to use for https, if this is not set, normal http will
+        be used. The key should be in PKCS#8 format
+
+        [env: SPIN_TLS_KEY=]
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+    --listen <ADDRESS>
+        IP address and port to listen on
+
+        [default: 127.0.0.1:3000]
+
+    --tls-cert <TLS_CERT>
+        The path to the certificate to use for https, if this is not set, normal http will be
+        used. The cert should be in PEM format
+
+        [env: SPIN_TLS_CERT=]
+
+    --tls-key <TLS_KEY>
+        The path to the certificate key to use for https, if this is not set, normal http will
+        be used. The key should be in PKCS#8 format
+
+        [env: SPIN_TLS_KEY=]
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+    --listen <ADDRESS>
+        IP address and port to listen on
+
+        [default: 127.0.0.1:3000]
+
+    --tls-cert <TLS_CERT>
+        The path to the certificate to use for https, if this is not set, normal http will be
+        used. The cert should be in PEM format
+
+        [env: SPIN_TLS_CERT=]
+
+    --tls-key <TLS_KEY>
+        The path to the certificate key to use for https, if this is not set, normal http will
+        be used. The key should be in PKCS#8 format
+
+        [env: SPIN_TLS_KEY=]
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin watch
+
+{{ tabs "spin-version" }}
+
+{{ startTab "v1.1"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin watch --help
+
+spin-watch
+Build and run the Spin application, rebuilding and restarting it when files change
+
+USAGE:
+    spin watch [OPTIONS] [UP_ARGS]...
+
+ARGS:
+    <UP_ARGS>...    Arguments to be passed through to spin up
+
+OPTIONS:
+    -c, --clear                       Clear the screen before each run
+    -d, --debounce <DEBOUNCE>         Set the timeout between detected change and re-execution, in
+                                      milliseconds [default: 100]
+    -f, --file <APP_MANIFEST_FILE>    Path to spin.toml [default: spin.toml]
+    -h, --help                        Print help information
+        --skip-build                  Only run the Spin application, restarting it when build
+                                      artifacts change
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.2"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin watch --help
+
+spin-watch 
+Build and run the Spin application, rebuilding and restarting it when files change
+
+USAGE:
+    spin watch [OPTIONS] [UP_ARGS]...
+
+ARGS:
+    <UP_ARGS>...    Arguments to be passed through to spin up
+
+OPTIONS:
+    -c, --clear                       Clear the screen before each run
+    -d, --debounce <DEBOUNCE>         Set the timeout between detected change and re-execution, in
+                                      milliseconds [default: 100]
+    -f, --from <APP_MANIFEST_FILE>    The application to watch. This may be a manifest (spin.toml)
+                                      file, or a directory containing a spin.toml file. If omitted,
+                                      it defaults to "spin.toml" [default: spin.toml]
+    -h, --help                        Print help information
+        --skip-build                  Only run the Spin application, restarting it when build
+                                      artifacts change
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.3"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin watch --help
+
+spin-watch 
+Build and run the Spin application, rebuilding and restarting it when files change
+
+USAGE:
+    spin watch [OPTIONS] [UP_ARGS]...
+
+ARGS:
+    <UP_ARGS>...    Arguments to be passed through to spin up
+
+OPTIONS:
+    -c, --clear                       Clear the screen before each run
+    -d, --debounce <DEBOUNCE>         Set the timeout between detected change and re-execution, in
+                                      milliseconds [default: 100]
+    -f, --from <APP_MANIFEST_FILE>    The application to watch. This may be a manifest (spin.toml)
+                                      file, or a directory containing a spin.toml file. If omitted,
+                                      it defaults to "spin.toml" [default: spin.toml]
+    -h, --help                        Print help information
+        --skip-build                  Only run the Spin application, restarting it when build
+                                      artifacts change
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin watch --help
+
+spin-watch 
+Build and run the Spin application, rebuilding and restarting it when files change
+
+USAGE:
+    spin watch [OPTIONS] [UP_ARGS]...
+
+ARGS:
+    <UP_ARGS>...    Arguments to be passed through to spin up
+
+OPTIONS:
+    -c, --clear                       Clear the screen before each run
+    -d, --debounce <DEBOUNCE>         Set the timeout between detected change and re-execution, in
+                                      milliseconds [default: 100]
+    -f, --from <APP_MANIFEST_FILE>    The application to watch. This may be a manifest (spin.toml)
+                                      file, or a directory containing a spin.toml file. If omitted,
+                                      it defaults to "spin.toml" [default: spin.toml]
+    -h, --help                        Print help information
+        --skip-build                  Only run the Spin application, restarting it when build
+                                      artifacts change
+```
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin watch --help
+
+spin-watch 
+Build and run the Spin application, rebuilding and restarting it when files change
+
+USAGE:
+    spin watch [OPTIONS] [UP_ARGS]...
+
+ARGS:
+    <UP_ARGS>...    Arguments to be passed through to spin up
+
+OPTIONS:
+    -c, --clear                       Clear the screen before each run
+    -d, --debounce <DEBOUNCE>         Set the timeout between detected change and re-execution, in
+                                      milliseconds [default: 100]
+    -f, --from <APP_MANIFEST_FILE>    The application to watch. This may be a manifest (spin.toml)
+                                      file, or a directory containing a spin.toml file. If omitted,
+                                      it defaults to "spin.toml" [default: spin.toml]
+    -h, --help                        Print help information
+        --skip-build                  Only run the Spin application, restarting it when build
+                                      artifacts change
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+## Stability Table
+
+CLI commands have four phases that indicate levels of stability:
+
+- `Experimental`: These commands are experiments and may or may not be available in later versions of the CLI.
+- `Stabilizing`: These commands have moved out of the `experimental` phase and we are now in the active process of stabilizing them. This includes updating flags, command output, errors, and more.
+- `Stable`: These commands have moved out of the `stablizing` phase and will not change in backwards incompatible ways until the next major version release.
+- `Deprecated`: Support for these commands will be removed in a future release.
+
+{{ tabs "spin-version" }}
+
+{{ startTab "v1.0"}}
+
+| Command                                                    | Stability   |
+| ---------------------------------------------------------- | ----------- |
+| <code>spin add</code>                                      | Stable      |
+| <code>spin build</code>                                    | Stable      |
+| <code>spin new</code>                                      | Stable      |
+| <code>spin plugins</code>                                  | Stable      |
+| <code>spin templates </code>                               | Stable      |
+| <code>spin up</code>                                       | Stable      |
+| <code>spin cloud </code>                                   | Stabilizing |
+| <code>spin registry</code>                                 | Stabilizing |
+| <code>spin bindle</code>                                   | Deprecated  |
+
+{{ blockEnd }}
+
+{{ startTab "v1.1"}}
+
+| Command                                                                               | Stability    |
+| ------------------------------------------------------------------------------------- | ------------ |
+| <code>spin add</code>                                                                 | Stable       |
+| <code>spin build</code>                                                               | Stable       |
+| <code>spin new</code>                                                                 | Stable       |
+| <code>spin plugins</code>                                                             | Stable       |
+| <code>spin templates</code>                                                           | Stable       |
+| <code>spin up</code>                                                                  | Stable       |
+| <code>spin cloud</code>                                                               | Stabilizing  |
+| <code>spin registry</code>                                                            | Stabilizing  |
+| <code>spin watch</code>                                                               | Experimental |
+| <code>spin bindle</code>                                                              | Deprecated   |
+
+{{ blockEnd }}
+
+{{ startTab "v1.2"}}
+
+| Command                                                                               | Stability    |
+| ------------------------------------------------------------------------------------- | ------------ |
+| <code>spin add</code>                                                                 | Stable       |
+| <code>spin build</code>                                                               | Stable       |
+| <code>spin new</code>                                                                 | Stable       |
+| <code>spin plugins</code>                                                             | Stable       |
+| <code>spin templates</code>                                                           | Stable       |
+| <code>spin up</code>                                                                  | Stable       |
+| <code>spin cloud</code>                                                               | Stabilizing  |
+| <code>spin registry</code>                                                            | Stabilizing  |
+| <code>spin watch</code>                                                               | Experimental |
+| <code>spin bindle</code>                                                              | Deprecated   |
+
+{{ blockEnd }}
+
+{{ startTab "v1.3"}}
+
+| Command                                                                               | Stability    |
+| ------------------------------------------------------------------------------------- | ------------ |
+| <code>spin add</code>                                                                 | Stable       |
+| <code>spin build</code>                                                               | Stable       |
+| <code>spin new</code>                                                                 | Stable       |
+| <code>spin plugins</code>                                                             | Stable       |
+| <code>spin templates</code>                                                           | Stable       |
+| <code>spin up</code>                                                                  | Stable       |
+| <code>spin cloud</code>                                                               | Stabilizing  |
+| <code>spin registry</code>                                                            | Stabilizing  |
+| <code>spin watch</code>                                                               | Experimental |
+| <code>spin bindle</code>                                                              | Deprecated   |
+
+{{ blockEnd }}
+
+{{ startTab "v1.4"}}
+
+| Command                                                                               | Stability    |
+| ------------------------------------------------------------------------------------- | ------------ |
+| <code>spin add</code>                                                                 | Stable       |
+| <code>spin build</code>                                                               | Stable       |
+| <code>spin new</code>                                                                 | Stable       |
+| <code>spin plugins</code>                                                             | Stable       |
+| <code>spin templates</code>                                                           | Stable       |
+| <code>spin up</code>                                                                  | Stable       |
+| <code>spin cloud</code>                                                               | Stabilizing  |
+| <code>spin registry</code>                                                            | Stabilizing  |
+| <code>spin doctor</code>                                                              | Experimental |
+| <code>spin watch</code>                                                               | Experimental |
+| <code>spin bindle</code>                                                              | Deprecated   |
+
+{{ blockEnd }}
+
+{{ startTab "v1.5"}}
+
+| Command                                                                               | Stability    |
+| ------------------------------------------------------------------------------------- | ------------ |
+| <code>spin add</code>                                                                 | Stable       |
+| <code>spin build</code>                                                               | Stable       |
+| <code>spin new</code>                                                                 | Stable       |
+| <code>spin plugins</code>                                                             | Stable       |
+| <code>spin templates</code>                                                           | Stable       |
+| <code>spin up</code>                                                                  | Stable       |
+| <code>spin cloud</code>                                                               | Stabilizing  |
+| <code>spin registry</code>                                                            | Stabilizing  |
+| <code>spin doctor</code>                                                              | Experimental |
+| <code>spin watch</code>                                                               | Experimental |
+| <code>spin bindle</code>                                                              | Deprecated   |
+
+{{ blockEnd }}
+
+{{ blockEnd }}

--- a/content/spin/v2/contributing-docs.md
+++ b/content/spin/v2/contributing-docs.md
@@ -1,0 +1,544 @@
+title = "Contributing to Docs"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/contributing-docs.md"
+keywords = "contribute contributing"
+
+---
+
+- [Technical Documentation Types](#technical-documentation-types)
+  - [1. Tutorials](#1-tutorials)
+  - [2. How-To Guides](#2-how-to-guides)
+  - [3. Reference](#3-reference)
+  - [4. Explanation](#4-explanation)
+- [Documents Relevant to Two or More Projects](#documents-relevant-to-two-or-more-projects)
+- [Technical Documentation Procedure (Video)](#technical-documentation-procedure-video)
+- [Technical Documentation Procedure (Text)](#technical-documentation-procedure-text)
+  - [1. Fork the Repository](#1-fork-the-repository)
+  - [2. Clone the Fork](#2-clone-the-fork)
+  - [3. Create New Branch](#3-create-new-branch)
+  - [4. Add Upstream](#4-add-upstream)
+  - [5. Code Blocks, Annotations and Table of Contents (ToC)](#5-code-blocks-annotations-and-table-of-contents-toc)
+  - [6.1 Checking Your Content - Using NPM](#61-checking-your-content---using-npm)
+  - [6.2 Indexing Your Content](#62-indexing-your-content)
+  - [6.3 Increasing Search Visibility For Your Content](#63-increasing-search-visibility-for-your-content)
+  - [6.4 The Edit On GitHub Button](#64-the-edit-on-github-button)
+  - [6.5 How To Properly Edit CSS Styles](#65-how-to-properly-edit-css-styles)
+  - [6.6 Checking Your Content - Using Bartholomew's CLI](#66-checking-your-content---using-bartholomews-cli)
+  - [6.7 Checking Your Content - Preview a Documentation Page on Localhost](#67-checking-your-content---preview-a-documentation-page-on-localhost)
+  - [7. Checking Web Pages](#7-checking-web-pages)
+  - [8. Add Changes](#8-add-changes)
+  - [9. Commit Changes](#9-commit-changes)
+  - [10. Push Changes](#10-push-changes)
+  - [11. Create a Pull Request](#11-create-a-pull-request)
+
+We are delighted that you are interested in making our developer documentation better. Thank you! We welcome and appreciate contributions of all types — opening issues, fixing typos, adding examples, one-liner code fixes, tests, or complete features.
+
+Any contribution and interaction on any Fermyon project MUST follow our [code of conduct](https://www.fermyon.com/code-of-conduct). Thank you for being part of an inclusive and open community!
+
+Below are a few pointers designed to help you contribute.
+
+## Technical Documentation Types
+
+The following points will help guide your contribution from a resource-type perspective; essentially we would really appreciate you creating and contributing any of the following 4 resource types. 
+
+### 1. Tutorials
+
+Tutorials are oriented toward learning. Tutorials are designed to get a user started on something new (that they have not tried before). You can think of a tutorial as a lesson i.e. teaching a Spin user [how to use Redis to persist data](../cloud/data-redis). The tutorial may contain many logically ordered steps i.e. installing Spin, installing Redis, using Spin templates, configuring a Spin application and so forth. The desired outcome for a tutorial is for the user to have a working deployment or application. Think of it as a lesson in how to bake a cake.
+
+### 2. How-To Guides
+
+How-to guides are oriented towards showing a user how to solve a problem, which leads them to be able to achieve their own goal. The how-to guide will follow a series of logical steps. Think of it as providing a recipe for the user's creativity. For example, you can show a user how to [develop a Spin application](../cloud/develop) without telling them what the application must do; that is up to the user's imagination.
+
+### 3. Reference
+
+Reference resources are merely a dry description; describing the feature in its simplest form. A great example of a reference resource is the [Spin CLI Reference page](/spin/cli-reference). You will notice that the CLI Reference page simply lists all of the commands and available options.
+
+### 4. Explanation
+
+An explanation resource is written using a deep-dive approach i.e. providing a deep explanation with the view to impart a deep understanding of a particular concept, feature or product. You may find your contribution is so in-depth that it becomes a long form article like a blog post. If that is the case, please get in touch and we can discuss options around getting your content published on another platform; like the [Fermyon Blog](https://www.fermyon.com/blog/index).
+
+**Tying It All Together**
+
+You will notice that the menu system is organized in terms of "Tutorial", "How-To", "Reference" and so forth. When you write your contribution please decide which product (Cloud, Spin, Bartholomew) category it falls into and also which resource type it aligns with. Armed with that information you can go ahead and create your new file. For example, your "how-to" resource on "developing a Spin application" in Fermyon cloud would be saved to the `content/cloud/` folder; specifically, `content/cloud/develop.md` and the menu item (for the left-hand-side menu) would be added to the `templates/cloud_sidebar.hbs` file, as shown below.
+
+![cloud develop example](../static/image/docs/cloud-develop-example.png)
+
+The resulting output would be as follows.
+
+![cloud develop example](../static/image/docs/cloud-develop-example-2.png)
+
+## Documents Relevant to Two or More Projects
+
+If a document is relevant to two or more projects, the dynamic body feature of bartholomew is to be used. Create the document in one of the projects with the content. In the other project(s) create a file with only the frontmatter. Then add the following field to the frontmatter:
+
+<!-- @nocpy -->
+
+```toml
+.
+.
+body_source = "<path to the content>"
+
+[extra]
+
+```
+
+The value for the `body_source` key, should be the path from which the content is being shared (relative to the repository's `content` folder). For example if the Spin project's `developer/content/spin/contributing-docs.md` holds the sharable content (as the single source of truth), then the Cloud project can display that same content by using the following frontmatter:
+
+<!-- @nocpy -->
+
+```toml
+title = "Contributing to Docs"
+template = "cloud_main"
+date = "2023-11-02T16:00:00Z"
+body_source = "/spin/contributing-docs"
+
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/cloud/contributing-docs.md"
+keywords = "contribute contributing"
+
+---
+```
+
+> Note: the `body_source = "/spin/contributing-docs"` part of the frontmatter does not need to include the `.md` file extention (as is also the case when hyperlinking via markdown anywhere in a developer documentation file's body).
+
+## Technical Documentation Procedure (Video)
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/Edku4hQj9Mo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
+## Technical Documentation Procedure (Text)
+
+### 1. Fork the Repository
+
+The first step is to fork the [developer repository](https://github.com/fermyon/developer), from Fermyon's GitHub, to your own GitHub account.
+
+![Fork the repository](/static/image/fork_developer_repo.png)
+
+Ensure that you are forking the developer repository **to your own** GitHub account; where you have full editing privileges.
+
+### 2. Clone the Fork
+
+Copy the URL from the UI in readiness for running the `git clone` command.
+
+![Fork the repository](/static/image/clone_developer_repo.png)
+
+Go ahead and clone the new fork that you just created (the one which resides in your own GitHub account):
+
+<!-- @selectiveCpy -->
+
+```bash
+$ cd ~
+$ git clone git@github.com:yourusername/developer.git
+$ cd developer
+```
+
+### 3. Create New Branch
+
+Create a new branch that will house all of your changes for this specific contribution:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ git checkout -b my_new_branch
+```
+
+### 4. Add Upstream
+
+Create a new remote for the upstream (a pointer to the original repository to which you are contributing):
+
+<!-- @selectiveCpy -->
+
+```bash
+$ git remote add upstream https://github.com/fermyon/developer
+```
+
+### 5. Code Blocks, Annotations and Table of Contents (ToC)
+
+It is highly recommended that you use either the `<!-- @selectiveCpy -->` or the `<!-- @nocpy -->` annotation before each of your code blocks, and that each code block defines the appropriate [syntax highlighting](https://rdmd.readme.io/docs/code-blocks#language-support). The annotation can be skipped for code blocks with example code snippets i.e. non-terminal or generic output examples.
+
+**Selective copy**
+
+The selective copy annotation (`<!-- @selectiveCpy -->`) is intended for use when communicating code and/or CLI commands for the reader to copy and paste. The selective copy annotation allows the reader to see the entire code block (both commands and results) but only copies the lines that start with `$` into the reader's clipboard (minus the `$`) when the user clicks the copy button. For example, copying the following code block will only copy `echo "hello"` into your clipboard, for pasting.
+
+<!-- @selectiveCpy -->
+
+```bash
+$ echo "hello"
+hello
+```
+
+> Note: If the command, that starts with `$`, is deliberately spread over two lines (by escaping the newline character), then the copy mechanism will still copy the second line which is technically still part of that single command.
+
+**No copy**
+
+The no copy annotation (`<!-- @nocpy -->`) precedes a code block where no copy and pasting of code is intended. If using the no copy attribute please still be sure to add the appropriate syntax highlighting to your code block (for display purposes). For example:
+
+`<!-- @nocpy -->`
+
+```bash
+Some generic code not intended for copying/pasting
+```
+
+**Non-selective copy** - just a straight copy without any additional features.
+
+If you want the code in a code block to be copyable with no "smarts" to remove the `$` then you can just simply leave out the annotation altogether. A code block in markdown will be copyable without smarts just as is.
+
+**Multi-tab code blocks**
+
+Multi-tab code blocks [have recently been implemented](https://github.com/fermyon/developer/pull/239). Examples can be seen in the [Spin](/spin/install#installing-spin) installer documentation](/spin/install#installing-spin) and [Spin Key/Value documentation](/spin/kv-store-tutorial#the-spin-toml-file). The above examples demonstrate how tabs can either represent platforms i.e. `Windows`, `Linux` and `macOS` or represent specific programming languages i.e. `Rust`, `JavaScript` and `Golang` etc. Here is a brief example of how to implement multi-tab code blocks when writing technical documentation for this site, using markdown.
+
+The first step to implementing multi-tab code blocks is placing the `enable_shortcodes = true` configuration at the start of the `.md` file. Specifically, in the `.md` file's frontmatter.
+
+The markup to create tabs in markdown is as follows 
+
+```
+{{ tabs "os" }}
+
+{{ startTab "Windows"}}
+
+To list files on windows use `dir`
+
+<!-- @selectiveCpy -->
+
+\`\`\`bash
+$ dir hello_fermyon
+\`\`\`
+and script in windows have the extension `.bat`
+
+<!-- @nocpy -->
+
+\`\`\`bash
+hello.bat
+test.bat
+\`\`\`
+
+{{ blockEnd }}
+
+{{ startTab "Linux"}}
+
+To list files on linux use `ls`
+
+<!-- @selectiveCpy -->
+
+\`\`\`bash
+$ ls
+\`\`\`
+
+and script in linux have the extension `.sh`
+
+<!-- @nocpy -->
+
+\`\`\`bash
+hello.sh
+test.sh
+\`\`\`
+
+{{ blockEnd }}
+{{ blockEnd }}
+```
+
+**Note**: Existing documentation will already be using class names for code block `tabs` and `startTab` i.e. `{{ tabs "os" }}` and `{{ startTab "Windows"}}` respectively. Please consult the following `tabs` and `startTab` class names that are already in use (before creating your own). If you need to create a new class name (because one does not already exist) please add it to the list below as part of the pull request that contains your code block contribution.
+
+**tabs**:
+- `gh-interact`
+- `os`
+- `platforms`
+- `sdk-type`
+- `spin-version`
+- `cloud-plugin-version`
+
+**startTab**
+- `Azure AKS`
+- `C#`
+- `Docker Desktop`
+- `Generic Kubernetes`
+- `GitHub CLI`
+- `GitHub UI`
+- `K3d`
+- `Linux`
+- `macOS`
+- `Python`
+- `Rust`
+- `TinyGo`
+- `TypeScript`
+- `v0.9.0`
+- `v0.10.0`
+- `v1.0.0`
+- `v1.1.0`
+- `v1.2.0`
+- `v0.1.0`
+- `v0.1.1`
+- `Windows`
+
+The next section covers the highly recommended use of ToCs.
+
+**Implementing a Table of Contents (ToC)**
+
+If you create content with many headings it is highly recommended to place a ToC in your markdown file. There are excellent extensions (such as this Visual Studio Code Extension called [markdown-all-in-one](https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one) which will automatically generate your ToC).
+
+### 6.1 Checking Your Content - Using NPM
+
+Once you are satisfied with your contribution, you can programmatically check your content.
+
+If you have not done so already, please go ahead and perform the `npm install` command; to enable Node dependencies such as `markdownlint-cli2`. Simply run the following command, from the root of the developer repository:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ npm install
+```
+
+With all Node dependencies installed, you can now check for broken links (which takes several minutes) and also lint your markdown files. Simply run the following command, from the root of the developer repository:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ npm run test
+```
+
+**Hint:** Optionally you can run only the linter with the following command:
+
+<!-- @nocpy -->
+
+```bash
+# Example of how to lint all Markdown files in a local folder (in this case the spin folder) 
+npx markdownlint-cli2 content/spin/*.md \"#node_modules\"
+# Example of how to lint a local Markdown file
+npx markdownlint-cli2 content/spin/install.md \"#node_modules\"
+```
+
+**Note:** Whilst the `npm run test` command (which lints and also programmatically checks all URLs) does take extra time to complete it **must** be utilized before you [push changes](#10-push-changes); preventing the potential pushing of broken URLs to the developer documentation site.
+
+### 6.2 Indexing Your Content
+
+The developer documentation site implements in-house search. A new index is automatically generated for you when your contribution is merged into the developer documentation repository. This is done via a GitHub action. The following section explains how to alter content to increase search visibility for your content.
+
+### 6.3 Increasing Search Visibility For Your Content
+
+The built-in search functionality is based on the indexing of individual words in each markdown file, which works well most of the time. However, there are a couple of scenarios where you _may_ want to deliberately increase search visibility for your content.
+
+**Word Mismatch**
+
+Words in a documentation markdown file may not be words that are searched for by a user. For example, you may write about "different HTTP listening options" whereas a user may only ever try to find that specific content using a search phrase like "alternate port". If you are aware of typical user search phrases it is always recommended to craft your content to include any predictable user search phrases. However, in the rare case of a mismatch between words in your content and the words a user searches for, you can utilize use the `keywords` string in the `[extra]` section of your document's frontmatter to increase visibility. For example, the following code block shows frontmatter that helps a user find your documentation page (when the user searches for `port`):
+
+```markdown
+[extra]
+keywords = "port ports"
+```
+
+Adding a word to the `keywords` string of a page overrides the built-in search functionality by at least one order of magnitude. Adding a word to the `keywords` string may displace other content, so please use it only if necessary.
+
+**Homing in on specific content**
+
+The `keywords` string takes users to the start of a page. In some cases, this is not ideal. You may want to home in on specific content to resolve a search query.
+
+If a search term relates to a specific part of a page, you may use the following syntax anywhere in the body of your markdown file, and the user's search action will direct them straight to the previous heading (nearest heading above the `@searchTerm` syntax).
+
+```markdown
+<!-- @searchTerm "homing" -->
+```
+
+<!-- @searchTerm "homing" -->
+
+When using the above `@searchTerm` feature, please note the following:
+- the words must be separated by a space i.e. <!-- @searchTerm "port listen request" -->
+- these keywords will be boosted in the search results by at least one order of magnitude; so please use them with caution, so as not to displace other valid pages containing similar content.
+
+Example: If you search for the word "homing", the results will point you to the previous heading in this specific section of the developer documentation.
+
+![homing example](/static/image/homing.png)
+
+### 6.4 The Edit On GitHub Button
+
+Each markdown file in the developer documentation requires a link to its GitHub page for the site to correctly render the "Edit on GitHub" button for that page.
+
+![edit on github](/static/image/edit-on-github.png)
+
+If you create a new markdown file and/or you notice a file without the explicit GitHub URL, please add a URL entry to the [extra] section. For example, the following `url` is required for this page that you are reading (you can check the raw markdown contents of this page to see this example):
+
+```
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/contributing-docs.md"
+```
+
+### 6.5 How To Properly Edit CSS Styles
+
+> The following section (the running of the `npm run styles` command) is not necessary unless you are editing styles i.e. updating `.scss` files, in order to generate new `.css` files, as part of your contribution.
+
+Directly editing `.css` files is not recommended, because `.css` files are overwritten. Instead, if you would like to make and test a new/different style please go ahead and update the appropriate `.scss` file. The following command will automatically update the `.css` file that is relevant to the `.scss` file that you are editing:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ npm run styles
+```
+
+The above command is designed to be run in the background; enabling you to view your design changes (that are reflected in the `.css`) while you are editing the `.scss` in real-time. If you are not running this command in the background (i.e. just deliberately regenerating the `.css` files once), then the above command can be stopped by pressing `Ctrl` + `C`.
+
+### 6.6 Checking Your Content - Using Bartholomew's CLI
+
+The Bartholomew Command Line Interface (CLI) Tool is called `bart`. The `bart` CLI is a tool that simplifies working with Bartholomew projects (by now you probably already know that [Bartholomew](https://www.fermyon.com/blog/introducing-bartholomew) is our in-house WebAssembly (Wasm) content management system (CMS) that powers [our official Website](https://www.fermyon.com/)). And this (our official documentation) site. The `bart` CLI is handy to ensure quality assurance of new and existing content. Installing the CLI is a cinch, so please go ahead and use it when contributing.
+
+To build the Bartholomew CLI from source perform the following commands:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ cd ~
+$ git clone https://github.com/fermyon/bartholomew.git
+$ cd ~/bartholomew
+$ make bart
+```
+
+Once built, you will find the `bart` CLI executable in the `~/bartholomew/target/release` directory. However, for convenience it would be a great idea to go ahead and add the `bart` executable to your system path, for example:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ sudo mv ~/bartholomew/target/release/bart /usr/local/bin/
+```
+
+Once installed, you can use the CLI's `--help` flag to learn more. For example:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ bart --help
+bart 0.6.0
+The Bartholomew CLI
+
+USAGE:
+    bart <SUBCOMMAND>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+SUBCOMMANDS:
+    calendar    Print the content calendar for a Bartholomew website
+    check       Check content and identify errors or warnings
+    help        Prints this message or the help of the given subcommand(s)
+    new         Create a new page or website from a template
+```
+
+Let's take a quick look at how you can use the `bart` CLI to check any content that you are wanting to contribute.
+
+### 6.7 Checking Your Content - Preview a Documentation Page on Localhost
+
+You can host your changes to the developer documentation on your own machine (localhost) by using the following `spin` commands: 
+
+<!-- @selectiveCpy -->
+
+```bash
+$ npm install
+$ cd spin-up-hub
+$ npm install
+$ cd ..
+$ spin build
+$ spin up -e "PREVIEW_MODE=1"
+```
+
+> Please note: using the `PREVIEW_MODE=1` as part of a `spin` command is safe on localhost and allows you to view content (even if the `date` setting in the content's `.md` is set to a future date). It is often the case that you will be checking content before the publishing date via your system. The developer documentation's manifest file `spin.toml` has the `PREVIEW_MODE` set to `0` i.e. `environment = { PREVIEW_MODE = "0" }`. This `spin.toml` file is correct for a production environment and should always be `0` (so that the CMS adheres to the publishing `date` setting for content on the public site). Simply put, you can use `PREVIEW_MODE=1` safely in your command line on your locahost but you should never update the `spin.toml` file (in this regard).
+
+### 7. Checking Web Pages
+
+The `bart check` command can be used to check the content. Simply pass in the content as a parameter. The developer documentation [uses shortcodes](/bartholomew/shortcodes), so always pass `--shortcodes ./shortcodes` as shown below:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ bart check --shortcodes ./shortcodes content/spin/variables.md
+shortcodes: registering alert
+shortcodes: registering details
+shortcodes: registering tabs
+shortcodes: registering startTab
+shortcodes: registering blockEnd
+✅ content/spin/variables.md
+```
+
+> Note: `using a wildcard `*` will check a whole directory via a single command. For example, running `bart check --shortcodes ./shortcodes content/spin/*` will check all markdown files in the Spin project's documentation section.
+
+### 8. Add Changes
+
+Once your changes have been checked, go ahead and add your changes by moving to a top-level directory, under which your changes exist i.e. `cd ~/developer`.
+
+Add your changes by running the following command, from the root of the developer repository:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ git add
+```
+
+### 9. Commit Changes
+
+Before committing, please ensure that your GitHub installation is configured sufficiently so that you can `--signoff` as part of the `git commit` command. For example, please ensure that the `user.name` and `user.email` are configured in your terminal. You can check if these are set by typing `git config --list`.
+
+If you need to set these values please use the following commands:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ git config user.name "yourusername"
+```
+<!-- @selectiveCpy -->
+
+```bash
+$ git config user.email "youremail@somemail.com"
+```
+
+More information can be found at this GitHub documentation page called [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
+
+Type the following commit command to ensure that you sign off (--signoff), sign the data (-S) - recommended, and also leave a short message (-m):
+
+<!-- @selectiveCpy -->
+
+```bash
+$ git commit -S --signoff -m "Updating documentation"
+```
+
+> Note: the `--signoff` option will only add a Signed-off-by trailer by the committer at the end of the commit log message. In addition to this, it is recommended that you use the `-S` option which will GPG-sign your commits. For more information about using GPG in GitHub see [this GitHub documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/adding-a-gpg-key-to-your-github-account).
+
+### 10. Push Changes
+
+At this stage, it is a good idea to just quickly check what GitHub thinks the origin is. For example, if we type `git remote -v` we can see that the origin is our repo; which we a) forked the original repo into and b) which we then cloned to our local disk so that we could edit:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ git remote -v
+```
+
+The above command will return output similar to the following:
+
+```bash
+origin	git@github.com:yourusername/developer.git (fetch)
+origin	git@github.com:yourusername/developer.git (push)
+upstream	https://github.com/fermyon/developer (fetch)
+upstream	https://github.com/fermyon/developer (push)
+```
+
+Once you are satisfied go ahead and push your changes:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ git push -u origin my_new_branch
+```
+
+### 11. Create a Pull Request
+
+If you return to your GitHub repository in your browser, you will notice that a PR has automatically been generated for you.
+
+Clicking on the green “Compare and pull request” button will allow you to add a title and description as part of the PR. 
+
+![Compare and pull request](/static/image/compare_and_pull_request.png)
+
+You can also add any information in the textbox provided below the title. For example, screen captures and/or code/console/terminal snippets of your contribution working correctly and/or tests passing etc.
+
+Once you have finished creating your PR, please keep an eye on the PR; answering any questions as part of the collaboration process.
+
+**Thank You**
+
+Thanks for contributing.

--- a/content/spin/v2/contributing-spin.md
+++ b/content/spin/v2/contributing-spin.md
@@ -1,0 +1,114 @@
+title = "Contributing to Spin"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/contributing-spin.md"
+
+---
+- [Making Code Contributions to Spin](#making-code-contributions-to-spin)
+- [Before You Commit](#before-you-commit)
+- [Committing and Pushing Your Changes](#committing-and-pushing-your-changes)
+
+We are delighted that you are interested in making Spin better! Thank you! This
+document will guide you through making your first contribution to the project.
+We welcome and appreciate contributions of all types — opening issues, fixing
+typos, adding examples, one-liner code fixes, tests, or complete features.
+
+First, any contribution and interaction on any Fermyon project MUST follow our
+[code of conduct](https://www.fermyon.com/code-of-conduct). Thank you for being
+part of an inclusive and open community!
+
+If you plan on contributing anything complex, please go through the issue and PR
+queues first to make sure someone else has not started working on it. If it
+doesn't exist already, please open an issue so you have a chance to get feedback
+from the community and the maintainers before you start working on your feature.
+
+## Making Code Contributions to Spin
+
+The following guide is intended to make sure your contribution can get merged as
+soon as possible. First, make sure you have the following prerequisites
+configured:
+
+- [Rust](https://www.rust-lang.org/) at
+  [1.68+](https://www.rust-lang.org/tools/install) with the `wasm32-wasi` and
+  `wasm32-unknown-unknown` targets configured
+  (`rustup target add wasm32-wasi && rustup target add wasm32-unknown-unknown`)
+- [`rustfmt`](https://github.com/rust-lang/rustfmt) and
+  [`clippy`](https://github.com/rust-lang/rust-clippy) configured for your Rust
+  installation
+- `make`
+- if you are a VS Code user, we recommend the [`rust-analyzer`](https://rust-analyzer.github.io/) extension.
+- please ensure you
+  [configure adding a GPG signature to your commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)
+  as well as appending a sign-off message (`git commit -S -s`)
+
+Once you have set up the prerequisites and identified the contribution you want
+to make to Spin, make sure you can correctly build the project:
+
+<!-- @selectiveCpy -->
+
+```bash
+# clone the repository
+$ git clone https://github.com/fermyon/spin && cd spin
+# add a new remote pointing to your fork of the project
+$ git remote add fork https://github.com/<your-username>/spin
+# create a new branch for your work
+$ git checkout -b <your-branch>
+
+# build the Spin CLI
+$ cargo build
+
+# make sure compilation is successful
+$ ./target/debug/spin --help
+
+# run the tests and make sure they pass
+$ make test
+```
+
+Now you should be ready to start making your contribution. To familiarize
+yourself with the Spin project, please read the
+[document about extending Spin](./extending-and-embedding.md). Since most of Spin is implemented in
+Rust, we try to follow the common Rust coding conventions (keep an eye on the
+recommendations from Clippy!). If applicable, add unit or integration tests to
+ensure your contribution is correct.
+
+## Before You Commit
+
+* Format the code (`cargo fmt`)
+* Run Clippy (`cargo clippy`)
+* Run the `lint` task (`make lint`)
+* Build the project and run the tests (`make test`)
+
+Spin enforces lints and tests as part of continuous integration - running them locally will save you a round-trip to your pull request!
+
+If everything works locally, you're ready to commit your changes.
+
+## Committing and Pushing Your Changes
+
+We require commits to be signed both with an email address and with a GPG signature.
+
+> Because of the way GitHub runs enforcement, the GPG signature isn't checked until _after_ all tests have run.  Be sure to GPG sign up front, as it can be a bit frustrating to wait for all the tests and _then_ get blocked on the signature!
+
+<!-- @selectiveCpy -->
+
+```bash
+$ git commit -S -s -m "<your commit message>"
+```
+
+> Some contributors like to follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) convention for commit messages.
+
+We try to only keep useful changes as separate commits — if you prefer to commit
+often, please
+[cleanup the commit history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)
+before opening a pull request.
+
+Once you are happy with your changes you can push the branch to your fork:
+
+<!-- @selectiveCpy -->
+
+```bash
+# "fork" is the name of the git remote pointing to your fork
+$ git push fork
+```
+
+Now you are ready to create a pull request. Thank you for your contribution!

--- a/content/spin/v2/deploying-to-fermyon.md
+++ b/content/spin/v2/deploying-to-fermyon.md
@@ -1,0 +1,26 @@
+title = "Deploying Spin Applications to Fermyon"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/deploying-to-fermyon.md"
+
+---
+- [Deploying Microservices \& Web Apps](#deploying-microservices--web-apps)
+- [Running on Your Workstation](#running-on-your-workstation)
+- [Running on AWS](#running-on-aws)
+
+## Deploying Microservices & Web Apps
+
+[Fermyon](https://www.fermyon.dev/) is the frictionless WebAssembly platform for deploying
+microservices and web apps. With Fermyon, you can deploy your spin applications onto a server in
+moments.
+
+## Running on Your Workstation
+
+For instructions guiding you through running the Fermyon platform on your development workstation,
+follow [this guide](https://www.fermyon.dev/quickstart-local).
+
+## Running on AWS
+
+For instructions guiding you through running the Fermyon platform on AWS, follow
+[this guide](https://www.fermyon.dev/quickstart-aws).

--- a/content/spin/v2/distributing-apps.md
+++ b/content/spin/v2/distributing-apps.md
@@ -1,0 +1,140 @@
+title = "Publishing and Distribution"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+enable_shortcodes = true
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/distributing-apps.md"
+
+---
+- [Logging Into a Registry](#logging-into-a-registry)
+  - [Logging In Using a Token](#logging-in-using-a-token)
+  - [Fallback Credentials](#fallback-credentials)
+- [Publishing a Spin Application to a Registry](#publishing-a-spin-application-to-a-registry)
+- [Running Published Applications](#running-published-applications)
+  - [Running Published Applications by Digest](#running-published-applications-by-digest)
+  - [Pulling a Published Application](#pulling-a-published-application)
+- [Signing Spin Applications and Verifying Signatures](#signing-spin-applications-and-verifying-signatures)
+
+If you would like to publish a Spin application, so that other users can run it, you can do so using a _container registry_.
+
+{{ details "What's all this about containers?" "The registry protocol was originally created to publish and distribute Docker containers. Over time, registries have evolved to host other kinds of artifact - see [the OCI registry artifacts project](https://github.com/opencontainers/artifacts) for more information. However, the term remains, in services such as GitHub Container Registry or AWS Elastic Container Registry, and in the generic description _OCI (Open Container Initiative) registries_. When you use a 'container' registry to publish and distribute Spin applications, there are no actual containers involved at all!" }}
+
+Many cloud services offer public registries.  Examples include GitHub Container Registry, Docker Hub, or Amazon Elastic Container Registry.  These support both public and private distribution.  You can also run your own registry using open source software.
+
+## Logging Into a Registry
+
+Before you can publish to a registry, or run applications whose registry artifacts are private, you must log in to the registry.  This example shows logging into the GitHub Container Registry, `ghcr.io`:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin registry login ghcr.io
+```
+
+If you don't provide any options to `spin registry login`, it prompts you for a username and password.
+
+### Logging In Using a Token
+
+In a non-interactive environment such as GitHub Actions, you will typically log in using a token configured in the environment settings, rather than a password.  To do this, use the `--password-stdin` flag, and `echo` the token value to the login command's standard input.  This example shows logging into GHCR from a GitHub action:
+
+<!-- @noCpy -->
+
+```bash
+$ echo "$\{{ secrets.GITHUB_TOKEN }}" | spin registry login ghcr.io --username $\{{ github.actor }} --password-stdin
+```
+
+Other environments will have different ways of referring to the token and user but the pattern remains the same.
+
+### Fallback Credentials
+
+If you have logged into a registry using `docker login`, but not using `spin registry login`, Spin will fall back to your Docker credentials.
+
+## Publishing a Spin Application to a Registry
+
+To publish an application to a registry, use the `spin registry push` command.  You must provide a _reference_ for the published application.  This is a string whose format is defined by the registry standard, and generally consists of `<registry>/<username>/<application-name>:<version>`.  (In specific circumstances you may be able to omit the username and/or the version.  If you want more detail on references, see the OCI documentation.)
+
+> Remember you will (usually) need to be logged in to publish to a registry.
+
+Here is an example of pushing an application to GHCR:
+
+<!-- @nocpy -->
+
+```bash
+$ spin registry push ghcr.io/alyssa-p-hacker/hello-world:v1
+Pushed with digest sha256:06b19
+```
+
+Notice that the username is part of the reference; the registry does not infer it from the login.  Also notice that the version is specified explicitly; Spin does not infer it from the `spin.toml` file.
+
+> Whether newly uploaded artifacts are private or public depends on the registry.  See your registry documentation.  This will also tell you how to change the visibility if the default is not what you want.
+
+## Running Published Applications
+
+To run a published application from a registry, use `spin up -f` and pass the registry reference:
+
+<!-- @nocpy -->
+
+```bash
+$ spin up -f ghcr.io/alyssa-p-hacker/hello-world:v1
+```
+
+> Remember that if the artifact is private you will need to be logged in, with permission to access it.
+
+> Spin optimizes downloads using a local [registry cache](/spin/cache). When running an application from a remote registry, Spin always tries to check the registry for updates, even if the application has already been pulled. However, content files that are already pulled will not be re-downloaded. This applies even if they were downloaded as part of a different application.
+
+### Running Published Applications by Digest
+
+Registry versions are mutable; that is, the owner of an application can change which build the `:v1` label points to at any time.  If you want to run a specific build of the package, you can refer to it by _digest_.  This is similar to a Git commit hash: it is immutable, meaning the same digest always gets the exact same data, no matter what the package owner does.  To do this, use the `@sha256:...` syntax instead of the `:v...` syntax:
+
+<!-- @nocpy -->
+
+```bash
+$ spin up -f ghcr.io/alyssa-p-hacker/hello-world@sha256:06b19
+```
+
+### Pulling a Published Application
+
+`spin up` automatically downloads the application from the registry. If you want to manually download the application, without running it, use the `spin registry pull` command:
+
+<!-- @nocpy -->
+
+```bash
+$ spin registry pull ghcr.io/alyssa-p-hacker/hello-world:v1
+$ spin registry pull ghcr.io/alyssa-p-hacker/hello-world@sha256:06b19
+```
+
+> Downloaded applications are cached. When run, or pulled again, Spin checks to see if they have changed from the cached copy, and downloads only the changes if any.
+
+## Signing Spin Applications and Verifying Signatures
+
+Because Spin uses the container registry standards to distribute applications, it can also take advantage of tooling built around those standards.  Here is an example of using [Cosign and Sigstore](https://docs.sigstore.dev/) to sign and verify a Spin application:
+
+<!-- @nocpy -->
+
+```bash
+# Push your Spin application to any registry that supports the OCI registry artifacts,
+# such as the GitHub Container Registry, Docker Hub, Azure ACR, or AWS ECR.
+$ spin registry push ghcr.io/alyssa-p-hacker/hello-world:v1
+
+# You can now sign your Spin app using Cosign (or any other tool that can sign
+# OCI registry objects).
+$ cosign sign ghcr.io/alyssa-p-hacker/hello-world@sha256:06b19
+Generating ephemeral keys...
+Retrieving signed certificate...
+tlog entry created with index: 12519542
+Pushing signature to: ghcr.io/alyssa-p-hacker/hello-world
+
+# Someone interested in your application can now use Cosign to verify the signature
+# before running the application.
+$ cosign verify ghcr.io/alyssa-p-hacker/hello-world@sha256:06b19
+Verification for ghcr.io/alyssa-p-hacker/hello-world@sha256:06b19 --
+The following checks were performed on each of these signatures:
+  - The cosign claims were validated
+  - Existence of the claims in the transparency log was verified offline
+  - Any certificates were verified against the Fulcio roots.
+
+# The consumer of your app can now run it from the registry.
+$ spin up -f ghcr.io/alyssa-p-hacker/hello-world@sha256:06b19
+```
+
+> You'll need Cosign 2.0 or above to verify Spin artifacts.

--- a/content/spin/v2/dynamic-configuration.md
+++ b/content/spin/v2/dynamic-configuration.md
@@ -1,0 +1,246 @@
+title = "Dynamic and Runtime Application Configuration"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/dynamic-configuration.md"
+
+---
+- [Custom Config Variables](#custom-config-variables)
+  - [Component Custom Config](#component-custom-config)
+- [Custom Config Providers](#custom-config-providers)
+  - [Environment Variable Provider](#environment-variable-provider)
+  - [Vault Config Provider](#vault-config-provider)
+    - [Vault Config Provider Example](#vault-config-provider-example)
+- [Runtime Configuration](#runtime-configuration)
+  - [Key Value Store Runtime Configuration](#key-value-store-runtime-configuration)
+  - [SQLite Storage Runtime Configuration](#sqlite-storage-runtime-configuration)
+
+Spin applications may define custom configuration which can be looked up by
+component code via the [spin-config interface](https://github.com/fermyon/spin/blob/main/wit/ephemeral/spin-config.wit).
+
+## Custom Config Variables
+
+Application-global custom config variables are defined in the top-level `[variables]`
+section. These entries aren't accessed directly by components but are referenced
+by [component config](#component-custom-config) value templates. Each entry must
+either have a `default` value or be marked as `required = true`. "Required" entries
+must be [provided](#custom-config-providers) with a value.
+
+Configuration keys may only contain lowercase letters and underscores between letters:
+
+<!-- @nocpy -->
+
+```toml
+[variables]
+api_host = { default = "api.example.com" }
+api_key = { required = true }
+```
+
+### Component Custom Config
+
+The configuration entries available to a component are listed in its
+`[component.config]` section. Configuration values may reference
+[config variables](#custom-config-variables) with simple
+[mustache](https://mustache.github.io/)-inspired string templates:
+
+<!-- @nocpy -->
+
+```toml
+[[component]]
+# ...
+[component.config]
+api_base_url = "https://{{ api_host }}/v1"
+api_key = "{{ api_key }}"
+```
+
+## Custom Config Providers
+
+[Custom config variables](#custom-config-variables) values may be set at runtime by
+config "providers". Currently, there are two providers: the environment
+variable provider and vault config provider.
+
+### Environment Variable Provider
+
+The environment variable provider which gets config values from the `spin` process's
+environment (_not_ the component `environment`). Config keys are translated
+to environment variables by upper-casing and prepending with `SPIN_CONFIG_`:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ export SPIN_CONFIG_API_KEY = "1234"  # Sets the `api_key` value.
+$ spin up
+```
+
+### Vault Config Provider
+
+The Vault config provider gets secret values from [HashiCorp Vault](https://www.vaultproject.io/).
+Currently, only [KV Secrets Engine - Version 2](https://developer.hashicorp.com/vault/docs/secrets/kv/kv-v2) is supported.
+You can set up v2 kv secret engine at any mount point and give Vault information in the [runtime configuration](#runtime-configuration) file:
+
+<!-- @nocpy -->
+
+```toml
+[[config_provider]]
+type = "vault"
+url = "http://127.0.0.1:8200"
+token = "root"
+mount = "secret"
+```
+
+#### Vault Config Provider Example
+
+1. [Install Vault](https://developer.hashicorp.com/vault/tutorials/getting-started/getting-started-install).
+2. Start Vault:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ vault server -dev -dev-root-token-id root
+```
+
+3. Set a password:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ export VAULT_TOKEN=root
+$ export VAULT_ADDR=http://127.0.0.1:8200
+$ vault kv put secret/password value="test_password"
+$ vault kv get secret/password
+```
+
+4. Go to the [spin/tests/http/vault-config-test](https://github.com/fermyon/spin/tree/main/tests/http/vault-config-test) folder.
+5. Build and run the `vault-config-test` app:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin build
+$ spin up --runtime-config-file runtime_config.toml
+```
+
+6. Test the app:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ curl -i http://127.0.0.1:3000
+HTTP/1.1 200 OK
+content-length: 26
+date = "2023-11-02T16:00:00Z"
+
+Got password test_password
+```
+
+## Runtime Configuration
+
+Runtime configuration contains information for the selected config provider, such as the [Vault config provider](#vault-config-provider).
+You can supply runtime configuration by providing a value for the `--runtime-config-file` flag when invoking the `spin up` command.
+
+### Key Value Store Runtime Configuration
+
+Spin provides built-in key-value storage. This storage is backed by an SQLite database embedded in Spin by default. However, the Spin runtime configuration file (runtime-config.toml) can be updated to not only modify the SQLite configuration but also choose to use a different backing store. The available store options are the embedded SQLite database, an external Redis database or Azure CosmosDB.
+
+The following is an example of how an application's `runtime-config.toml` file can be configured to use Redis instead. Note the `type` and `url` values, which are set to `redis` and the URL of the Redis host, respectively:
+
+```toml
+[key_value_store.default]
+type = "redis"
+url = "redis://localhost"
+```
+
+Similarly, to implement Azure CosmosDB as a backend for Spin's key/value store, change the type to `azure_cosmos` and specify your database account details:
+
+```toml
+[key_value_store.default]
+type = "azure_cosmos"
+key = "<key>"
+account = "<cosmos-account>"
+database = "<cosmos-database>"
+container = "<cosmos-container>"
+```
+
+> Note: The CosmosDB container must be created with the default partition key, `/id`.
+
+Whilst a single default store may be sufficient for certain application use cases, each Spin application can be configured to support multiple stores of any `type`, as shown in the `runtime-config.toml` file below:
+
+> **Note:** At present, when deploying an application to Fermyon Cloud only the single "default" key-value store is supported. To see more about Spin support on Fermyon Cloud, visit the [limitations documentation](/cloud/faq#spin-limitations):
+
+```toml
+# This defines a new store named user_data
+[key_value_store.user_data]
+type = "spin" 
+path = ".spin/user_data.db"
+
+# This defines a new store named other_data backed by a Redis database
+[key_value_store.other_data]
+type = "redis"
+url = "redis://localhost"
+```
+
+You must individually grant each component access to the stores that it needs to use. To do this, use the `component.key_value_stores` entry in the component manifest within `spin.toml`. See [Spin Key Value Store](kv-store-api-guide.md) for more details. 
+
+### SQLite Storage Runtime Configuration
+
+Spin provides built-in SQLite storage. By default, this is backed by a database that Spin creates for you underneath your application directory (in the `.spin` subdirectory). However, you can use the Spin runtime configuration file (`runtime-config.toml`) to add and customize SQLite databases.
+
+The following example `runtime-config.toml` tells Spin to map the `default` database to an SQLite database elsewhere in the file system:
+
+```toml
+[sqlite_database.default]
+path = "/planning/todo.db"
+```
+
+If you need more than one database, you can configure multiple databases, each with its own name:
+
+```toml
+# This defines a new store named todo
+[sqlite_database.todo]
+path = "/planning/todo.db"
+
+# This defines a new store named finance
+[sqlite_database.finance]
+path = "/super/secret/monies.db"
+```
+
+Spin creates any database files that don't exist.  However, it is up to you to delete them when you no longer need them.
+
+Spin can also use [libSQL](https://libsql.org/) databases accessed over HTTPS.  libSQL is fully compatible with SQLite but provides additional features including remote, distributed databases.
+
+> Spin does not provide libSQL access to file-based databases, only databases served over HTTPS. Specifically, Spin supports [the `sqld` libSQL server](https://github.com/libsql/sqld).
+
+To use libSQL, set `type = "libsql"` in your `runtime-config.toml` entry.  You must then provide a `url` and authentication `token` instead of a file path.  For example, this entry tells Spin to map the `default` database to a libSQL service running on `libsql.example.com`:
+
+```toml
+# This tells Spin to use the remote host as its default database
+[sqlite_database.default]
+type = "libsql"
+url = "https://sensational-penguin-ahacker.libsql.example.com"
+token = "a secret"
+```
+
+Spin does _not_ create libSQL databases.  Use your hosting service's tools to create them (or `sqld` if you are self-hosting) .  You can still set up tables and data in a libSQL database via `spin up --sqlite`.
+
+> You must include the scheme in the `url` field. The scheme must be `http` or `https`. Non-HTTP libSQL protocols are not supported.
+
+The `default` database will still be defined, even if you add other databases.
+
+By default, components will not have access to any of these databases (even the default one). You must grant each component access to the databases that it needs to use. To do this, use the `component.sqlite_databases` entry in the component manifest within `spin.toml`. See [SQLite Database](/spin/sqlite-api-guide.md) for more details. 
+
+### LLM Runtime Configuration
+
+Spin provides a Large Language Model interface for interacting with LLMs for inferencing and embedding. The default host implementation is to use local CPU/GPU compute. However, the Spin runtime configuration file (runtime-config.toml) can be updated to enable Spin to use remote compute using HTTP requests.
+
+The following is an example of how an application's `runtime-config.toml` file can be configured to use the remote compute option. Note the `type`, `url` and `auth_token` are set to `remote_http`, URL of the server and the auth token for the server. 
+
+```toml
+[llm_compute]
+type = "remote_http"
+url = "http://example.com"
+auth_token = "<auth_token>"
+```
+
+Currently, the remote compute option requires an user to deploy their own LLM proxy service. Fermyon Cloud users can do this using the [`cloud-gpu` plugin](https://github.com/fermyon/spin-cloud-gpu).  If you prefer to create and deploy your own proxy service, you can find a reference implementation of the proxy protocol in the [`spin-cloud-gpu plugin repository`](https://github.com/fermyon/spin-cloud-gpu/blob/main/fermyon-cloud-gpu/src/index.ts). 
+
+By default, componenets will not have access to the LLM models unless granted explicit access through the `component.ai_models` entry in the component manifest within `spin.toml`. See [Serverless AI](/spin/serverless-ai-api-guide) for more details.

--- a/content/spin/v2/extending-and-embedding.md
+++ b/content/spin/v2/extending-and-embedding.md
@@ -1,0 +1,184 @@
+title = "Extending and Embedding Spin"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/extending-and-embedding.md"
+
+---
+- [Other Ways to Extend and Use Spin](#other-ways-to-extend-and-use-spin)
+
+> The complete example for extending and embedding Spin [can be found on GitHub](https://github.com/fermyon/spin/tree/main/examples/spin-timer).
+
+Spin currently implements triggers and application models for:
+
+- [HTTP applications](./http-trigger.md) that are triggered by incoming HTTP
+requests, and that return an HTTP response
+- [Redis applications](./redis-trigger.md) that are triggered by messages on Redis
+channels
+
+The Spin internals and execution context (the part of Spin executing
+components) are agnostic of the event source and application model.
+In this document, we will explore how to extend Spin with custom event sources
+(triggers) and application models built on top of the WebAssembly component
+model, as well as how to embed Spin in your application.
+
+In this article, we will build a Spin trigger to run the applications based on a
+timer, executing Spin components at a configured time interval.
+
+The current application types that can be implemented with Spin have entry points
+defined using
+[WebAssembly Interface (WIT)](https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md):
+
+<!-- @nocpy -->
+
+```fsharp
+// The entry point for an HTTP handler.
+handle-http-request: function(req: request) -> response
+
+// The entry point for a Redis handler.
+handle-redis-message: function(msg: payload) -> expected<_, error>
+```
+
+The entry point we want to execute for our timer trigger takes a string as its
+only argument (the trigger will populate that with the current date and time),
+and it expects a string as the only return value. This is purposefully chosen
+to be a simple function signature:
+
+<!-- @nocpy -->
+
+```fsharp
+// examples/spin-timer/spin-timer.wit
+handle-timer-request: function(msg: string) -> string
+```
+
+This is the function that all components executed by the timer trigger must
+implement, and which is used by the timer executor when instantiating and
+invoking the component.
+
+Let's have a look at building the timer trigger:
+
+<!-- @nocpy -->
+
+```rust
+// examples/spin-timer/src/main.rs
+wit_bindgen_wasmtime::import!({paths: ["spin-timer.wit"], async: *});
+type ExecutionContext = spin_engine::ExecutionContext<spin_timer::SpinTimerData>;
+
+/// A custom timer trigger that executes a component on every interval.
+#[derive(Clone)]
+pub struct TimerTrigger {
+    /// The interval at which the component is executed.
+    pub interval: Duration,
+    /// The Spin execution context.
+    engine: Arc<ExecutionContext>,
+}
+```
+
+A few important things to note from the start:
+
+- we use the WIT defined entry point with the
+[Bytecode Alliance `wit-bindgen` project](https://github.com/bytecodealliance/wit-bindgen)
+to generate "import" bindings based on the entry point — this generates code that
+allows us to easily invoke the entry point from application components that
+implement our new application model.
+- the new trigger has a field that contains a `Application` —
+in most cases, either `CoreComponent` will have to be updated with new trigger
+and component configuration (not the case for our simple application model),
+or an entirely new component can be defined and used in `Application<T>`.
+- the trigger has a field that contains the Spin execution context — this is the
+part of Spin that instantiates and helps execute the WebAssembly modules. When
+creating the trigger (in the `new` function, you get access to the underlying
+Wasmtime store, instance, and linker, which can be configured as necessary).
+
+Finally, whenever there is a new event (in the case of our timer-based trigger
+every `n` seconds), we execute the entry point of a selected component:
+
+<!-- @nocpy -->
+
+```rust
+/// Execute the first component in the application manifest.
+async fn handle(&self, msg: String) -> Result<()> {
+    // create a new Wasmtime store and instance based on the first component's WebAssembly module.
+    let (mut store, instance) =
+        self.engine
+            .prepare_component(&self.app.components[0].id, None, None, None, None)?;
+
+    // spawn a new thread and call the entry point function from the WebAssembly module 
+    let res = spawn_blocking(move || -> Result<String> {
+            // use the auto-generated WIT bindings to get the Wasm exports and call the `handle-timer-request` function.
+        let t = spin_timer::SpinTimer::new(&mut store, &instance, |host| {
+            host.data.as_mut().unwrap()
+        })?;
+        Ok(t.handle_timer_request(&mut store, &msg)?)
+    })
+    .await??;
+    // do something with the result.
+    log::info!("{}\n", res);
+    Ok(())
+}
+```
+
+A few notes:
+
+- `prepare_component` is a function implemented by the Spin execution context,
+and it handles taking the Wasmtime pre-instantiated module, mapping all the
+component files, environment variables, and allowed HTTP domains, populating
+the Wasmtime store with the appropriate data, and returning the store and instance.
+- invoking the entry point `handle-timer-request` is done in this example in a new Tokio thread —
+this is an implementation choice based on the needs of the trigger.
+- the return value from the component (a string in this example) can then be
+used — in the case of the HTTP trigger, this is an HTTP response, which is then
+returned to the client.
+
+This is very similar to how the [HTTP](./http-trigger.md) and [Redis](./redis-trigger.md)
+triggers are implemented, and it is the recommended way to extend Spin with your
+own trigger and application model.
+
+Writing components for the new trigger can be done by using the
+[`wit-bindgen` tooling](https://github.com/bytecodealliance/wit-bindgen) from
+Rust and other supported languages (see [the example in Rust](https://github.com/fermyon/spin/tree/main/examples/spin-timer/app-example)):
+
+<!-- @nocpy -->
+
+```rust
+// automatically generate Rust bindings that help us implement the 
+// `handle-timer-request` function that the trigger will execute.
+wit_bindgen_rust::export!("../spin-timer.wit");
+...
+fn handle_timer_request(msg: String) -> String {
+    format!("ECHO: {}", msg)
+}
+```
+
+Components can be compiled to WebAssembly, then used from a `spin.toml`
+application manifest.
+
+Embedding the new trigger in a Rust application is done by creating a new trigger
+instance, then calling its `run` function:
+
+<!-- @nocpy -->
+
+```rust
+// app() is a utility function that generates a complete application configuration.
+let trigger = TimerTrigger::new(Duration::from_secs(1), app()).await?;
+// run the trigger indefinitely
+trigger.run().await
+```
+
+> We are exploring [APIs for embedding Spin from other programming languages](https://github.com/fermyon/spin/issues/197)
+> such as Go or C#.
+
+In this example, we built a simple timer trigger — building more complex triggers
+would also involve updating the Spin application manifest, and extending
+the application-level trigger configuration, as well as component-level
+trigger configuration (an example of component-level trigger configuration
+for this scenario would be each component being able to define its own
+independent time interval for scheduling the execution).
+
+## Other Ways to Extend and Use Spin
+
+Besides building custom triggers, the internals of Spin could also be used independently:
+
+- the Spin execution context can be used entirely without a `spin.toml` application manifest — for embedding scenarios, the configuration for the
+execution can be constructed without a `spin.toml` (see [issue #229](https://github.com/fermyon/spin/issues/229) for context)
+- the standard way of distributing a Spin application can be changed by re-implementing the [`loader`](https://github.com/fermyon/spin/tree/main/crates/loader) crate — all is required is that loading the application returns a valid `Application` that the Spin execution context can use to instantiate and execute components.

--- a/content/spin/v2/go-components.md
+++ b/content/spin/v2/go-components.md
@@ -1,0 +1,355 @@
+title = "Building Spin components in Go"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/go-components.md"
+
+---
+
+- [Versions](#versions)
+- [HTTP Components](#http-components)
+- [Sending Outbound HTTP Requests](#sending-outbound-http-requests)
+- [Redis Components](#redis-components)
+- [Storing Data in Redis From Go Components](#storing-data-in-redis-from-go-components)
+- [Using Go Packages in Spin Components](#using-go-packages-in-spin-components)
+- [Storing Data in the Spin Key-Value Store](#storing-data-in-the-spin-key-value-store)
+- [Storing Data in SQLite](#storing-data-in-sqlite)
+
+> This guide assumes you have Spin installed. If this is your first encounter with Spin, please see the [Quick Start](quickstart), which includes information about installing Spin with the Go templates, installing required tools, and creating Go applications.
+
+> This guide assumes you are familiar with the Go programming language, and that
+> you have
+> [configured the TinyGo toolchain locally](https://tinygo.org/getting-started/install/).
+Using TinyGo to compile components for Spin is currently required, as the
+[Go compiler doesn't currently have support for compiling to WASI](https://github.com/golang/go/issues/31105).
+
+> All examples from this page can be found in [the Spin repository on GitHub](https://github.com/fermyon/spin/tree/main/examples).
+
+## Versions
+
+TinyGo `0.29.0` is recommended, which requires Go `v1.18+` or newer.
+
+> TinyGo version `0.29.0` is known to have issues with Spin on some systems.
+
+## HTTP Components
+
+In Spin, HTTP components are triggered by the occurrence of an HTTP request, and
+must return an HTTP response at the end of their execution. Components can be
+built in any language that compiles to WASI, and Go has improved support for
+writing applications, through its SDK.
+
+Building a Spin HTTP component using the Go SDK means writing a single function,
+`init` — below is a complete implementation for such a component:
+
+<!-- @nocpy -->
+
+```go
+// A Spin component written in Go that returns "Hello, Fermyon!"
+package main
+
+import (
+ "fmt"
+ "net/http"
+
+ spinhttp "github.com/fermyon/spin/sdk/go/http"
+)
+
+func init() {
+ spinhttp.Handle(func(w http.ResponseWriter, r *http.Request) {
+  w.Header().Set("Content-Type", "text/plain")
+  fmt.Fprintln(w, "Hello Fermyon!")
+ })
+}
+
+func main() {}
+```
+
+The important things to note in the implementation above:
+
+- the entry point to the component is the standard `func init()` for Go programs
+- handling the request is done by calling the `spinhttp.Handle` function,
+which takes a `func(w http.ResponseWriter, r *http.Request)` as parameter — these
+contain the HTTP request and response writer you can use to handle the request
+- the HTTP objects (`*http.Request`, `http.Response`, and `http.ResponseWriter`)
+are the Go objects from the standard library, so working with them should feel
+familiar if you are a Go developer
+
+## Sending Outbound HTTP Requests
+
+If allowed, Spin components can send outbound requests to HTTP endpoints. Let's
+see an example of a component that makes a request to
+[an API that returns random animal facts](https://random-data-api.fermyon.app/animals/json) and
+inserts a custom header into the response before returning:
+
+<!-- @nocpy -->
+
+```go
+// A Spin component written in Go that sends a request to an API
+// with random animal facts.
+
+package main
+
+import (
+ "fmt"
+ "net/http"
+ "os"
+
+ spinhttp "github.com/fermyon/spin/sdk/go/http"
+)
+
+func init() {
+ spinhttp.Handle(func(w http.ResponseWriter, r *http.Request) {
+    resp, _ := spinhttp.Get("https://random-data-api.fermyon.app/animals/json")
+
+  fmt.Fprintln(w, resp.Body)
+  fmt.Fprintln(w, resp.Header.Get("content-type"))
+
+  // `spin.toml` is not configured to allow outbound HTTP requests to this host,
+  // so this request will fail.
+  if _, err := spinhttp.Get("https://fermyon.com"); err != nil {
+   fmt.Fprintf(os.Stderr, "Cannot send HTTP request: %v", err)
+  }
+ })
+}
+
+func main() {}
+```
+
+The component can be built using the `tingygo` toolchain:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ tinygo build -wasm-abi=generic -target=wasi -no-debug -o main.wasm main.go
+```
+
+Before we can execute this component, we need to add the
+`random-data-api.fermyon.app` domain to the application manifest `allowed_http_hosts`
+list containing the list of domains the component is allowed to make HTTP
+requests to:
+
+<!-- @nocpy -->
+
+```toml
+# spin.toml
+spin_manifest_version = "1"
+name = "spin-hello-tinygo"
+trigger = { type = "http", base = "/" }
+version = "1.0.0"
+
+[[component]]
+id = "tinygo-hello"
+source = "main.wasm"
+allowed_http_hosts = [ "random-data-api.fermyon.app" ]
+[component.trigger]
+route = "/hello"
+```
+
+> Spin HTTP components written in Go use the Spin executor.
+
+Running the application using `spin up --file spin.toml` will start the HTTP
+listener locally (by default on `localhost:3000`), and our component can
+now receive requests in route `/hello`:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ curl -i localhost:3000/hello
+HTTP/1.1 200 OK
+content-type: text/plain; charset=utf-8
+server: spin/0.1.0
+content-length: 85
+date = "2023-11-02T16:00:00Z"
+
+{"timestamp":1684299253331,"fact":"Reindeer grow new antlers every year"}
+```
+
+> Without the `allowed_http_hosts` field populated properly in `spin.toml`,
+> the component would not be allowed to send HTTP requests, and sending the
+> request would generate in a "Destination not allowed" error.
+
+> You can set `allowed_http_hosts = ["insecure:allow-all"]` if you want to allow
+> the component to make requests to any HTTP host. This is **NOT** recommended
+> for any production or publicly-accessible application.
+
+## Redis Components
+
+Besides the HTTP trigger, Spin has built-in support for a Redis trigger, which
+will connect to a Redis instance and will execute components for new messages
+on the configured channels.
+
+> See the [Redis trigger](./redis-trigger.md) for details about the Redis trigger.
+
+Writing a Redis component in Go also takes advantage of the SDK:
+
+<!-- @nocpy -->
+
+```go
+package main
+
+import (
+ "fmt"
+
+ "github.com/fermyon/spin/sdk/go/redis"
+)
+
+func init() {
+ // redis.Handle() must be called in the init() function.
+ redis.Handle(func(payload []byte) error {
+  fmt.Println("Payload::::")
+  fmt.Println(string(payload))
+  return nil
+ })
+}
+
+// main function must be included for the compiler but is not executed.
+func main() {}
+```
+
+The manifest for a Redis application must contain the address of the Redis instance:
+
+<!-- @nocpy -->
+
+```toml
+spin_manifest_version = "1"
+name = "spin-redis"
+trigger = { type = "redis", address = "redis://localhost:6379" }
+version = "0.1.0"
+
+[[component]]
+id = "echo-message"
+source = "main.wasm"
+[component.trigger]
+channel = "messages"
+[component.build]
+command = "tinygo build -wasm-abi=generic -target=wasi -gc=leaking -no-debug -o main.wasm main.go"
+```
+
+The application will connect to `redis://localhost:6379`, and for every new message
+on the `messages` channel, the `echo-message` component will be executed:
+
+<!-- @selectiveCpy -->
+
+```bash
+# first, start redis-server on the default port 6379
+$ redis-server --port 6379
+# then, start the Spin application
+$ spin build --up
+INFO spin_redis_engine: Connecting to Redis server at redis://localhost:6379
+INFO spin_redis_engine: Subscribed component 0 (echo-message) to channel: messages
+```
+
+For every new message on the `messages` channel:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ redis-cli
+127.0.0.1:6379> publish messages "Hello, there!"
+```
+
+Spin will instantiate and execute the component:
+
+<!-- @nocpy -->
+
+```bash
+INFO spin_redis_engine: Received message on channel "messages"
+Payload::::
+Hello, there!
+```
+
+## Storing Data in Redis From Go Components
+
+Using the Spin's Go SDK, you can use the Redis key/value store to publish
+messages to Redis channels. This can be used from both HTTP and Redis triggered
+components.
+
+Let's see how we can use the Go SDK to connect to Redis:
+
+<!-- @nocpy -->
+
+```go
+package main
+
+import (
+ "net/http"
+ "os"
+
+ spin_http "github.com/fermyon/spin/sdk/go/http"
+ "github.com/fermyon/spin/sdk/go/redis"
+)
+
+func init() {
+ // handler for the http trigger
+ spin_http.Handle(func(w http.ResponseWriter, r *http.Request) {
+
+  // addr is the environment variable set in `spin.toml` that points to the
+  // address of the Redis server.
+  addr := os.Getenv("REDIS_ADDRESS")
+
+  // channel is the environment variable set in `spin.toml` that specifies
+  // the Redis channel that the component will publish to.
+  channel := os.Getenv("REDIS_CHANNEL")
+
+  // payload is the data publish to the redis channel.
+  payload := []byte(`Hello redis from tinygo!`)
+
+  if err := redis.Publish(addr, channel, payload); err != nil {
+   http.Error(w, err.Error(), http.StatusInternalServerError)
+   return
+  }
+
+  // set redis `mykey` = `myvalue`
+  if err := redis.Set(addr, "mykey", []byte("myvalue")); err != nil {
+   http.Error(w, err.Error(), http.StatusInternalServerError)
+   return
+  }
+
+  // get redis payload for `mykey`
+  if payload, err := redis.Get(addr, "mykey"); err != nil {
+   http.Error(w, err.Error(), http.StatusInternalServerError)
+  } else {
+   w.Write([]byte("mykey value was: "))
+   w.Write(payload)
+  }
+ })
+}
+
+func main() {}
+```
+
+This HTTP component demonstrates fetching a value from Redis by key, setting a
+key with a value, and publishing a message to a Redis channel. The component is
+triggered by an HTTP request served on the route configured in the `spin.toml`:
+
+<!-- @nocpy -->
+
+```toml
+[[component]]
+environment = { REDIS_ADDRESS = "redis://127.0.0.1:6379", REDIS_CHANNEL = "messages" }
+[component.trigger]
+route = "/publish"
+```
+
+This HTTP component can be paired with a Redis component, triggered on new
+messages on the `messages` Redis channel.
+
+> You can find a complete example for using outbound Redis from an HTTP component
+> in the [Spin repository on GitHub](https://github.com/fermyon/spin/tree/main/examples/tinygo-outbound-redis).
+
+## Using Go Packages in Spin Components
+
+Any
+[package from the Go standard library](https://tinygo.org/docs/reference/lang-support/stdlib/) that can be imported in TinyGo and that compiles to
+WASI can be used when implementing a Spin component.
+
+> Make sure to read [the page describing the HTTP trigger](./http-trigger.md) for more
+> details about building HTTP applications.
+
+## Storing Data in the Spin Key-Value Store
+
+Spin has a key-value store built in. For information about using it from TinyGo, see [the key-value store tutorial](kv-store-tutorial).
+
+## Storing Data in SQLite
+
+For more information about using SQLite from TinyGo, see [SQLite storage](sqlite-api-guide).

--- a/content/spin/v2/http-outbound.md
+++ b/content/spin/v2/http-outbound.md
@@ -1,0 +1,166 @@
+title = "Making HTTP Requests"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+enable_shortcodes = true
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/http-outbound.md"
+
+---
+- [Using HTTP From Applications](#using-http-from-applications)
+- [Granting HTTP Permissions to Components](#granting-http-permissions-to-components)
+  - [Making HTTP Requests Within an Application](#making-http-requests-within-an-application)
+
+Spin provides an interface for you to make outgoing HTTP requests.
+
+{{ details "Why do I need a Spin interface? Why can't I just use my language's HTTP library?" "The current version of the WebAssembly System Interface (WASI) doesn't provide a sockets interface, so HTTP libraries can't be built to Wasm. The Spin interface means Wasm modules can bypass this limitation by asking Spin to perform the HTTP request on their behalf." }}
+
+## Using HTTP From Applications
+
+The Spin SDK surfaces the Spin HTTP interface to your language. The interface contains only one operation:
+
+| Operation  | Parameters | Returns | Behavior |
+|------------|------------|---------|----------|
+| `request`  | request record | response record   | Sends the given HTTP request, and returns the response. |
+
+The request record specifies:
+
+| Field      | Type     | Meaning          |
+|------------|----------|------------------|
+| `method`   | enum     | The HTTP method for the request, e.g. GET, POST, DELETE, etc. |
+| `uri`      | string   | The URI to which to make the request |
+| `headers`  | list of key-value string pairs | The request headers |
+| `body`     | bytes    | Optional request body |
+
+> The Wasm request record declaration also contains a `parameters` field. This is unused and is retained only for binary compatibility.
+
+The response record contains:
+
+| Field      | Type     | Meaning          |
+|------------|----------|------------------|
+| `status`   | integer  | The HTTP status code of the response, e.g. 200, 404, etc. |
+| `headers`  | list of key-value string pairs | The response headers, if any |
+| `body`     | bytes    | The response body, if any |
+
+The exact detail of calling the `request` operation from your application depends on your language:
+
+{{ tabs "sdk-type" }}
+
+{{ startTab "Rust"}}
+
+HTTP functions are available in the `spin_sdk::outbound_http` module. The function is named `send_request`. It takes a `spin_sdk::http::Request` and returns a `spin_sdk::http::Response`. Both of these types are specializations of the `Request` and `Response` types from the `http` crate, and have all their behaviour and methods; the Spin SDK maps them to the underlying Wasm interface. For example:
+
+```rust
+use spin_sdk::http::{Request, Response};
+
+let request = http::Request::builder()
+    .method("POST")
+    .uri("https://example.com/users")
+    .body(Some(json_text.into()))?;
+
+let response = spin_sdk::outbound_http::send_request(request)?;
+println!("Status: {}", response.status().as_str());
+```
+
+**Notes**
+
+* The Rust SDK surfaces the idiomatic `http` types rather than the raw Wasm interface types. For example, the `method` in Rust is a string, not an enum.
+* Request and response bodies are of type `Option<bytes::Bytes>`.
+
+You can find a complete example for using outbound HTTP in the [Spin repository on GitHub](https://github.com/fermyon/spin/tree/main/examples/http-rust-outbound-http).
+
+{{ blockEnd }}
+
+{{ startTab "TypeScript"}}
+
+HTTP operations are available via the standard JavaScript `fetch` function. The Spin runtime maps this to the underlying Wasm interface. For example:
+
+```javascript
+const response = await fetch("https://example.com/users");
+```
+
+**Notes**
+
+* Although the underlying Spin interface is blocking, the `fetch` function is defined by JavaScript as async. You must await the response, but the request will always block, and the promise will resolve as soon as the request is returned.
+
+You can find a complete example of using outbound HTTP in the JavaScript SDK repository on GitHub ([TypeScript](https://github.com/fermyon/spin-js-sdk/tree/main/examples/typescript/outbound_http), [JavaScript](https://github.com/fermyon/spin-js-sdk/tree/main/examples/javascript/outbound-http)).
+
+{{ blockEnd }}
+
+{{ startTab "Python"}}
+
+HTTP functions and classes are available in the `spin_http` module. The function name is `http_send`. The request type is `Request`, and the response type is `Response`. For example:
+
+```python
+from spin_http import Request, Response, http_send
+
+response = http_send(
+    Request("GET", "https://random-data-api.fermyon.app/animals/json", {}, None))
+```
+
+**Notes**
+
+* For compatibility with idiomatic Python, types do not necessarily match the underlying Wasm interface. For example, `method` is a string.
+* Request and response bodies are `bytes`. (You can pass literal strings using the `b` prefix.)  Pass `None` for no body.
+* Request and response headers are dictionaries.
+* Errors are signalled through exceptions.
+
+You can find a complete example for using outbound HTTP in the [Python SDK repository on GitHub](https://github.com/fermyon/spin-python-sdk/tree/main/examples/outbound_http).
+
+{{ blockEnd }}
+
+{{ startTab "TinyGo"}}
+
+HTTP functions are available in the `github.com/fermyon/spin/sdk/go/http` package. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/http). The general function is named `Send`, but the Go SDK also surfaces individual functions, with request-specific parameters, for the `Get` and `Post` operations. For example:
+
+```go
+import (
+	spinhttp "github.com/fermyon/spin/sdk/go/http"
+)
+
+res1, err1 := spinhttp.Get("https://random-data-api.fermyon.app/animals/json")
+res2, err2 := spinhttp.Post("https://example.com/users", "application/json", json)
+
+request, err := http.NewRequest("PUT", "https://example.com/users/1", bytes.NewBufferString(user1))
+request.Header.Add("content-type", "application/json")
+res3, err3 := spinhttp.Send(req)
+
+```
+
+**Notes**
+
+* In the `Post` function, the body is an `io.Reader`. The Spin SDK reads this into the underlying Wasm byte array.
+* The `NewRequest` function is part of the standard library. The `Send` method adapts the standard request type to the underlying Wasm interface.
+* Errors are returned through the usual Go multiple return values mechanism.
+
+You can find a complete example for using outbound HTTP in the [Spin repository on GitHub](https://github.com/fermyon/spin/tree/main/examples/http-tinygo-outbound-http).
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+## Granting HTTP Permissions to Components
+
+By default, Spin components are not allowed to make outgoing HTTP requests. This follows the general Wasm rule that modules must be explicitly granted capabilities, which is important to sandboxing. To grant a component permission to make HTTP requests to a particular host, use the `allowed_http_hosts` field in the component manifest:
+
+```toml
+[component]
+allowed_http_hosts = [ "random-data-api.fermyon.app", "api.example.com:8080" ]
+```
+
+The Wasm module can make HTTP requests _only_ to the specified hosts. If a port is specified, the module can make requests only to that port; otherwise, the module can make requests only on the default HTTP and HTTPS ports. Requests to other hosts (or ports) will fail with an error.
+
+For development-time convenience, you can also pass the string `"insecure:allow-all"` in the `allowed_http_hosts` collection. This allows the Wasm module to make HTTP requests to _any_ host and on any port. However, once you've determined which hosts your code needs, you should remove this string and list the hosts instead.  Other Spin implementations may restrict host access and disallow components that ask to connect to anything and everything!
+
+### Making HTTP Requests Within an Application
+
+In an HTTP component, you can use the special host `self` to make HTTP requests **within the current Spin application**. For example, if you make an outbound HTTP request to http://self/api/customers/, Spin replaces self with whatever host the application is running on. It also replaces the URL scheme (`http` or `https`) with the scheme of the current HTTP request. For example, if the application is running in the cloud, Spin changes `http://self/api` to `https://.../api`.
+
+Using `self` means that the application doesn't need to know the URL where it's deployed, or whether it's running locally versus in the cloud.
+
+> This doesn't work in Redis components because Spin uses the incoming HTTP request to determine the current host.
+
+You must still grant permission by including `self` in `allowed_http_hosts`:
+
+```toml
+allowed_http_hosts = ["self"]
+```

--- a/content/spin/v2/http-trigger.md
+++ b/content/spin/v2/http-trigger.md
@@ -1,0 +1,498 @@
+title = "The Spin HTTP Trigger"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+enable_shortcodes = true
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/http-trigger.md"
+
+---
+- [Specifying an Application as HTTP](#specifying-an-application-as-http)
+- [Mapping a Route to a Component](#mapping-a-route-to-a-component)
+  - [Routing with an Application `base`](#routing-with-an-application-base)
+  - [Resolving Overlapping Routes](#resolving-overlapping-routes)
+  - [Health Check Route](#health-check-route)
+- [HTTP Components](#http-components)
+  - [The Request Handler](#the-request-handler)
+  - [The Request and Response Records](#the-request-and-response-records)
+  - [Additional Request Information](#additional-request-information)
+  - [Inside HTTP Components](#inside-http-components)
+- [HTTP With Wagi (WebAssembly Gateway Interface)](#http-with-wagi-webassembly-gateway-interface)
+  - [Wagi Component Requirements](#wagi-component-requirements)
+  - [Request Handling in Wagi](#request-handling-in-wagi)
+  - [Wagi HTTP Environment Variables](#wagi-http-environment-variables)
+- [Exposing HTTP Triggers Using HTTPS](#exposing-http-triggers-using-https)
+  - [Trigger Options](#trigger-options)
+  - [Environment Variables](#environment-variables)
+
+HTTP applications are an important workload in event-driven environments,
+and Spin has built-in support for creating and running HTTP
+components. This page covers Spin options that are specific to HTTP applications.
+
+The HTTP trigger in Spin is a web server. It listens for incoming requests and
+based on the [application manifest](./writing-apps.md), it routes them to a
+component, which returns an HTTP response.
+
+## Specifying an Application as HTTP
+
+Every Spin application has a trigger specified in the manifest, which declares the type of events it responds to.
+For HTTP applications, the application trigger has `type = "http"`:
+
+<!-- @nocpy -->
+
+```toml
+# spin.toml
+trigger = { type = "http", base = "/" }
+```
+
+The HTTP trigger also requires a `base` field.  Spin interprets each component route as relative to this route.  In most cases, you can set this to `"/"`, the base of the Web server, meaning Spin applies no prefix to component routes.
+
+> If you create an application from a HTTP template, the trigger will be already set up for you.
+
+In addition, each component must have HTTP-specific configuration in its `[component.trigger]` table.
+
+## Mapping a Route to a Component
+
+Each component handles one route, specified in the `route` field of the component `trigger` table.
+
+The route may be _exact_ or _wildcard_.
+
+An _exact_ route matches only the given route.  This is the default behavior.  For example, `/cart` matches only `/cart`, and not `/cart/checkout`:
+
+<!-- @nocpy -->
+
+```toml
+# Run the `cart.wasm` module when the application receives a request to `/cart`...
+[[component]]
+id = "cart"
+source = "cart.wasm"
+[component.trigger]
+route = "/cart"
+
+# ...and the `checkout.wasm` module for `/cart/checkout`
+[[component]]
+id = "checkout"
+source = "checkout.wasm"
+[component.trigger]
+route = "/cart/checkout"
+```
+
+A _wildcard_ route matches the given route and any route under it.  A route is a wildcard if it ends in `/...`.  For example, `/users/...` matches `/users`, `/users/1`, `/users/1/edit`, and so on.  Any of these routes will run the mapped component.
+
+> In particular, the route `/...` matches all routes.
+
+<!-- @nocpy -->
+
+```toml
+[[component]]
+id = "user-manager"
+source = "users.wasm"
+# Run the `users.wasm` module when the application receives a request to `/users`
+# or any path beginning with `/users/`
+[component.trigger]
+route = "/users/..."
+```
+
+### Routing with an Application `base`
+
+If the application `base` is `"/"` then all component routes are matched exactly as given.
+
+If `base` contains a non-root path, this is prefixed to all component routes,
+exact or wildcard.
+
+For example, suppose the application `base` path is `base = "/shop"`.  Then a component with `route = "/cart"` will be executed for requests to `/shop/cart`.  Similarly, a component with `route = "/users/..."` will be executed for requests to `/shop/users`, `/shop/users/1`, `/shop/users/1/edit` and so on.
+
+### Resolving Overlapping Routes
+
+If multiple components could potentially handle the same request based on their
+defined routes, the component whose route has the longest matching prefix 
+takes precedence.  This also means that exact matches take precedence over wildcard matches.
+
+In the following example, requests starting with the  `/users/` prefix (e.g. `/users/1`)
+will be handled by `user-manager`, even though it is also matched by the `shop` route, because the `/users` prefix is longer than `/`.
+But requests to `/users/admin` will be handled by the `admin` component, not `user-manager`, because that is a more exact match still:
+
+<!-- @nocpy -->
+
+```toml
+# spin.toml
+
+trigger = { type = "http", base = "/"}
+
+[[component]]
+id = "user-manager"
+[component.trigger]
+route = "/users/..."
+
+[[component]]
+id = "admin"
+[component.trigger]
+route = "/users/admin"
+
+[[component]]
+id = "shop"
+[component.trigger]
+route = "/..."
+```
+
+### Health Check Route
+
+Every HTTP application automatically has a special route always configured at `/.well-known/spin/health`, which
+returns `OK 200` when the Spin instance is healthy.
+
+## HTTP Components
+
+> Spin has two ways of running HTTP components, depending on language support for the evolving WebAssembly component standards.  This section describes the default way, which is currently used by Rust, JavaScript/TypeScript, Python, and TinyGo components.  For other languages, see [HTTP Components with Wagi](#http-with-wagi-webassembly-gateway-interface)) below.
+
+By default, Spin runs components using the [WebAssembly component model](https://github.com/WebAssembly/component-model).  In this model, the Wasm module exports a well-known function that Spin calls to handle the HTTP request.
+
+### The Request Handler
+
+The exact signature of the HTTP handler, and how a function is identified to be exported as the handler, will depend on your language.
+
+{{ tabs "sdk-type" }}
+
+{{ startTab "Rust"}}
+
+In Rust, the handler is identified by the `#[spin_sdk::http_component]` attribute.  It takes a `spin_sdk::http::Request`, and returns a `spin_sdk::http::Response` (or error).  These types are instantiations of the standard `http::Request` and `http::Response` types and behave exactly like them:
+
+```rust
+use anyhow::Result;
+use spin_sdk::{
+    http::{Request, Response},
+    http_component,
+};
+
+/// A simple Spin HTTP component.
+#[http_component]
+fn handle_hello_rust(req: Request) -> Result<Response> {
+    Ok(http::Response::builder()
+        .status(200)
+        .header("foo", "bar")
+        .body(Some("Hello, Fermyon".into()))?)
+}
+```
+
+{{ blockEnd }}
+
+{{ startTab "TypeScript"}}
+
+In JavaScript or TypeScript, the handler is identified by name.  It must be called `handleRequest`.  The way you declare it is slightly different between the two languages.
+
+In **JavaScript**, `handleRequest` is declared as `export async function`.  It takes a JsvaScript object representing the request, and returns a response object.  The fields of these objects are exactly the same as in TypeScript:
+
+```javascript
+export async function handleRequest(request) {
+    return {
+        status: 200,
+        headers: { "foo": "bar" },
+        body: "Hello from JS-SDK"
+    }
+}
+```
+
+In **TypeScript**, `handleRequest` is declared as an `export const` of the `HandleRequest` function type - that is, a function literal rather than a function declaration.  It takes a `HttpRequest` object, and returns a `HttpResponse` object, both defined in the `@fermyon/spin-sdk` package:
+
+```javascript
+import { HandleRequest, HttpRequest, HttpResponse} from "@fermyon/spin-sdk"
+
+export const handleRequest: HandleRequest = async function(request: HttpRequest): Promise<HttpResponse> {
+    return {
+      status: 200,
+      headers: { "foo": "bar" },
+      body: "Hello from TS-SDK"
+    }
+}
+```
+
+{{ blockEnd }}
+
+{{ startTab "Python"}}
+
+In Python, the handler is identified by name.  It must be called `handle_request`.  It takes a request object and must return an instance of `Response`, defined in the `spin_http` package:
+
+```python
+from spin_http import Response
+
+def handle_request(request):
+    return Response(200,
+                    [("content-type", "text/plain")],
+                    bytes(f"Hello from the Python SDK", "utf-8"))
+```
+
+{{ blockEnd }}
+
+{{ startTab "TinyGo"}}
+
+In Go, you register the handler as a callback in your program's `init` function.  Call `spinhttp.Handle`, passing your handler as the sole argument.  Your handler takes a `http.Request` record, from the standard `net/http` package, and a `ResponseWriter` to construct the response.
+
+> The do-nothing `main` function is required by TinyGo but is not used; the action happens in the `init` function and handler callback.
+
+```go
+package main
+
+import (
+        "fmt"
+        "net/http"
+
+        spinhttp "github.com/fermyon/spin/sdk/go/http"
+)
+
+func init() {
+        spinhttp.Handle(func(w http.ResponseWriter, r *http.Request) {
+                w.Header().Set("Content-Type", "text/plain")
+                fmt.Fprintln(w, "Hello Fermyon!")
+        })
+}
+
+func main() {}
+```
+
+> If you are moving between languages, note that in most other Spin SDKs, your handler _constructs and returns_ a response, but in Go, _Spin_ constructs a `ResponseWriter`, and you write to it; your handler does not return a value.
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+### The Request and Response Records
+
+Exactly how the Spin SDK surfaces the request and response types varies from language to language; this section calls out general features.
+
+* In the request record, the URL contains the path and query, but not the scheme and host.  For example, in a request to `https://example.com/shop/users/1?theme=pink`, the URL contains `/shop/users/1?theme=pink`.  If you need the full URL, you can get it from the `spin-full-url` header - see the table below.
+
+### Additional Request Information
+
+As well as any headers passed by the client, Spin sets several headers on the request passed to your component, which you can use to access additional information about the HTTP request.
+
+> In the following table, the examples suppose that:
+> * Spin is listening on `example.com:8080`
+> * The application `base` is `/shop`
+> * The component `route` is `/users/...`
+> * The request is to `https://example.com:8080/shop/users/1/edit?theme=pink`
+
+| Header Name                  | Value                | Example |
+|------------------------------|----------------------|---------|
+| `spin-full-url`              | The full URL of the request. This includes full host and scheme information. | `https://example.com:8080/shop/users/1/edit?theme=pink` |
+| `spin-path-info`             | The request path relative to the component route (including any base) | `/1/edit` |
+| `spin-matched-route`         | The part of the request path that was matched by the route (including the base and wildcard indicator if present) | `/shop/users/...` |
+| `spin-raw-component-route`   | The component route pattern matched, as written in the component manifest (that is, _excluding_ the base, but including the wildcard indicator if present) | `/users/...` |
+| `spin-component-route`       | The component route pattern matched, _excluding_ any wildcard indicator | `/users` |
+| `spin-base-path`             | The application base path | `/shop` |
+| `spin-client-addr`           | The IP address and port of the client | `127.0.0.1:53152` |
+
+### Inside HTTP Components
+
+For the most part, you'll build HTTP component modules using a language SDK (see the Language Guides section), such as a JavaScript module or a Rust crate.  If you're interested in what happens inside the SDK, or want to implement HTTP components in another language, read on!
+
+> The WebAssembly component model is in its early stages, and over time the triggers and application entry points will undergo changes, both in the definitions of functions and types, and in the binary representations of those definitions and of primitive types (the so-called Application Binary Interface or ABI).  However, Spin ensures binary compatibility over the course of any given major release.  For example, a component built using the Spin 1.0 SDK will work on any version of Spin in the 1.x range.
+
+The HTTP component interface is defined using a WebAssembly Interface (WIT) file.  ([Learn more about the evolving WIT standard here.](https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md)).  You can find the latest WITs for Spin HTTP components at [https://github.com/fermyon/spin/blob/main/wit/ephemeral](https://github.com/fermyon/spin/blob/main/wit/ephemeral).
+
+The core HTTP types are defined in [https://github.com/fermyon/spin/blob/main/wit/ephemeral/http-types.wit](https://github.com/fermyon/spin/blob/main/wit/ephemeral/http-types.wit):
+
+<!-- @nocpy -->
+
+```fsharp
+// wit/ephemeral/http-types.wit
+
+// The HTTP status code.
+type http-status = u16
+// The HTTP body.
+type body = list<u8>
+// The HTTP headers represented as a list of (name, value) pairs.
+type headers = list<tuple<string, string>>
+// The HTTP parameter queries, represented as a list of (name, value) pairs.
+type params = list<tuple<string, string>>
+// The HTTP URI of the current request.
+type uri = string
+// The HTTP method.
+enum method { get, post, put,... }
+
+// An HTTP request.
+record request {
+    method: method,
+    uri: uri,
+    headers: headers,
+    params: params, // Retained for binary compatibility but no longer used
+    body: option<body>,
+}
+
+// An HTTP response.
+record response {
+    status: http-status,
+    headers: option<headers>,
+    body: option<body>,
+}
+
+// error types omitted
+```
+
+> The same HTTP types are also used to model the API for sending outbound HTTP requests.
+
+The entry point for Spin HTTP components is then defined in [https://github.com/fermyon/spin/blob/main/wit/ephemeral/spin-http.wit](https://github.com/fermyon/spin/blob/main/wit/ephemeral/spin-http.wit):
+
+<!-- @nocpy -->
+
+```fsharp
+// wit/ephemeral/spin-http.wit
+
+use * from http-types
+
+// The entry point for an HTTP handler.
+handle-http-request: function(req: request) -> response
+```
+
+This is the function signature that all HTTP components must implement, and
+which is used by the Spin HTTP executor when instantiating and invoking the
+component.
+
+This interface (`spin-http.wit`) can be directly used together with the
+[Bytecode Alliance `wit-bindgen` project](https://github.com/bytecodealliance/wit-bindgen)
+to build a component that the Spin HTTP executor can invoke.
+
+This is exactly how Spin SDKs, such as the [Rust](rust-components), [JavaScript](javascript-components), [Python](python-components) and [Go](go-components) SDKs, are built.
+As more languages add support for the component model, we plan to add support for them in the same way.
+
+> WIT and the ABI are evolving standards.  The latest version of `wit-bindgen` creates binary implementations that do not work with current language implementations of the WebAssembly System Interface (WASI).  Spin remains pinned to an older implementation of `wit-bindgen` until the next generation of the component model stabilizes and achieves language-level support.
+
+## HTTP With Wagi (WebAssembly Gateway Interface)
+
+The WebAssembly component model proposal is currently in its early stages, which
+means only a few programming languages fully implement it. While the language
+communities implement toolchain support for the component model (for emitting
+components and for automatically generating bindings for importing other
+components), we want to allow developers to use any language that compiles to
+WASI to build Spin HTTP applications. This is why Spin currently implements an
+HTTP executor based on [Wagi](https://github.com/deislabs/wagi), or the
+WebAssembly Gateway Interface, a project that implements the
+[Common Gateway Interface](https://datatracker.ietf.org/doc/html/rfc3875)
+specification for WebAssembly.
+
+> Spin will keep supporting the Wagi-based executor while language toolchains
+> add support for the WebAssembly component model. When enough programming
+> languages have implemented the component model, we will work with the Spin
+> community to decide when to deprecate the Wagi executor.
+
+Wagi allows a module built in any programming language that compiles to [WASI](https://wasi.dev/)
+to handle an HTTP request by passing the HTTP request information to the module's
+standard input, environment variables, and arguments, and expecting the HTTP
+responses through the module's standard output.
+This means that if a language has support for the WebAssembly System Interface,
+it can be used to build Spin HTTP components.
+The Wagi model is only used to parse the HTTP request and response. Everything
+else — defining the application, running it, or [distributing](./distributing-apps.md)
+is done the same way as a component that uses the Spin executor.
+
+### Wagi Component Requirements
+
+Spin uses the component model by default, and cannot detect from the Wasm module alone whether it was built with component model support.  For Wagi components, therefore, you must tell Spin in the component manifest to run them using Wagi instead of 'default' Spin.  To do this, use the `executor` field in the `[component.trigger]` table:
+
+```toml
+[[component]]
+id = "wagi-test"
+source = "wagitest.wasm"
+[component.trigger]
+route = "/"
+executor = { type = "wagi" }
+```
+
+> If, for whatever reason, you want to highlight that a component uses the default Spin execution model, you can write `executor = { type = "spin" }`.  But this is the default and is rarely written out.
+
+Wagi supports non-default entry points, and allows you to pass an arguments string that a program can receive as if it had been passed on the command line. If you need these you can specify them in the `executor` table. For details, see the [Manifest Reference](manifest-reference#the-componenttrigger-table-for-http-applications).
+
+### Request Handling in Wagi
+
+Building a Wagi component in a particular programming language that can compile
+to `wasm32-wasi` does not require any special libraries — instead,
+[building Wagi components](https://github.com/deislabs/wagi/tree/main/docs) can
+be done by reading the HTTP request from the standard input and environment
+variables, and sending the HTTP response to the module's standard output.
+
+In pseudo-code, this is the minimum required in a Wagi component:
+
+- either the `content-media` or `location` headers must be set — this is done by
+printing its value to standard output
+- an empty line between the headers and the body
+- the response body printed to standard output:
+
+<!-- @nocpy -->
+
+```text
+print("content-type: text/html; charset=UTF-8\n\n");
+print("hello world\n");
+```
+
+Here is a working example, written in [Grain](https://grain-lang.org/),
+a programming language that natively targets WebAssembly and WASI but
+does not yet support the component model:
+
+```js
+import Process from "sys/process";
+import Array from "array";
+
+print("content-type: text/plain\n");
+
+// This will print all the Wagi env variables
+print("==== Environment: ====");
+Array.forEach(print, Process.env());
+
+// This will print the route path followed by each query
+// param. So /foo?bar=baz will be ["/foo", "bar=baz"].
+print("==== Args: ====");
+Array.forEach(print, Process.argv());
+```
+
+> You can find examples on how to build Wagi applications in
+> [the DeisLabs GitHub organization](https://github.com/deislabs?q=wagi&type=public&language=&sort=).
+
+### Wagi HTTP Environment Variables
+
+Wagi passes request metadata to the program through well-known environment variables. The key path-related request variables are:
+
+- `X_FULL_URL` - the full URL of the request —
+  `http://localhost:3000/test/hello/abc/def?foo=bar`
+- `PATH_INFO` - the path info, relative to both the base application path _and_
+  component route — in our example, where the base path is `/test`, and the
+  component route is `/hello`, this is `/abc/def`.
+- `X_MATCHED_ROUTE` - the base path and route pattern matched (including the
+  wildcard pattern, if applicable; this updates the header set in Wagi to
+  include the base path) — in our case `"/test/hello/..."`.
+- `X_RAW_COMPONENT_ROUTE` - the route pattern matched (including the wildcard
+  pattern, if applicable) — in our case `/hello/...`.
+- `X_COMPONENT_ROUTE` - the route path matched (stripped of the wildcard
+  pattern) — in our case `/hello`
+- `X_BASE_PATH` - the application base path — in our case `/test`.
+
+For details, and for a full list of all Wagi environment variables, see
+[the Wagi documentation](https://github.com/deislabs/wagi/blob/main/docs/environment_variables.md).
+
+## Exposing HTTP Triggers Using HTTPS
+
+When exposing HTTP triggers using HTTPS you must provide `spin up` with a TLS certificate and a private key. This can be achieved by either using trigger options (`--tls-cert` and `--tls-key`) when running the `spin up` command, or by setting environment variables (`SPIN_TLS_CERT` and `SPIN_TLS_KEY`) before running the `spin up` command.
+
+### Trigger Options
+
+The `spin up` command's `--tls-cert` and `--tls-key` trigger options provide a way for you to specify both a TLS certificate and a private key (whilst running the `spin up` command).
+
+The `--tls-cert` option specifies the path to the TLS certificate to use for HTTPS, if this is not set, normal HTTP will be used. The certificate should be in PEM format. 
+
+The `--tls-key` option specifies the path to the private key to use for HTTPS, if this is not set, normal HTTP will be used. The key should be in PKCS#8 format. For more information, please see the [Spin CLI Reference](../common/cli-reference#trigger-options).
+
+### Environment Variables
+
+The `spin up` command can also automatically use the `SPIN_TLS_CERT` and `SPIN_TLS_KEY` environment variables instead of the respective flags (`--tls-cert` and `--tls-key`):
+
+<!-- @nocpy -->
+
+```bash
+SPIN_TLS_CERT=<path/to/cert>
+SPIN_TLS_KEY=<path/to/key>
+```
+
+Once set, `spin up` will automatically use these explicitly set environment variables. For example, if using a Linux-based system, you can go ahead and use the `export` command to set the variables in your session (before you run the `spin up` command):
+
+<!-- @nocpy -->
+
+```bash
+export SPIN_TLS_CERT=<path/to/cert>
+export SPIN_TLS_KEY=<path/to/key>
+```

--- a/content/spin/v2/index.md
+++ b/content/spin/v2/index.md
@@ -1,0 +1,24 @@
+title = "Introducing Spin"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/index.md"
+
+---
+
+Spin is a framework for building and running event-driven microservice applications with WebAssembly (Wasm) components.
+
+Spin uses Wasm because it is **sandboxed, portable, and fast**.  Millisecond cold start times mean no need to keep applications "warm".
+
+Many languages have Wasm implementations, so **developers don't have to learn new languages or libraries**.
+
+Spin is **open source** and **built on standards**, meaning you can take your Spin applications anywhere.  There are Spin implementations for local development, for self-hosted servers, for Kubernetes, and for cloud-hosted services.
+
+**Want to see the kinds of things people are building with Spin?**  Check out what's [Built With Spin](/spin/see-what-people-have-built-with-spin)!
+
+Or dive into the documentation and get started:
+
+- [Take Spin for a spin](quickstart)
+- [Install Spin](install)
+- [Learn how to write Spin applications](writing-apps)
+- [Run your Spin applications in the Fermyon Cloud](/cloud/index)

--- a/content/spin/v2/install.md
+++ b/content/spin/v2/install.md
@@ -1,0 +1,325 @@
+title = "Install Spin"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+enable_shortcodes = true
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/install.md"
+keywords = "install"
+
+---
+- [Installing Spin](#installing-spin)
+- [Verifying the Release Signature](#verifying-the-release-signature)
+- [Building Spin From Source](#building-spin-from-source)
+- [Using Cargo to Install Spin](#using-cargo-to-install-spin)
+- [Installing Templates and Plugins](#installing-templates-and-plugins)
+  - [Templates](#templates)
+  - [Plugins](#plugins)
+- [Next Steps](#next-steps)
+
+## Installing Spin
+
+Spin runs on Linux (amd64 and arm64), macOS (Intel and Apple Silicon), and Windows (amd64):
+
+{{ tabs "os" }}
+
+{{ startTab "Linux"}}
+
+**Homebrew**
+
+You can manage your Spin installation via [Homebrew](https://brew.sh/). Homebrew automatically installs Spin templates and Spin plugins, and on uninstall, will prompt you to delete the directory where the templates and plugins were downloaded:
+
+Install the Fermyon tap, which Homebrew tracks, updates, and installs Spin from:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ brew tap fermyon/tap
+```
+
+Install Spin:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ brew install fermyon/tap/spin
+```
+
+> Note: `brew install spin` will **not** install Fermyon's Spin framework. Fermyon Spin is accessed from the `fermyon` tap, as shown above.
+
+**Installer script**
+
+Another option (other than brew) is to use our installer script. The installer script installs Spin along with a starter set of language templates and plugins:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ curl -fsSL https://developer.fermyon.com/downloads/install.sh | bash
+```
+
+Once you have run the installer script, it is highly recommended to add Spin to a folder, which is on your path, e.g.:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ sudo mv spin /usr/local/bin/
+```
+
+> If you have already installed Spin by building from source, and then install it via the installer, we recommend you remove the older source install by running `cargo uninstall spin-cli`  Otherwise the Cargo path may take precedence over the "install from binary" path, and commands may get the "wrong" version of Spin. Use `spin --version` to confirm the version on the PATH is the one you intend, or `which spin` to confirm the path it is found on.
+
+To install a specific version, you can pass arguments to the install script this way:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ curl -fsSL https://developer.fermyon.com/downloads/install.sh | bash -s -- -v v1.5.0
+```
+
+To install the canary version of spin, you should pass the argument `-v canary`. The canary version is always the latest commit to the main branch of Spin:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ curl -fsSL https://developer.fermyon.com/downloads/install.sh | bash -s -- -v canary
+```
+
+{{ blockEnd }}
+
+{{ startTab "macOS"}}
+
+**Homebrew**
+
+You can manage your Spin installation via [Homebrew](https://brew.sh/). Homebrew automatically installs Spin templates and Spin plugins, and on uninstall, will prompt you to delete the directory where the templates and plugins were downloaded:
+
+Install the Fermyon tap, which Homebrew tracks, updates, and installs Spin from:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ brew tap fermyon/tap
+```
+
+Install Spin:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ brew install fermyon/tap/spin
+```
+
+> Note: `brew install spin` will **not** install Fermyon's Spin framework. Fermyon Spin is accessed from the `fermyon` tap, as shown above.
+
+**Installer script**
+
+Another option (other than brew) is to use our installer script. The installer script installs Spin along with a starter set of language templates and plugins:
+
+The installer script also installs Spin along with a starter set of language templates and plugins:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ curl -fsSL https://developer.fermyon.com/downloads/install.sh | bash
+```
+
+Once you have run the installer script, it is highly recommended to add Spin to a folder, which is on your path, e.g.:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ sudo mv spin /usr/local/bin/
+```
+
+> If you have already installed Spin by building from source, and then install it via the installer, we recommend you remove the older source install by running `cargo uninstall spin-cli`  Otherwise the Cargo path may take precedence over the "install from binary" path, and commands may get the "wrong" version of Spin. Use `spin --version` to confirm the version on the PATH is the one you intend, or `which spin` to confirm the path it is found on.
+
+To install a specific version, you can pass arguments to the install script this way:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ curl -fsSL https://developer.fermyon.com/downloads/install.sh | bash -s -- -v v0.10.0
+```
+
+To install the canary version of spin, you should pass the argument `-v canary`. The canary version is always the latest commit to the main branch of Spin:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ curl -fsSL https://developer.fermyon.com/downloads/install.sh | bash -s -- -v canary
+```
+
+{{ blockEnd }}
+
+{{ startTab "Windows"}}
+
+If using Windows (PowerShell / cmd.exe), you can download <a href="https://github.com/fermyon/spin/releases/latest" class="spin-install" id="spin-install-windows">the Windows binary release of Spin</a>.
+
+Simply unzip the binary release and place the `spin.exe` in your system path.
+
+This does not install any Spin templates or plugins. For a starter list, see the [Installing Templates and Plugins section](#installing-templates-and-plugins).
+
+If you want to use WSL2 (Windows Subsystem for Linux 2), please follow the instructions for using Linux.
+
+{{ blockEnd }}
+{{ blockEnd }}
+
+## Verifying the Release Signature
+
+The Spin project [signs releases](https://github.com/fermyon/spin/blob/main/docs/content/sips/012-signing-spin-releases.md) using [Sigstore](https://docs.sigstore.dev/), a project that helps with signing software and _stores signatures in a tamper-resistant public log_. Consumers of Spin releases can validate the integrity of the package they downloaded by performing a validation of the artifact against the signature present in the public log. Specifically, users get two main guarantees by verifying the signature: 1) that the author of the artifact is indeed the one expected (i.e. the build infrastructure associated with the Spin project, at a given revision that can be inspected), and 2) that the content generated by the build infrastructure has not been tampered with.
+
+To verify the release signature, first [configure Cosign v2.0.0+](https://docs.sigstore.dev/system_config/installation/). This is the CLI tool that we will use validate the signature.
+The same directory where the installation script was run should also contain a signature of the Spin binary and the certificate used to perform the signature. The following command will perform the signature verification using the `cosign` CLI:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ cosign verify-blob \
+    --signature spin.sig \
+    --certificate crt.pem \
+    --certificate-identity https://github.com/fermyon/spin/.github/workflows/release.yml@refs/tags/<version> \
+    --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+    # --certificate-github-workflow-sha <optionally, pass the commit SHA associated with the tag> \
+    ./spin
+Verified OK
+```
+
+You can now move the Spin binary to the path knowing that it was indeed built by the infrastructure associated with the Spin project, and that it has not been tampered with since the build.
+
+## Building Spin From Source
+
+[Follow the contribution document](./contributing-spin.md) for a detailed guide on building Spin from source:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ git clone https://github.com/fermyon/spin
+$ cd spin && make build
+$ ./target/release/spin --help
+```
+
+> Please note: On a fresh Linux installation, you will also need the standard build toolchain (`gcc`, `make`, etc.), the SSL library headers, and on some distributions you may need `pkg-config`. For example, on Debian-like distributions, including Ubuntu, you can install the standard build toolchain with this command:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ sudo apt-get install build-essential libssl-dev pkg-config
+```
+
+This does not install any Spin templates or plugins. For a starter list, see the [Installing Templates and Plugins section](#installing-templates-and-plugins).
+
+## Using Cargo to Install Spin
+
+If you have [`cargo`](https://doc.rust-lang.org/cargo/getting-started/installation.html), you can clone the repo and install it to your path:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ git clone https://github.com/fermyon/spin -b v1.4.1
+$ cd spin
+$ rustup target add wasm32-wasi
+$ rustup target add wasm32-unknown-unknown
+$ cargo install --locked --path .
+$ spin --help
+```
+
+> Please note: Installing Spin v1.4.1 from source requires Rust 1.68.0 or newer. You can update Rust using the following command:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ rustup update
+```
+
+This does not install any Spin templates or plugins. For a starter list, see the [Installing Templates and Plugins section](#installing-templates-and-plugins).
+
+## Installing Templates and Plugins
+
+Spin has a variety of templates and plugins to make it easier to create Spin applications in your favorite programming language. [The install script](install#installing-spin) automatically installs a starter set of templates and plugins, namely templates from the Spin repository and JavaScript and Python toolchain plugins and the Fermyon Cloud plugin. 
+
+If you used a different installation method, we recommend you install these templates and plugins manually, as follows.
+
+### Templates
+
+Spin:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin templates install --git https://github.com/fermyon/spin --upgrade
+```
+
+Spin Python SDK
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin templates install --git https://github.com/fermyon/spin-python-sdk --upgrade
+```
+
+Spin JS SDK:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin templates install --git https://github.com/fermyon/spin-js-sdk --upgrade
+```
+
+To list installed templates, run:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin templates list
+```
+
+For more information please read the [managing templates](https://developer.fermyon.com/spin/managing-templates) section of the documentation.
+
+### Plugins
+
+First update the local cache by running the `spin plugins update` command:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin plugins update
+```
+
+Then install plugins by name.
+
+Python:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin plugins install py2wasm --yes
+```
+
+Javascript:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin plugins install js2wasm --yes
+```
+
+Fermyon Cloud:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin plugins install cloud --yes
+```
+
+To list installed and available plugins, run:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin plugins list
+```
+
+For more information, please visit the [managing plugins](https://developer.fermyon.com/spin/managing-plugins) section of the documentation.
+
+## Next Steps
+
+- [Take Spin for a spin](./quickstart.md)
+- Learn about how to [write a Spin application](writing-apps)
+- Try the [Fermyon Cloud](/cloud/quickstart)

--- a/content/spin/v2/javascript-components.md
+++ b/content/spin/v2/javascript-components.md
@@ -1,0 +1,417 @@
+title = "Building Spin Components in JavaScript"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+enable_shortcodes = true
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/javascript-components.md"
+
+---
+- [Installing Templates](#installing-templates)
+- [Structure of a JS/TS Component](#structure-of-a-jsts-component)
+- [Building and Running the Template](#building-and-running-the-template)
+- [A Quick Note About NPM Scripts](#a-quick-note-about-npm-scripts)
+- [HTTP Components](#http-components)
+- [Sending Outbound HTTP Requests](#sending-outbound-http-requests)
+- [Storing Data in Redis From JS/TS Components](#storing-data-in-redis-from-jsts-components)
+- [Routing in a Component](#routing-in-a-component)
+- [Storing Data in the Spin Key-Value Store](#storing-data-in-the-spin-key-value-store)
+- [Storing Data in SQLite](#storing-data-in-sqlite)
+- [Storing Data in MySQL and PostgreSQL Relational Databases](#storing-data-in-mysql-and-postgresql-relational-databases)
+- [AI Inferencing From JS/TS Components](#ai-inferencing-from-jsts-components)
+- [Using External NPM Libraries](#using-external-npm-libraries)
+  - [Suggested Libraries for Common Tasks](#suggested-libraries-for-common-tasks)
+- [Caveats](#caveats)
+
+With JavaScript being a very popular language, Spin provides support for building components with it using the experimental SDK. The development of the JavaScript SDK is continually being worked on to improve user experience and add features. 
+
+> This guide assumes you have Spin installed. If this is your first encounter with Spin, please see the [Quick Start](quickstart), which includes information about installing Spin with the JavaScript templates, installing required tools, and creating JavaScript and TypeScript applications.
+
+> This guide assumes you are familiar with the JavaScript programming language,
+> but if you are just getting started, be sure to check [the MDN guide](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide).
+
+> All examples from this page can be found in [the JavaScript SDK repository on GitHub](https://github.com/fermyon/spin-js-sdk/tree/main/examples).
+
+In order to compile JavaScript programs to Spin components, you also need to install a Spin plugin `js2wasm` using the following command:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin plugin update
+$ spin plugin install js2wasm
+```
+
+## Installing Templates
+
+The JavaScript/TypeScript templates can be installed from [spin-js-sdk repository](https://github.com/fermyon/spin-js-sdk/tree/main/) using the following command:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin templates install --git https://github.com/fermyon/spin-js-sdk --update
+```
+
+which will install the `http-js` and `http-ts` templates:
+
+<!-- @nocpy -->
+
+```text
+Copying remote template source
+Installing template http-ts...
+Installing template http-js...
+Installed 2 template(s)
+
++-------------------------------------------------+
+| Name      Description                           |
++=================================================+
+| http-js   HTTP request handler using Javascript |
+| http-ts   HTTP request handler using Typescript |
++-------------------------------------------------+
+```
+
+## Structure of a JS/TS Component
+
+A new JS/TS component can be created using the following command:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin new http-ts hello-world --accept-defaults
+```
+
+This creates a directory of the following structure:
+
+<!-- @nocpy -->
+
+```text
+hello-world/
+├── package.json
+├── package-lock.json
+├── README.md
+├── spin.toml
+├── src
+│   └── index.ts
+├── tsconfig.json
+└── webpack.config.js
+```
+
+The source for the component is present in `src/index.ts`. [Webpack](https://webpack.js.org) is used to bundle the component into a single `.js` file which will then be compiled to a `.wasm` module using the `js2wasm` plugin.
+
+## Building and Running the Template
+
+First, the dependencies for the template need to be installed and then bundled into a single JavaScript file using the following commands:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ cd hello-world
+$ npm install
+$ npm run build
+```
+
+Once a Spin compatible module is created, it can be run using:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin up
+```
+
+---
+
+## A Quick Note About NPM Scripts
+
+Please note that using pre-built NPM scripts can have different effects on different Operating Systems (OSs). Let's take the `npm run build` command (like [the one in the spin-js-sdk](https://github.com/fermyon/spin-js-sdk/blob/main/examples/javascript/hello_world/package.json)) as an example:
+
+<!-- @nocpy -->
+
+```bash
+"scripts": {
+    "build": "npx webpack --mode=production && mkdir -p target && spin js2wasm -o target/spin-http-js.wasm dist/spin.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+```
+
+The `npm run build` command will work on Linux and macOS. However, on Windows it will create both a `-p` directory and a `target` directory.
+
+On Linux/Unix systems, the `-p` option in the `mkdir` command is designed to prevent an error from occuring in the event that the `target` directory already exists. However, on Windows systems, npm (by default) uses cmd.exe which does not recognize the `-p` option, regarding its `mkdir` command.
+
+If you run `npm run build` on Windows (more than once) the following error will be encountered:
+
+<!-- @nocpy -->
+
+```bash
+A subdirectory or file -p already exists
+A Subdirectory or file target already exists
+```
+
+If any errors, as described above, occur please consider one of the two following options:
+
+a) Configure your instance of `npm` to use bash (by using the `script-shell` configuration setting): 
+
+<!-- @selectiveCpy -->
+
+```bash
+$ npm config set script-shell "C:\\Program Files\\git\\bin\\bash.exe"
+```
+
+b) Run the separate parts of the `build` manually, to suite your needs (OS syntax requirements):
+
+<!-- @selectiveCpy -->
+
+```bash
+$ npx webpack --mode=production
+$ spin js2wasm -o target/spin-http-js.wasm dist/spin.js
+```
+
+---
+
+## HTTP Components
+
+In Spin, HTTP components are triggered by the occurrence of an HTTP request, and
+must return an HTTP response at the end of their execution. Components can be
+built in any language that compiles to WASI, and Javascript/TypeScript has improved support
+for writing Spin components with the Spin JS/TS SDK.
+
+> Make sure to read [the page describing the HTTP trigger](./http-trigger.md) for more
+> details about building HTTP applications.
+
+Building a Spin HTTP component using the JS/TS SDK means writing a single function
+that takes an HTTP request as a parameter, and returns an HTTP response — below
+is a complete implementation for such a component in TypeScript:
+
+```Javascript
+import { HandleRequest, HttpRequest, HttpResponse } from "@fermyon/spin-sdk"
+
+const encoder = new TextEncoder()
+
+export const handleRequest: HandleRequest = async function (request: HttpRequest): Promise<HttpResponse> {
+
+    return {
+        status: 200,
+        headers: {"foo": "bar"},
+        body: encoder.encode("Hello from JS-SDK").buffer
+    }
+}
+```
+
+The important things to note in the implementation above:
+
+- the `handleRequest` function is the
+  entry point for the Spin component.
+- the component returns `HttpResponse`.
+
+Please note: If you need to decode a request body (which is either an `ArrayBuffer` or `ArrayBufferView`) into plain text or JSON please consider using the following:
+
+<!-- @nocpy -->
+
+```javascript
+// Create new TextDecoder instance
+let decoder = new TextDecoder()
+
+// Then decode request body to text
+let text = decoder.decode(request.body)
+
+// Or decode request body to JSON
+let text = JSON.parse(decoder.decode(request.body))
+```
+
+## Sending Outbound HTTP Requests
+
+If allowed, Spin components can send outbound HTTP requests.
+Let's see an example of a component that makes a request to
+[an API that returns random animal facts](https://random-data-api.fermyon.app/animals/json) and
+inserts a custom header into the response before returning:
+
+```javascript
+const encoder = new TextEncoder("utf-8")
+const decoder = new TextDecoder("utf-8")
+
+export async function handleRequest(request) {
+    const animalFact = await fetch("https://random-data-api.fermyon.app/animals/json")
+
+    const animalFactBody = decoder.decode(await animalFact.arrayBuffer() || new Uint8Array())
+
+    const body = `Here's an animal fact: ${animalFactBody}\n`
+
+    return {
+        status: 200,
+        headers: { "foo": "bar" },
+        body: encoder.encode(body).buffer
+    }
+}
+```
+
+Before we can execute this component, we need to add the `random-data-api.fermyon.app`
+domain to the application manifest `allowed_http_hosts` list containing the list of
+domains the component is allowed to make HTTP requests to:
+
+<!-- @nocpy -->
+
+```toml
+# spin.toml
+spin_manifest_version = "1"
+authors = ["Fermyon Engineering <engineering@fermyon.com>"]
+name = "spin-http-js"
+trigger = { type = "http", base = "/" }
+version = "1.0.0"
+
+[variables]
+object = { default = "teapot" }
+
+[[component]]
+id = "hello"
+source = "target/spin-http-js.wasm"
+allowed_http_hosts = ["random-data-api.fermyon.app"]
+[component.trigger]
+route = "/hello"
+[component.build]
+command = "npm run build"
+```
+
+The component can be built using the `spin build` command. Running the application using `spin up --file spin.toml` will start the HTTP
+listener locally (by default on `localhost:3000`), and our component can
+now receive requests in route `/hello`:
+
+<!-- @selectiveCpy -->
+
+```text
+$ curl -i localhost:3000/hello
+HTTP/1.1 200 OK
+date = "2023-11-02T16:00:00Z"
+content-type: application/json; charset=utf-8
+content-length: 185
+server: spin/0.1.0
+
+Here's an animal fact: {"timestamp":1684299253331,"fact":"Reindeer grow new antlers every year"}
+```
+
+> Without the `allowed_http_hosts` field populated properly in `spin.toml`,
+> the component would not be allowed to send HTTP requests, and sending the
+> request would result in a "Destination not allowed" error.
+
+> You can set `allowed_http_hosts = ["insecure:allow-all"]` if you want to allow
+> the component to make requests to any HTTP host. This is **NOT** recommended
+> for any production or publicly-accessible application.
+
+We just built a WebAssembly component that sends an HTTP request to another
+service, manipulates that result, then responds to the original request.
+This can be the basis for building components that communicate with external
+databases or storage accounts, or even more specialized components like HTTP
+proxies or URL shorteners.
+
+---
+
+## Storing Data in Redis From JS/TS Components
+
+> You can find a complete example for using outbound Redis from an HTTP component
+> in the [spin-js-sdk repository on GitHub](https://github.com/fermyon/spin-js-sdk/blob/main/examples/typescript/outbound_redis/src/index.ts).
+
+Using the Spin's JS SDK, you can use the Redis key/value store and to publish messages to Redis channels.
+
+Let's see how we can use the JS/TS SDK to connect to Redis:
+
+```javascript
+import { HandleRequest, HttpRequest, HttpResponse, Redis } from "@fermyon/spin-sdk"
+
+const encoder = new TextEncoder()
+const decoder = new TextDecoder()
+
+const redisAddress = "redis://localhost:6379/"
+
+export const handleRequest: HandleRequest = async function (request: HttpRequest): Promise<HttpResponse> {
+
+    Redis.incr(redisAddress, "test")
+    Redis.incr(redisAddress, "test")
+
+    console.log(decoder.decode(Redis.get(redisAddress, "test")))
+
+    Redis.set(redisAddress, "test-set", encoder.encode("This is a test").buffer)
+
+    console.log(decoder.decode(Redis.get(redisAddress, "test-set")))
+
+    Redis.publish(redisAddress, "test", encoder.encode("This is a test").buffer)
+
+    return {
+        status: 200,
+        headers: {"foo": "bar"},
+        body: encoder.encode("Hello from JS-SDK").buffer
+    }
+}
+```
+
+This HTTP component demonstrates fetching a value from Redis by key, setting a key with a value, and publishing a message to a Redis channel. The component is triggered by an HTTP request served on the route configured in the `spin.toml`:
+
+> When using Redis databases hosted on the internet (i.e) not on localhost, the `redisAddress` must be of the format "redis://\<USERNAME\>:\<PASSWORD\>@\<REDIS_URL\>" (e.g) `redis://myUsername:myPassword@redis-database.com`
+
+## Routing in a Component
+
+The JavaScript/TypeScript SDK provides a router that makes it easier to handle routing within a component. The router is based on [`itty-router`](https://www.npmjs.com/package/itty-router). An additional function `handleRequest` has been implemented in the router to allow passing in the Spin HTTP request directly. For a more complete documentation on the route, checkout the documentationa at [itty-router](https://github.com/kwhitley/itty-router). An example usage of the router is given below:
+
+```javascript
+import { HandleRequest, HttpRequest, HttpResponse, Router} from "@fermyon/spin-sdk"
+
+let router = Router()
+
+function handleDefaultRoute() {
+  return {
+    status: 200,
+      headers: { "content-type": "text/html" },
+    body: "Hello from Default Route"
+  }
+}
+
+function handleHomeRoute(id: string) {
+  return {
+    status: 200,
+      headers: { "content-type": "text/html" },
+    body: "Hello from Home Route with id:" + id
+  }
+}
+
+router.get("/", handleDefaultRoute)
+router.get("/home/:id", ({params}) => handleHomeRoute(params.id))
+
+export const handleRequest: HandleRequest = async function(request: HttpRequest): Promise<HttpResponse> {
+    return await router.handleRequest(request)
+}
+```
+
+## Storing Data in the Spin Key-Value Store
+
+Spin has a key-value store built in. For information about using it from TypeScript/JavaScript, see [the key-value store tutorial](kv-store-tutorial).
+
+## Storing Data in SQLite
+
+For more information about using SQLite from TypeScript/Javascript, see [SQLite storage](sqlite-api-guide).
+
+## Storing Data in MySQL and PostgreSQL Relational Databases
+
+For more information about using relational databases from TypeScript/JavaScript, see [Relational Databases](rdbms-storage).
+
+## AI Inferencing From JS/TS Components
+
+For more information about using Serverless AI from JS/TS, see the [Serverless AI](serverless-ai-api-guide) API guide.
+
+## Using External NPM Libraries
+
+> Not all the NPM packages are guaranteed to work with the SDK as it is not fully compatible with the browser or `Node.js`. It implements only a subset of the API.
+
+Some NPM packages can be installed and used in the component. If a popular library does not work, please open an issue/feature request in the [spin-js-sdk repository](https://github.com/fermyon/spin-js-sdk/issues).
+
+### Suggested Libraries for Common Tasks
+
+These are some of the suggested libraries that have been tested and confired to work with the SDK for common tasks.
+
+{{ details "HTML parsers" "- [node-html-parser](https://www.npmjs.com/package/node-html-parser)" }}
+
+{{ details "Parsing formdata" "- [parse-multipart-data](https://www.npmjs.com/package/parse-multipart-data)" }} 
+
+{{ details "Runtime schema validation" "- [zod](https://www.npmjs.com/package/zod)" }} 
+
+{{ details "Unique ID generator" "- [nanoid](https://www.npmjs.com/package/nanoid)\n- [ulidx](https://www.npmjs.com/package/ulidx)\n- [uuid](https://www.npmjs.com/package/uuid)" }} 
+
+## Caveats
+
+- All `spin-sdk` related functions and methods (like `Config`, `Redis`, `Mysql`, `Pg`, `Kv` and `Sqlite`) can be called only inside the `handleRequest` function. This includes the usage of `fetch`. Any attempts to use it outside the function will lead to an error. This is due to Wizer using only Wasmtime to execute the script at build time, which does not include any Spin SDK support.
+- Only a subset of the browser and `Node.js` APIs are implemented.
+- The support for Crypto  module is limited. The methods currently supported are `crypto.getRandomValues`, `crypto.subtle.digest`, `cryto.createHash` and `crypto.createHmac`

--- a/content/spin/v2/key-value-store-tutorial.md
+++ b/content/spin/v2/key-value-store-tutorial.md
@@ -1,0 +1,534 @@
+title = "Spin Key-Value Store"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+enable_shortcodes = true
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/key-value-store-tutorial.md"
+
+---
+- [Key Value Store With Spin Applications](#key-value-store-with-spin-applications)
+- [Tutorial Prerequisites](#tutorial-prerequisites)
+- [Creating a New Spin Application](#creating-a-new-spin-application)
+- [Configuration](#configuration)
+  - [The Spin TOML File](#the-spin-toml-file)
+- [Write Code to Save and Load Data](#write-code-to-save-and-load-data)
+  - [The Spin SDK Version](#the-spin-sdk-version)
+- [Quick Overview - Video](#quick-overview---video)
+- [Source Code](#source-code)
+- [Building and Deploying Your Spin Application](#building-and-deploying-your-spin-application)
+- [Storing and Retrieving Data From Your Default Key/Value Store](#storing-and-retrieving-data-from-your-default-keyvalue-store)
+- [Conclusion](#conclusion)
+- [Next Steps](#next-steps)
+
+## Key Value Store With Spin Applications
+
+Spin applications are best suited for event-driven, stateless workloads that have low-latency requirements. Keeping track of the application's state (storing information) is an integral part of any useful product or service. For example, users (and the business) will expect to store and load data/information at all times during an application’s execution. [Spin](https://www.fermyon.com/blog/spin-v09) has support for applications that need data in the form of key/value pairs and are satisfied by a Basically Available, Soft State, and Eventually Consistent (BASE) model. Workload examples include general value caching, session caching, counters, and serialized application state. In this tutorial, you will learn how to do the following:
+
+* Create a Spin application with `spin new`
+* Use the key value store SDK to get, set, and list key value pairs
+* Configure your application manifest (`spin.toml`) to use the default key value store
+* Run your key value store Spin application locally with `spin up`
+
+## Tutorial Prerequisites
+
+First, follow [this guide](./install.md) to install Spin. To ensure you have the correct version, you can check with this command:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin --version
+```
+
+> Please ensure you're on version 1.0 or newer.
+
+## Creating a New Spin Application
+
+Let's create a Spin application that will send and retreive data from a key value store. To make things easy, we'll start from a template using the following commands ([learn more](/spin/quickstart#creating-a-new-spin-application-from-a-template)):
+
+{{ tabs "sdk-type" }}
+
+{{ startTab "Rust"}}
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin new http-rust spin-key-value
+
+# Reference: https://github.com/fermyon/spin/tree/main/examples/rust-key-value
+```
+
+{{ blockEnd }}
+
+{{ startTab "TypeScript" }}
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin new http-ts spin-key-value
+
+# Reference: https://github.com/fermyon/spin-js-sdk/tree/main/examples/typescript/spin_kv
+```
+
+{{ blockEnd }}
+
+{{ startTab "TinyGo" }}
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin new http-go spin-key-value
+
+# Reference: https://github.com/fermyon/spin/tree/main/examples/tinygo-key-value
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+## Configuration
+
+Good news - Spin will take care of setting up your key value store. However, in order to make sure your Spin application has permission to access the key value store, you must add the `key_value_stores = ["default"]` line in the `[[component]]` area of the `spin.toml` file. This line is necessary to communicate to Spin that a given component has access to the default key value store. A newly scaffolded Spin application will not have this line; you will need to add it. 
+
+>> Tip: You can choose between various store implementations by modifying [the runtime configuration](dynamic-configuration.md#key-value-store-runtime-configuration). The default implementation uses [SQLite](https://www.sqlite.org/index.html) within the Spin framework.
+
+Each Spin application's `key_value_stores` instances are implemented on a per-component basis across the entire Spin application. This means that within a multi-component Spin application (which has the same `key_value_stores = ["default"]` configuration line), each `[[component]]` will access that same data store. If one of your application's components creates a new key/value pair, another one of your application's components can update/overwrite that initial key/value after the fact.
+
+### The Spin TOML File
+
+We will give our components access to the key value store by adding the `key_value_stores = ["default"]` in the `[[component manifest]]` as shown below:
+
+{{ tabs "sdk-type" }}
+
+{{ startTab "Rust"}}
+
+```toml
+spin_manifest_version = "1"
+authors = ["Fermyon Engineering <engineering@fermyon.com>"]
+description = "A simple application that exercises key-value storage."
+name = "spin-key-value"
+trigger = { type = "http", base = "/test" }
+version = "0.1.0"
+
+[[component]]
+id = "spin-key-value"
+source = "target/wasm32-wasi/release/spin-key-value.wasm"
+allowed_http_hosts = []
+# Gives this component access to the default key value store
+key_value_stores = ["default"]
+[component.trigger]
+route = "/..."
+[component.build]
+command = "cargo build --target wasm32-wasi --release"
+```
+
+{{ blockEnd }}
+
+{{ startTab "TypeScript" }}
+
+```toml
+spin_manifest_version = "1"
+authors = ["Fermyon Engineering <engineering@fermyon.com>"]
+description = "A simple application that exercises key-value storage."
+name = "spin-key-value"
+trigger = { type = "http", base = "/test" }
+version = "0.1.0"
+
+[[component]]
+id = "spin-key-value"
+source = "target/spin-key-value.wasm"
+exclude_files = ["**/node_modules"]
+# Gives this component access to the default key value store
+key_value_stores = ["default"]
+[component.trigger]
+route = "/..."
+[component.build]
+command = "npm run build"
+```
+
+{{ blockEnd }}
+
+{{ startTab "TinyGo" }}
+
+```toml
+spin_manifest_version = "1"
+authors = ["Fermyon Engineering <engineering@fermyon.com>"]
+description = "A simple application that exercises key-value storage."
+name = "spin-key-value"
+trigger = { type = "http", base = "/test" }
+version = "1.0.0"
+
+[[component]]
+id = "spin-key-value"
+source = "main.wasm"
+# Gives this component access to the default key value store
+key_value_stores = ["default"]
+[component.trigger]
+route = "/..."
+[component.build]
+command = "tinygo build -target=wasi -gc=leaking -no-debug -o main.wasm main.go"
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+## Write Code to Save and Load Data
+
+In this section, we use the Spin SDK to open and persist our application's data inside our default key/value store. This is a special store that every environment running Spin applications will make available for their application. 
+
+> Please note: Spin applications written in Rust can [store and retrieve Rust data structures](/spin/rust-components#storing-data-in-the-spin-key-value-store) in the application's data store.
+
+### The Spin SDK Version
+
+If you have an existing application and would like to try out the key/value feature, please check the Spin SDK reference in your existing application's configuration. For example, if using Rust please check your application's `Cargo.toml` file. If it refers to version 0.8 or earlier then update the Spin SDK reference to match your upgraded version of Spin:
+
+<!-- @nocpy -->
+
+```toml
+# The Spin SDK.
+spin-sdk = { git = "https://github.com/fermyon/spin", tag = "v0.10.0" }
+```
+
+Similarly an application created using the `http-go` template might need the reference to the Spin SDK in its `go.mod` file updated to look like the following:
+
+<!-- @nocpy -->
+
+```bash
+module github.com/http_go
+
+go 1.17
+
+require github.com/fermyon/spin/sdk/go v0.10.0
+```
+
+The same applies to other programming languages and their respective configuration. This information is provided to prevent you from experiencing an error such as the following:
+
+<!-- @nocpy -->
+
+```bash
+unresolved import spin_sdk::key_value
+key_value::{Error, Store}
+^^^^^^^^^ could not find `key_value` in `spin_sdk`
+```
+
+## Quick Overview - Video
+
+Before we get into the source code, let's watch a quick overview of the new key/value store feature.
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/qNBnVA2pkkY" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
+## Source Code
+
+Now let's use the Spin SDK to:
+- add new data
+- check that the new data exists
+- retrieve that data
+- delete data
+- check the data has been removed
+
+{{ tabs "sdk-type" }}
+
+{{ startTab "Rust"}}
+
+```rust
+use anyhow::Result;
+use http::{Method, StatusCode};
+use spin_sdk::{
+    http::{Request, Response},
+    http_component,
+    key_value::{Error, Store},
+};
+
+#[http_component]
+fn handle_request(req: Request) -> Result<Response> {
+    // Open the default key-value store
+    let store = Store::open_default()?;
+
+    let (status, body) = match req.method() {
+        &Method::POST => {
+            // Add the request (URI, body) tuple to the store
+            store.set(req.uri().path(), req.body().as_deref().unwrap_or(&[]))?;
+            (StatusCode::OK, None)
+        }
+        &Method::GET => {
+            // Get the value associated with the request URI, or return a 404 if it's not present
+            match store.get(req.uri().path()) {
+                Ok(value) => (StatusCode::OK, Some(value.into())),
+                Err(Error::NoSuchKey) => (StatusCode::NOT_FOUND, None),
+                Err(error) => return Err(error.into()),
+            }
+        }
+        &Method::DELETE => {
+            // Delete the value associated with the request URI, if present
+            store.delete(req.uri().path())?;
+            (StatusCode::OK, None)
+        }
+        &Method::HEAD => {
+            // Like GET, except do not return the value
+            match store.exists(req.uri().path()) {
+                Ok(true) => (StatusCode::OK, None),
+                Ok(false) => (StatusCode::NOT_FOUND, None),
+                Err(error) => return Err(error.into()),
+            }
+        }
+        // No other methods are currently supported
+        _ => (StatusCode::METHOD_NOT_ALLOWED, None),
+    };
+
+    Ok(http::Response::builder().status(status).body(body)?)
+}
+```
+
+{{ blockEnd }}
+
+{{ startTab "TypeScript"}}
+
+```typescript
+import { HandleRequest, HttpRequest, HttpResponse, Kv } from "@fermyon/spin-sdk"
+
+const encoder = new TextEncoder()
+const decoder = new TextDecoder()
+
+export const handleRequest: HandleRequest = async function (request: HttpRequest): Promise<HttpResponse> {
+
+  let store = Kv.openDefault()
+  let status = 200
+  let body
+
+  switch (request.method) {
+    case "POST":
+      store.set(request.uri, request.body || (new Uint8Array()).buffer)
+      break;
+    case "GET":
+      let val
+      try {
+        val = store.get(request.uri)
+        body = decoder.decode(val)
+      } catch (error) {
+        status = 404
+      }
+      break;
+    case "DELETE":
+      store.delete(request.uri)
+      break;
+    case "HEAD":
+      if (!store.exists(request.uri)) {
+        status = 404
+      }
+      break;
+    default:
+  }
+
+  return {
+    status: status,
+    body: body
+  }
+}
+```
+
+{{ blockEnd }}
+
+{{ startTab "TinyGo" }}
+
+```go
+package main
+
+import (
+	"io"
+	"net/http"
+
+	spin_http "github.com/fermyon/spin/sdk/go/http"
+	"github.com/fermyon/spin/sdk/go/key_value"
+)
+
+func init() {
+	// handler for the http trigger
+	spin_http.Handle(func(w http.ResponseWriter, r *http.Request) {
+		store, err := key_value.Open("default")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		defer key_value.Close(store)
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		switch r.Method {
+		case http.MethodPost:
+			err := key_value.Set(store, r.URL.Path, body)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			value, err := key_value.Get(store, r.URL.Path)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+
+			w.WriteHeader(http.StatusOK)
+			w.Write(value)
+		case http.MethodDelete:
+			err := key_value.Delete(store, r.URL.Path)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+
+			w.WriteHeader(http.StatusOK)
+		case http.MethodHead:
+			exists, err := key_value.Exists(store, r.URL.Path)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+
+			if exists {
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+
+			w.WriteHeader(http.StatusNotFound)
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	})
+}
+
+func main() {}
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+## Building and Deploying Your Spin Application
+
+Now let's build and deploy our Spin Application locally. Run the following command to build your application: 
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin build
+```
+
+## Storing and Retrieving Data From Your Default Key/Value Store
+
+Once you have completed this minimal configuration and deployed your application, data will be persisted across requests. Let's begin by creating a `POST` request that stores a JSON key/value object:
+
+<!-- @selectiveCpy -->
+
+```bash
+# Create a new POST request and set the key/value pair of foo:bar
+$ curl -X POST localhost:3000/test -H 'Content-Type: application/json' -d '{"foo":"bar"}' -v
+
+Trying 127.0.0.1:3000...
+Connected to localhost (127.0.0.1) port 3000
+POST /test HTTP/1.1
+Host: localhost:3000
+Content-Type: application/json
+HTTP/1.1 200 OK
+```
+
+We can now use a `HEAD` request to confirm that our component is holding data for us. Essentially, all we want to see here is a `200 OK` response when calling our components endpoint (`/test`). Let's give it a try:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ curl -I HEAD localhost:3000/test -v                                                     
+
+Trying 127.0.0.1:3000...
+* Connected to localhost (127.0.0.1) port 3000
+HEAD /test HTTP/1.1
+Host: localhost:3000
+HTTP/1.1 200 OK
+```
+
+Perfect, `200 OK`. Now, let's create a `GET` request that fetches the data from our component:
+
+<!-- @selectiveCpy -->
+
+```bash
+# Create a GET request and fetch the key/value that we stored in the previous request
+$ curl -X GET localhost:3000/test -v
+
+Trying 127.0.0.1:3000...
+Connected to localhost (127.0.0.1) port 3000
+GET /test HTTP/1.1
+Host: localhost:3000
+HTTP/1.1 200 OK
+{
+    "foo": "bar"
+}
+```
+
+Great!, the above command successfully returned our data as intended:
+
+<!-- @nocpy -->
+
+```json
+{
+    "foo": "bar"
+}
+```
+
+Lastly, we show how to create a `DELETE` request that removes the data for this specific component altogether:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ curl -X DELETE localhost:3000/test -v
+
+Trying 127.0.0.1:3000...
+Connected to localhost (127.0.0.1) port 3000
+DELETE /test HTTP/1.1
+Host: localhost:3000
+HTTP/1.1 200 OK
+```
+
+Note how all of the above commands returned `200 OK` responses. In these examples, we were able to `POST`, `HEAD` (check to see if data exists), `GET` and also `DELETE` data from our component.
+
+Interestingly there is one more request we can re-run before wrapping up this tutorial. If no data exists in the component's endpoint of `/test` (which is technically the case now that we have sent the `DELETE` request) the `HEAD` request should correctly return `404 Not Found`. You can consider this a type of litmus test; let's try it out:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ curl -I HEAD localhost:3000/test -v
+
+Trying 127.0.0.1:3000...
+Connected to localhost (127.0.0.1) port 3000
+HEAD /test HTTP/1.1
+Host: localhost:3000
+HTTP/1.1 404 Not Found
+```
+
+As we can see above, there is currently no data found at the `/test` endpoint of our application.
+
+## Conclusion
+
+We want to get feedback on the ergonomics of the key value API. We are curious about what new APIs you would suggest we implement and are also interested in learning about what backing stores you would like to see.
+
+## Next Steps
+
+You can read the [improvement proposal for key/value support](https://github.com/fermyon/spin/blob/main/docs/content/sips/010-key-value.md) as well as the implementation for the [current feature](https://github.com/fermyon/spin/pull/1035). Please feel free to ask questions and also share your thoughts in [our Discord community](https://discord.gg/AAFNfS7NGf).
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "VideoObject",
+  "name": "Key/Value Store - Spin 0.10.0",
+  "description": "Overview of the key/value store in Spin v0.10.0",
+  "thumbnailUrl": "https://www.fermyon.com/static/image/twc-spin.png",
+  "uploadDate": "2023-02-25T08:00:00+00:00",
+  "duration": "PT3M16S",
+  "contentUrl": "https://www.youtube.com/watch?v=qNBnVA2pkkY",
+  "embedUrl": "https://www.youtube.com/embed/qNBnVA2pkkY"
+}
+</script>

--- a/content/spin/v2/kubernetes.md
+++ b/content/spin/v2/kubernetes.md
@@ -1,0 +1,492 @@
+title = "Spin on Kubernetes"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+enable_shortcodes = true
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/kubernetes.md"
+
+---
+- [Why Use Spin With Kubernetes?](#why-use-spin-with-kubernetes)
+- [How Does It Work?](#how-does-it-work)
+- [Next Steps](#next-steps)
+- [Setup Azure AKS for Spin](#setup-azure-aks-for-spin)
+  - [Introduction](#introduction)
+  - [Known Limitations](#known-limitations)
+  - [Setup](#setup)
+- [Setup Docker Desktop for Spin](#setup-docker-desktop-for-spin)
+  - [Introduction](#introduction-1)
+  - [Known Limitations](#known-limitations-1)
+  - [Setup](#setup-1)
+  - [Using Docker Desktop With Spin](#using-docker-desktop-with-spin)
+- [Setup K8s for Spin](#setup-k8s-for-spin)
+  - [Introduction](#introduction-2)
+  - [Known Limitations](#known-limitations-2)
+  - [Setup](#setup-2)
+- [Setup Generic Kubernetes for Spin](#setup-generic-kubernetes-for-spin)
+  - [Introduction](#introduction-3)
+  - [Known Limitations](#known-limitations-3)
+  - [Setup](#setup-3)
+- [Run a Spin Workload on Kubernetes](#run-a-spin-workload-on-kubernetes)
+  - [Introduction](#introduction-4)
+  - [Concepts](#concepts)
+  - [Requirements](#requirements)
+  - [Install Plugin](#install-plugin)
+  - [Workflow](#workflow)
+  - [Detailed Explanation of Steps](#detailed-explanation-of-steps)
+    - [Spin New](#spin-new)
+    - [Spin Build](#spin-build)
+    - [Spin K8s Scaffold](#spin-k8s-scaffold)
+    - [Spin K8s Build](#spin-k8s-build)
+    - [Spin K8s Push](#spin-k8s-push)
+    - [Spin K8s Deploy](#spin-k8s-deploy)
+    - [Spin K8s Getsvc](#spin-k8s-getsvc)
+
+## Why Use Spin With Kubernetes?
+
+In addition to `spin up` Fermyon also offers Fermyon Cloud to deploy spin apps into production, so why use Spin with Kubernetes? For users that have made existing investments into Kubernetes or have requirements that their applications stay within certain clouds, not be on shared infrastructure, or run on-premise, Kubernetes provides a robust solution.
+
+## How Does It Work?
+
+For Kubernetes to run Spin workloads, it needs to be taught about a new runtime class. To do this, there is a shim for containerd. This compiles to a binary that must be placed on the Kubernetes nodes that host Shim pods. That binary then needs to be registered with Kubernetes as a new RuntimeClass. After that, wasm containers can be deployed to Kubernetes using the Spin k8s plugin.
+
+## Next Steps
+
+- Use the appropriate guide below to configure Kubernetes cluster for Spin Apps.
+- Follow the instructions in the “Run a Spin Workload in Kubernetes” guide below.
+
+{{ tabs "platforms" }}
+
+{{ startTab "Azure AKS"}}
+
+## Setup Azure AKS for Spin
+
+### Introduction
+
+Azure AKS provides a straightforward and officially [documented](https://learn.microsoft.com/en-us/azure/aks/use-wasi-node-pools) way to use Spin with AKS.
+
+### Known Limitations
+
+- Node pools default to 100 max pods. When a node pool is configured it can be increased up to 250 pods.
+- Each Pod will constantly run its own HTTP listener, which adds overhead vs Fermyon Cloud.
+- You can run containers and wasm modules on the same node, but you can't run containers and wasm modules on the same pod.
+- The WASM/WASI node pools can't be used for system node pool.
+- The *os-type* for WASM/WASI node pools must be Linux.
+- You can't use the Azure portal to create WASM/WASI node pools.
+- AKS uses an older version of Spin for the shim, so you will need to change `spin_manifest_version` to `spin_version` in `spin.toml` if you are using a template-generated project from the Spin CLI.
+- The RuntimeClass `wasmtime-spin-v0-5-1` on Azure maps to spin v1.0.0, and the `wasmtime-spin-v1` RuntimeClass uses an older shim corresponding to v0.3.0 spin.
+
+#### Note for Rust
+
+In Cargo.toml, the `spin-sdk` dependency should be downgraded to `v1.0.0-rc.1` in order to match the lower version running on the AKS shim.
+
+### Setup
+
+To get spin working on an AKS cluster, a few setup steps are required. First Add the aks-preview extension:
+
+<!-- @selectiveCpy -->
+
+```console
+$ az extension add --name aks-preview
+```
+
+Next update to the latest version:
+
+<!-- @selectiveCpy -->
+
+```console
+$ az extension update --name aks-preview
+```
+
+Register the WasmNodePoolPreview feature:
+
+<!-- @selectiveCpy -->
+
+```console
+$ az feature register --namespace "Microsoft.ContainerService" --name "WasmNodePoolPreview"
+```
+
+This will take a few minutes to complete. You can verify it’s done when this command returns *Registered*:
+
+<!-- @selectiveCpy -->
+
+```console
+$ az feature show --namespace "Microsoft.ContainerService" --name "WasmNodePoolPreview"
+```
+
+Finally refresh the registration of the ContainerService:
+
+<!-- @selectiveCpy -->
+
+```console
+$ az provider register --namespace Microsoft.ContainerService
+```
+
+Once the service is registered, the next step is to add a Wasm/WASI nodepool to an existing AKS cluster. If a cluster doesn’t already exist, follow Azure’s [documentation](https://learn.microsoft.com/en-us/azure/aks/learn/quick-kubernetes-deploy-portal?tabs=azure-cli) to create a new cluster:
+
+<!-- @selectiveCpy -->
+
+```console
+$ az aks nodepool add \
+    --resource-group myResourceGroup \
+    --cluster-name myAKSCluster \
+    --name mywasipool \
+    --node-count 1 \
+    --node-vm-size Standard_B2s \
+    --workload-runtime WasmWasi
+```
+
+You can verify the workloadRuntime using the following command:
+
+<!-- @selectiveCpy -->
+
+```console
+$ az aks nodepool show -g myResourceGroup --cluster-name myAKSCluster -n mywasipool --query workloadRuntime
+```
+
+The next set of commands uses kubectl to create the necessary runtimeClass. If you don’t already have kubectl configured with the appropriate credentials, you can retrieve them with this command:
+
+<!-- @selectiveCpy -->
+
+```console
+$ az aks get-credentials -n myAKSCluster -g myResourceGroup
+```
+
+Find the name of the nodepool:
+
+<!-- @selectiveCpy -->
+
+```console
+$ kubectl get nodes -o wide
+```
+
+Then retrieve detailed information on the appropriate nodepool and verify among it’s labels is “kubernetes.azure.com/wasmtime-spin-v1=true”:
+
+<!-- @selectiveCpy -->
+
+```console
+kubectl describe node aks-mywasipool-12456878-vmss000000
+```
+
+Find the `wasmtime-spin-v1` RuntimeClass created by AKS:
+
+<!-- @selectiveCopy -->
+
+```console
+$ kubectl describe runtimeclass wasmtime-spin-v1
+```
+
+{{ blockEnd }}
+
+{{ startTab "Docker Desktop"}}
+
+## Setup Docker Desktop for Spin
+
+### Introduction
+
+Docker Desktop provides both [an easy way to run Spin apps in containers](https://www.fermyon.com/blog/spin-in-docker) directly and its own Kubernetes option.
+
+### Known Limitations
+
+- Each Pod will be constantly running it’s own HTTP listener which adds overhead vs Fermyon Cloud.
+- You can run containers and wasm modules on the same node, but you can't run containers and wasm modules on the same pod.
+- The Kubernetes commands are only required if you want to use the Kubernetes instance included as Experimental with Docker Desktop. The instructions to use spin with Docker Desktop directly are available at the bottom of this section.
+
+### Setup
+
+Install approproiate Preview Version of Docker Desktop+Wasm Technical Preview 2 from [here](https://www.docker.com/blog/announcing-dockerwasm-technical-preview-2/). Then [enable Containerd](https://docs.docker.com/desktop/containerd/) for Docker in Settings → Experimental → Use containerd for pulling and storing images.
+
+Next Enable Kubernetes under Settings → Experimental → Enable Kubernetes, then hit “Apply & Restart”.
+
+Create a file wasm-runtimeclass.yml and populate with the following information:
+
+```yaml
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: "wasmtime-spin-v1"
+handler: "spin"
+```
+
+Then register the runtime class with the cluster:
+
+<!-- @selectiveCpy -->
+
+```console
+$ kubectl apply -f wasm-runtimeclass.yaml
+```
+
+### Using Docker Desktop With Spin
+
+Docker Desktop can be used with spin as a Kubernetes target per the instructions in the below in this document. However Docker can also run the containers directly with the following command:
+
+<!-- @selectiveCpy -->
+
+```console
+$ docker run --runtime=io.containerd.spin.v1 --platform=wasi/wasm -p <port>:<port> <image>:<version>
+```
+
+If there is not command specified in the Dockerfile, one will need to be passed at the command line. Since Spin doesn't need this, "/" can be passed.
+
+{{ blockEnd }}
+
+{{ startTab "K3d"}}
+
+## Setup K8s for Spin
+
+### Introduction
+
+[K3d](https://k3d.io/) is a lightweight Kubernetes installation.
+
+### Known Limitations
+
+- Each Pod will be constantly running it’s own HTTP listener which adds overhead vs Fermyon Cloud.
+- You can run containers and wasm modules on the same node, but you can't run containers and wasm modules on the same pod.
+
+### Setup
+
+Ensure both Docker and k3d are installed. Then [enable Containerd](https://docs.docker.com/desktop/containerd/) for Docker in Settings → Experimental → Use containerd for pulling and storing images.
+
+Deis Labs provides a preconfigured K3d environment that can be run using this command:
+
+<!-- @selectiveCpy -->
+
+```console
+$ k3d cluster create wasm-cluster --image ghcr.io/deislabs/containerd-wasm-shims/examples/k3d:v0.8.0 -p "8081:80@loadbalancer" --agents 2 --registry-create mycluster-registry:12345
+```
+
+Create a file wasm-runtimeclass.yml and populate with the following information:
+
+```yaml
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: "wasmtime-spin-v1"
+handler: "spin"
+```
+
+Then register the runtime class with the cluster:
+
+<!-- @selectiveCpy -->
+
+```console
+$ kubectl apply -f wasm-runtimeclass.yaml
+```
+
+{{ blockEnd }}
+
+{{ startTab "Generic Kubernetes"}}
+
+## Setup Generic Kubernetes for Spin
+
+### Introduction
+
+These instructions are provided for a self-managed or other Kubernetes service that isn't documented elsewhere.
+
+### Known Limitations
+
+- Each Pod will be constantly running it’s own HTTP listener which adds overhead vs Fermyon Cloud.
+- You can run containers and wasm modules on the same node, but you can't run containers and wasm modules on the same pod.
+
+### Setup
+
+We provide the [spin-containerd-shim-installer](https://github.com/fermyon/spin-containerd-shim-installer) Helm chart that provides an automated method to install and configure the containerd shim for Fermyon Spin in Kubernetes. Please see the [README](https://github.com/fermyon/spin-containerd-shim-installer/blob/main/README.md) in the installer repository for more information.
+
+The version of the container image and Helm chart directly correlates to the version of the containerd shim. We recommend selecting the shim version that correlates the version of Spin that you use for your application(s). For simplicity, here is a table depicting the version matrix between Spin and the containerd shim.
+
+| [Spin](https://github.com/fermyon/spin/releases)              | [containerd-shim-spin-v1](https://github.com/deislabs/containerd-wasm-shims/releases) |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| [v1.4.0](https://github.com/fermyon/spin/releases/tag/v1.4.0) | [v0.8.0](https://github.com/deislabs/containerd-wasm-shims/releases/tag/v0.8.0)       |
+| [v1.3.0](https://github.com/fermyon/spin/releases/tag/v1.3.0) | [v0.7.0](https://github.com/deislabs/containerd-wasm-shims/releases/tag/v0.7.0)       |
+| [v1.1.0](https://github.com/fermyon/spin/releases/tag/v1.1.0) | [v0.6.0](https://github.com/deislabs/containerd-wasm-shims/releases/tag/v0.6.0)       |
+| [v1.0.0](https://github.com/fermyon/spin/releases/tag/v1.0.0) | [v0.5.1](https://github.com/deislabs/containerd-wasm-shims/releases/tag/v0.5.1)       |
+
+There are several values you may need to configure based on your Kubernetes environment. The installer needs to add a binary to the node's PATH and edit containerd's config.toml. The defaults we set are the same defaults for containerd and should work for most Kubernetes environments but you may need to adjust them if your distribution uses non-default paths.
+
+| Name                            | Default           | Description                                                              |
+| ------------------------------- | ----------------- | ------------------------------------------------------------------------ |
+| installer.hostEtcContainerdPath | `/etc/containerd` | Directory where containerd's config.toml is located                      |
+| installer.hostBinPath           | `/usr/local/bin`  | Directory where the shim binary should be installed to (must be on PATH) |
+
+> NOTE: Because it is difficult to cover all Kubernetes environments there are no default values for node selectors or tolerations but they are configurable through values. We recommend that you configure some sensible defaults for your environment:
+
+```console
+$ helm install fermyon-spin oci://ghcr.io/fermyon/charts/spin-containerd-shim-installer --version 0.8.0
+```
+
+{{ blockEnd }}
+
+## Run a Spin Workload on Kubernetes
+
+### Introduction
+
+This guide demonstrates the commands to run a Spin workload in Kubernetes. It should apply to all Kubernetes varients which have been properly configured using one of the Setup guides.
+
+### Concepts
+
+Spin apps are bundled using the OCI format. These packages include the spin.toml file, and the wasm and static files which it references. While Kubernetes also uses OCI repositories, it expects the package to be in a container format.
+
+The containerd shim for Spin allows Kubernetes to appropriately schedule Spin applications as long as they have been wrapped in a lightweight “scratch” container.
+
+Once the Spin App Container has been created, it can be pushed to an OCI repository, and then deployed to an appropriately configured kubernetes cluster.
+
+### Requirements
+
+The current Spin k8s plugin relies on Docker and Kubectl under the hood. It’s important that both of these tools be installed, the Docker service be running, and KUBECONFIG environment variable be configured to point to a kubeconfig file for the desired Kubernetes cluster.
+
+### Install Plugin
+
+To install this plugin, simply run:
+
+```yaml
+spin plugin install -u https://raw.githubusercontent.com/chrismatteson/spin-plugin-k8s/main/k8s.json
+```
+
+### Workflow
+
+The workflow is very similar to the workflow for Fermyon Cloud. 
+
+The k8s plugin handles all of the tasks necessary to build the docker container, push it to a repository and deploy it into production.
+
+Just like with Fermyon Cloud, when something changes with the application, the workflow is to iterate the version in the spin.toml file, and restart the sequence from spin build.
+
+### Detailed Explanation of Steps
+
+#### Spin New
+
+An optional command to use a template to create a new Spin App:
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin new
+```
+
+#### Spin Build
+
+The following command builds a spin app:
+
+<!-- @selectiveCpy -->
+
+```console
+spin build
+```
+
+#### Spin K8s Scaffold
+
+The following command creates two files necessary for a Spin app to run on Kubernetes. A Dockerfile and deploy.yaml. Scaffold takes in a namespace as a mandatory argument. This can either be a username if using the Docker hub, or can be the entire address if using a separate repository such as ghcr:
+
+<!-- @selectiveCpy -->
+
+```console
+spin k8s scaffold
+```
+
+An example Dockerfile is below. The only things which end up in the final image are wasm and other files mentioned as sources in the spin.toml. 
+
+Dockerfile
+
+```yaml
+FROM scratch
+COPY ./spin.toml .
+COPY ./target/wasm32-wasi/release/test.wasm ./target/wasm32-wasi/release/test.wasm
+COPY ./spin_static_fs.wasm ./spin_static_fs.wasm
+COPY ./static ./static
+```
+
+The deploy.yaml file defines the deployment to the Kubernetes server. By default the replicas is configured as 3, however this can be edited after the scaffolding stage and before the deployment stage. Additionally, the runtimeClassName is defined as wasmtime-spin-v1. It’s critical that that is the exact name used when setting up the Kubernetes service to support Spin, or that the deployment be edited to the appropriate name.
+
+deploy.yaml
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: test
+  template:
+    metadata:
+      labels:
+        app: test
+    spec:
+      runtimeClassName: wasmtime-spin-v1
+      containers:
+        - name: test
+          image: chrismatteson/test:0.1.5
+          command: ["/"]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test
+  spec:
+    type: LoadBalancer
+    ports:
+      - protocol: TCP
+        port: 80
+        targetPort: 80
+    selector:
+      app: test
+---
+apiVersion: [networking.k8s.io/v1](http://networking.k8s.io/v1)
+kind: Ingress
+metadata:
+  name: test
+  annotations:
+    [ingress.kubernetes.io/ssl-redirect:](http://ingress.kubernetes.io/ssl-redirect:) "false"
+    [kubernetes.io/ingress.class:](http://kubernetes.io/ingress.class:) traefik
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: test
+                port:
+                  number: 80
+```
+
+#### Spin K8s Build
+
+The following command uses the Dockerfile to locally build a Spin Docker Container. The container is tagged as latest and with the version from the spin.toml:
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin k8s build
+```
+
+#### Spin K8s Push
+
+The following command pushes the Dockerfile to the appropriate repository:
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin k8s push
+```
+
+#### Spin K8s Deploy
+
+The following command deploys the application to Kubernetes:
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin k8s deploy
+```
+
+#### Spin K8s Getsvc
+
+The following command retrieves information about the service that gets deployed (such as it’s external IP):
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin k8s getsvc
+```

--- a/content/spin/v2/kv-store-api-guide.md
+++ b/content/spin/v2/kv-store-api-guide.md
@@ -1,0 +1,173 @@
+title = "Key Value Store"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+enable_shortcodes = true
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/kv-store-api-guide.md"
+
+---
+- [Using Key Value Store From Applications](#using-key-value-store-from-applications)
+- [Custom Key Value Stores](#custom-key-value-stores)
+- [Granting Key Value Store Permissions to Components](#granting-key-value-store-permissions-to-components)
+
+Spin provides an interface for you to persist data in a key value store managed by Spin. This key value store allows Spin developers to persist non-relational data across application invocations. To learn more about key value store use cases and how to enable your Spin application to use a key value store, check out our [key value tutorial](./kv-store-tutorial.md).
+
+{{ details "Why do I need a Spin interface? Why can't I just use my own external store?" "You can absolutely still use your own external store either with the Redis or Postgres APIs, or outbound HTTP. However, if you're interested in quick, non-relational local storage without any infrastructure set-up then Spin's key value store is a great option." }}
+
+## Using Key Value Store From Applications
+
+The Spin SDK surfaces the Spin key value store interface to your language. The following characteristics are true of keys and values:
+
+* Keys as large as 256 bytes (UTF-8 encoded)
+* Values as large as 1 megabyte
+* Capacity for 1024 key value tuples
+
+The set of operations is common across all SDKs:
+
+| Operation  | Parameters | Returns | Behavior |
+|------------|------------|---------|----------|
+| `open`  | name | store  | Open the store with the specified name. If `name` is the string "default", the default store is opened, provided that the component that was granted access in the component manifest from `spin.toml`. Otherwise, `name` must refer to a store defined and configured in a [runtime configuration file](./dynamic-configuration.md#key-value-store-runtime-configuration) supplied with the application.|
+| `get` | store, key | value | Get the value associated with the specified `key` from the specified `store`. |
+| `set` | store, key, value | - | Set the `value` associated with the specified `key` in the specified `store`, overwriting any existing value. |
+| `delete` | store, key | - | Delete the tuple with the specified `key` from the specified `store`. `error::invalid-store` will be raised if `store` is not a valid handle to an open store.  No error is raised if a tuple did not previously exist for `key`.|
+| `exists` | store, key | boolean | Return whether a tuple exists for the specified `key` in the specified `store`.|
+| `get-keys` | store | list<keys> | Return a list of all the keys in the specified `store`. |
+| `close` | store | - | Close the specified `store`. |
+
+The exact detail of calling these operations from your application depends on your language:
+
+{{ tabs "sdk-type" }}
+
+{{ startTab "Rust"}}
+
+Key value functions are available in the `spin_sdk::key_value` module. The function names match the operations above. For example:
+
+```rust
+use anyhow::Result;
+use spin_sdk::{
+    http::{Request, Response},
+    http_component,
+    key_value::{Store},
+};
+#[http_component]
+fn handle_request(_req: Request) -> Result<Response> {
+    let store = Store::open_default()?;
+    store.set("mykey", "myvalue")?;
+    let value = store.get("mykey")?;
+    Ok(http::Response::builder().status(200).body(Some(value.into()))?)
+}
+```
+
+**General Notes** 
+
+`set` **Operation**
+- For set, the value argument can be of any type that implements AsRef<[u8]>
+
+`get` **Operation**
+- For get, the return value is of type Vec<u8>. If the key does not exist then Error::NoSuchKey is returned.
+
+`open` **Operation**
+- The close operation is not surfaced; it is called automatically when the store is dropped.
+
+`set_json` and `get_json` **Operation**
+- Rust applications can [store and retrieve serializable Rust types](/spin/rust-components#storing-data-in-the-spin-key-value-store).
+
+{{ blockEnd }}
+
+{{ startTab "Typescript"}}
+
+With Typescript, the key value functions can be accessed after opening a store using either the `Kv.open` or the `Kv.openDefault` methods which returns a handle to the store. For example:
+
+```javascript
+import { HandleRequest, HttpRequest, HttpResponse, Kv } from "@fermyon/spin-sdk"
+
+export const handleRequest: HandleRequest = async function (request: HttpRequest): Promise<HttpResponse> {
+    let store = Kv.openDefault()
+    store.set("mykey", "myvalue")
+    return {
+            status: 200,
+            headers: {"content-type":"text/plain"},
+            body: store.get("mykey") ?? encoder.encode("Key not found")
+    }
+}
+
+```
+
+**General Notes**
+- The spinSdk object is always available at runtime. Code checking and completion are available in TypeScript at design time if the module imports anything from the @fermyon/spin-sdk package. For example: 
+
+`get` **Operation**
+- The result is of the type `ArrayBuffer | null`
+- If the key does not exist, `get` returns `null` (no error is thrown)
+
+`set` **Operation**
+- The value argument is of the type `ArrayBuffer | string`.
+
+`setJson` and `getJson` **Operation**
+- JavaScript and TypeScript applications can store JavaScript objects using `setJson`; these are serialized within the store as JSON. These serialized objects can be retrieved and deserialized using `getJson`. If you call `getJson` on a key that doesn't exist then an error is thrown (note that this is different behavior from `get`).
+
+{{ blockEnd }}
+
+{{ startTab "Python"}}
+
+The key value functions are provided through the `spin_key_value` module in the Python SDK. For example:
+
+```python
+from spin_http import Response
+from spin_key_value import kv_open_default
+
+
+def handle_request(request):
+
+    store = kv_open_default()
+    store.set("mykey", "myvalue")
+    value = store.get()
+    //
+    return Response(status, [("content-type", "text/plain")], value)   
+
+```
+
+**General Notes**
+
+`get` **Operation**
+- If a key does not exist, it returns `None`
+
+{{ blockEnd }}
+
+{{ startTab "TinyGo"}}
+
+Key value functions are provided by the `github.com/fermyon/spin/sdk/go/key_value` module. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/key_value). For example: 
+
+```go
+import "github.com/fermyon/spin/sdk/go/key_value"
+
+func example() error {
+    store, err := key_value.Open("default")
+    if err != nil {
+        return err
+    }
+    defer key_value.Close(store)
+    return key_value.Set(store, "mykey", []byte("myvalue"))
+}
+
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+## Custom Key Value Stores
+
+Spin defines a key-value store named `"default"` and provides automatic backing storage.  If you need to customize Spin with additional stores, or to change the backing storage for the default store, you can do so via the `--runtime-config-file` flag and the `runtime-config.toml` file.  See [Key Value Store Runtime Configuration](/spin/dynamic-configuration#key-value-store-runtime-configuration) for details.
+
+## Granting Key Value Store Permissions to Components
+
+By default, a given component of an app will not have access to any key value store. Access must be granted specifically to each component via the component manifest:
+
+```toml
+[component]
+# Pass in 1 or more key value stores, based on how many you'd like your component to have access to
+key_value_stores = ["<store 1>", "<store 2>"]
+```
+
+For example, a component could be given access to the default store using `key_value_stores = ["default"]`.

--- a/content/spin/v2/language-support-overview.md
+++ b/content/spin/v2/language-support-overview.md
@@ -1,0 +1,119 @@
+title = "Language Support Overview"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+enable_shortcodes = true
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/language-support-overview.md"
+
+---
+
+This page contains information about language support for Spin features:
+
+{{ tabs "sdk-type" }}
+
+{{ startTab "Rust"}}
+
+| Feature | SDK Supported? |
+|-----|-----|
+| **Triggers** |
+| [HTTP](/spin/http-trigger) | Supported |
+| [Redis](/spin/redis-trigger) | Supported |
+| **APIs** |
+| [Outbound HTTP](/spin/rust-components.md#sending-outbound-http-requests) | Supported |
+| [Configuration Variables](/spin/variables) | Supported |
+| [Key Value Storage](/spin/kv-store-api-guide) | Supported |
+| [SQLite Storage](/spin/sqlite-api-guide) | Supported |
+| [MySQL](/spin/rdbms-storage#using-mysql-and-postgresql-from-applications) | Supported |
+| [PostgreSQL](/spin/rdbms-storage#using-mysql-and-postgresql-from-applications) | Supported |
+| [Outbound Redis](/spin/rust-components.md#storing-data-in-redis-from-rust-components) | Supported |
+| [Serverless AI](/spin/rust-components.md#ai-inferencing-from-rust-components) | Supported |
+| **Extensibility** |
+| [Authoring Custom Triggers](/spin/extending-and-embedding) | Supported |
+
+{{ blockEnd }}
+
+{{ startTab "TypeScript"}}
+
+| Feature | SDK Supported? |
+|-----|-----|
+| **Triggers** |
+| [HTTP](/spin/javascript-components#http-components) | Supported |
+| Redis | Not Supported |
+| **APIs** |
+| [Outbound HTTP](/spin/javascript-components#sending-outbound-http-requests) | Supported |
+| [Configuration Variables](/spin/dynamic-configuration#custom-config-variables) | Supported |
+| [Key Value Storage](/spin/kv-store-api-guide) | Supported |
+| [SQLite Storage](/spin/sqlite-api-guide) | Supported |
+| MySQL | Not Supported |
+| PostgreSQL| Not Supported |
+| [Outbound Redis](/spin/javascript-components#storing-data-in-redis-from-jsts-components) | Supported |
+| [Serverless AI](/spin/javascript-components#ai-inferencing-from-jsts-components) | Supported |
+| **Extensibility** |
+| Authoring Custom Triggers | Not Supported |
+
+{{ blockEnd }}
+
+{{ startTab "Python"}}
+
+| Feature | SDK Supported? |
+|-----|-----|
+| **Triggers** |
+| [HTTP](/spin/python-components#a-simple-http-components-example) | Supported |
+| Redis | Not Supported |
+| **APIs** |
+| [Outbound HTTP](/spin/python-components#an-outbound-http-example) | Supported |
+| [Configuration Variables](/spin/dynamic-configuration#custom-config-variables) | Supported |
+| [Key Value Storage](/spin/kv-store-api-guide) | Supported |
+| [SQLite Storage](/spin/sqlite-api-guide) | Supported |
+| MySQL | Not Supported |
+| PostgreSQL | Not Supported |
+| [Outbound Redis](/spin/python-components#an-outbound-redis-example) | Supported |
+| [Serverless AI](/spin/python-components#ai-inferencing-from-python-components) | Supported |
+| **Extensibility** |
+| Authoring Custom Triggers | Not Supported |
+
+{{ blockEnd }}
+
+{{ startTab "TinyGo"}}
+
+| Feature | SDK Supported? |
+|-----|-----|
+| **Triggers** |
+| [HTTP](/spin/go-components#http-components) | Supported |
+| [Redis](/spin/go-components#redis-components) | Supported |
+| **APIs** |
+| [Outbound HTTP](/spin/go-components#sending-outbound-http-requests) | Supported |
+| [Configuration Variables](/spin/dynamic-configuration#custom-config-variables) | Supported |
+| [Key Value Storage](/spin/kv-store-api-guide) | Supported |
+| [SQLite Storage](/spin/sqlite-api-guide) | Supported |
+| MySQL | Not Supported |
+| PostgreSQL | Not Supported |
+| [Outbound Redis](/spin/go-components#storing-data-in-redis-from-go-components) | Supported |
+| Serverless AI | Not Supported |
+| **Extensibility** |
+| Authoring Custom Triggers | Not Supported |
+
+{{ blockEnd }}
+
+{{ startTab "C#"}}
+
+| Feature | SDK Supported? |
+|-----|-----|
+| **Triggers** |
+| [HTTP](https://github.com/fermyon/spin-dotnet-sdk#handling-http-requests) | Supported |
+| Redis | Not Supported |
+| **APIs** |
+| [Outbound HTTP](https://github.com/fermyon/spin-dotnet-sdk#making-outbound-http-requests) | Supported |
+| [Configuration Variables](/spin/dynamic-configuration#custom-config-variables) | Supported |
+| Key Value Storage | Not Supported |
+| SQLite Storage | Not supported |
+| MySQL | Not Supported |
+| [PostgreSQL](https://github.com/fermyon/spin-dotnet-sdk#working-with-postgres) | Supported |
+| [Outbound Redis](https://github.com/fermyon/spin-dotnet-sdk#making-redis-requests) | Supported |
+| Serverless AI | Not Supported |
+| **Extensibility** |
+| Authoring Custom Triggers | Not Supported |
+
+{{ blockEnd }}
+
+{{ blockEnd }}

--- a/content/spin/v2/managing-plugins.md
+++ b/content/spin/v2/managing-plugins.md
@@ -1,0 +1,146 @@
+title = "Managing Plugins"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+enable_shortcodes = true
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/managing-plugins.md"
+
+---
+- [Installing Plugins](#installing-plugins)
+  - [Installing Well Known Plugins](#installing-well-known-plugins)
+  - [Installing a Specific Version of a Plugin](#installing-a-specific-version-of-a-plugin)
+  - [Installing a Plugin From a URL](#installing-a-plugin-from-a-url)
+  - [Installing a Plugin From a File](#installing-a-plugin-from-a-file)
+- [Running a Plugin](#running-a-plugin)
+- [Viewing Available Plugins](#viewing-available-plugins)
+  - [Viewing Installed Plugins](#viewing-installed-plugins)
+- [Uninstalling Plugins](#uninstalling-plugins)
+- [Upgrading Plugins](#upgrading-plugins)
+- [Refreshing the Catalogue](#refreshing-the-catalogue)
+- [Next Steps](#next-steps)
+
+Plugins are a way to extend the functionality of Spin. Spin provides commands for installing and removing them, so you don't need to use separate installation tools. When you have installed a plugin into Spin, you can call it as if it were a Spin subcommand. For example, the JavaScript SDK uses a tool called `js2wasm` to package JavaScript code into a Wasm module, and JavaScript applications run it via the `spin js2wasm` command.
+
+## Installing Plugins
+
+To install plugins, use the `spin plugins install` command. You can install plugins by name from a curated repository, or other plugins from a URL or file system.
+
+### Installing Well Known Plugins
+
+The Spin maintainers curate a catalogue of "known" plugins. You can install plugins from this catalogue by name:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin plugins install js2wasm
+```
+
+Spin checks that the plugin is available for your version of Spin and your operating system, and prompts you to confirm the installation. To skip the prompt, pass the `--yes` flag.
+
+> The curated plugins catalogue is stored in a GitHub repository. The first time you install a plugin from the catalogue, Spin clones this repository into a local cache and uses it for future install, list and upgrade commands (similar to OS package managers such as `apt`). If you want to see new catalogue entries - new plugins or new versions - you must update the local cache by running the `spin plugins update` command.
+
+### Installing a Specific Version of a Plugin
+
+To install a specific version of a plugin, pass the `--version` flag:
+
+<!-- @nocpy -->
+
+```bash
+$ spin plugins install js2wasm --version 0.4.0
+```
+
+### Installing a Plugin From a URL
+
+If the plugin you want has been published on the Web but has not been added to the catalogue, you can install it from its manifest URL. The manifest is the JSON document that links to the binaries for different operating systems and processors. For example:
+
+<!-- @nocpy -->
+
+```bash
+$ spin plugins install --url https://github.com/fermyon/spin-befunge-sdk/releases/download/v1.4.0/befunge2wasm.json
+```
+
+### Installing a Plugin From a File
+
+If the plugin you want is in your local file system, you can install it from its manifest file path. The manifest is the JSON document that links to the binaries for different operating systems and processors. For example:
+
+<!-- @nocpy -->
+
+```bash
+$ spin plugins install --file ~/dev/spin-befunge-sdk/befunge2wasm.json
+```
+
+## Running a Plugin
+
+You run plugins in the same way as built-in Spin subcommands. For example:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin js2wasm --help
+```
+
+## Viewing Available Plugins
+
+To see what plugins are available in the catalogue, run `spin plugins list`:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin plugins list
+befunge2wasm 1.4.0 [incompatible]
+js2wasm 0.3.0 [installed]
+js2wasm 0.4.0
+py2wasm 0.1.0 [installed]
+trigger-sqs 0.1.0
+```
+
+> The `list` command uses your local cache of the catalogue. This might not include recently added plugins or versions. Run `spin plugins update` to refresh your local cache of the catalogue.
+
+The annotations by the plugins show their status and compatibility:
+
+| Annotation                      | Meaning |
+|---------------------------------|---------|
+| `[incompatible]`                | The plugin does not run on your operating system or processor. |
+| `[installed]`                   | You have the plugin already installed and available to run. |
+| `[requires other Spin version]` | The plugin can run on your operating system and processor, but is not compatible with the version of Spin you are running. The annotation indicates which versions of Spin it is compatible with. |
+
+### Viewing Installed Plugins
+
+To see only the plugins you have installed, run `spin plugins list --installed`.
+
+## Uninstalling Plugins
+
+You can uninstall plugins using `spin plugins uninstall` with the plugin name:
+
+<!-- @nocpy -->
+
+```bash
+$ spin plugins uninstall befunge2wasm
+```
+
+## Upgrading Plugins
+
+To upgrade a plugin to the latest version, run `spin plugins upgrade`. This has the same options as `spin plugins install`, according to whether the plugin comes from the catalogue, a URL, or a file:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin plugins upgrade js2wasm
+$ spin plugins upgrade --url https://github.com/fermyon/spin-befunge-sdk/releases/download/v1.7.0/befunge2wasm.json
+$ spin plugins upgrade --file ~/dev/spin-befunge-sdk/befunge2wasm.json
+```
+
+> When upgrading from the catalogue, the `upgrade` command uses your local cache of the catalogue. This might not include recently added plugins or versions. Run `spin plugins update` to refresh your local cache of the catalogue.
+
+By default, Spin will only _upgrade_ plugins. If you want to allow Spin to roll back to an earlier version, pass the `--downgrade` flag.
+
+## Refreshing the Catalogue
+
+The first time you install a plugin from the catalogue, Spin creates a local cache of the catalogue. It continues to use this local cache for future install, list and upgrade commands; this is similar to OS package managers such as `apt`, and avoids rate limiting on the catalogue. However, this means that in order to see new catalogue entries - new plugins or new versions - you must first update the cache. 
+
+To update your local cache of the catalogue, run `spin plugins update`.
+
+## Next Steps
+
+- [Install the JavaScript or Python plugins](quickstart)
+- [Use the JavaScript or Python plugins to build a Wasm module](build)

--- a/content/spin/v2/managing-templates.md
+++ b/content/spin/v2/managing-templates.md
@@ -1,0 +1,119 @@
+title = "Managing Templates"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+enable_shortcodes = true
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/managing-templates.md"
+
+---
+- [Installing Templates](#installing-templates)
+  - [Installing From the Spin Git Repository](#installing-from-the-spin-git-repository)
+  - [Installing From a Specific Branch](#installing-from-a-specific-branch)
+  - [Installing From a Local Directory](#installing-from-a-local-directory)
+- [Viewing Your Installed Templates](#viewing-your-installed-templates)
+- [Uninstalling Templates](#uninstalling-templates)
+- [Upgrading Templates](#upgrading-templates)
+  - [Upgrading Templates From a Local Directory](#upgrading-templates-from-a-local-directory)
+- [Next Steps](#next-steps)
+
+Templates are a Spin tool for scaffolding new applications and components. You can use them via the `spin new` and `spin add` commands. For more information about creating applications with templates, see [Writing Spin Applications](writing-apps).
+
+## Installing Templates
+
+> This section covers general principles for installing templates. For information about installing templates for specific languages, see [Writing Spin Applications](writing-apps).
+
+To install templates, use the `spin templates install` command. You can install templates from a Git repository, or while [authoring templates](template-authoring) you can install them from a local directory.
+
+### Installing From the Spin Git Repository
+
+To install templates from the Spin Git repository, run `spin templates install --git`.
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin templates install --git https://github.com/fermyon/spin
+```
+
+The above command installs _all_ templates in the repository.
+
+> Language SDKs often ship templates in their repositories; see the relevant language guide to find out where to get its templates.
+
+### Installing From a Specific Branch
+
+By default, if you install templates from a Git repository, Spin tries to find a repo tag that matches the version of Spin, and installs from that tag.  Failing this, it installs from `HEAD`.  If you would like to install from a specific tag or branch, pass the `--branch` option:
+
+<!-- @nocpy -->
+
+```bash
+$ spin templates install --git https://github.com/fermyon/spin --branch spin/templates/v0.8
+```
+
+### Installing From a Local Directory
+
+To install templates from your local file system, run `spin templates install --dir`.
+
+> The directory you pass must be one that _contains_ a `templates` directory.  Don't pass the `templates` directory itself!
+
+<!-- @nocpy -->
+
+```bash
+# Expects to find a directory ~/dev/spin-befunge-sdk/templates
+$ spin templates install --dir ~/dev/spin-befunge-sdk
+```
+
+See [Template Authoring](template-authoring) for more details on this layout.
+
+## Viewing Your Installed Templates
+
+To see what templates you have installed, run `spin templates list`.
+
+You can use the `--verbose` option to see additional information such as where they were installed from.
+
+## Uninstalling Templates
+
+You can uninstall templates using `spin templates uninstall` with the template name:
+
+<!-- @nocpy -->
+
+```bash
+$ spin templates uninstall redis-befunge
+```
+
+> Spin doesn't currently support uninstalling a whole repo-worth of templates, only individual templates.
+
+## Upgrading Templates
+
+When you upgrade Spin, you will typically want to upgrade your templates to match.  This means new applications and components will get dependencies that match the Spin version you are using.  To do this, run `spin templates upgrade`:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin templates upgrade
+Select repos to upgrade. Use Space to select/deselect and Enter to confirm selection.
+  [x] https://github.com/fermyon/spin-python-sdk
+  [ ] https://github.com/fermyon/spin (at spin/templates/v1.0)
+> [x] https://github.com/fermyon/spin-js-sdk
+```
+
+Use the cursor keys and the space bar to select the repositories you want to upgrade, then hit Enter to upgrade the selected repositories.
+
+> Upgrading happens at the repo level, not the individual template level.  If you've uninstalled templates, upgrading the repo they came from will bring them back.
+
+If you want to upgrade _all_ repositories without being prompted, run `spin templates upgrade --all`.
+
+As mentioned above, if you want to check which templates come from which repositories use `--verbose` i.e. `spin templates list --verbose`.
+
+### Upgrading Templates From a Local Directory
+
+`spin templates upgrade` only upgrades from Git repositories.  If you want to upgrade and your templates are in a local directory, run the `spin templates install` command with the `--upgrade` flag:
+
+<!-- @nocpy -->
+
+```bash
+$ spin templates install --dir ~/dev/spin-befunge-sdk --upgrade
+```
+
+## Next Steps
+
+- [Install the templates for your language](quickstart)
+- [Use your language templates to create an application](writing-apps)

--- a/content/spin/v2/manifest-reference.md
+++ b/content/spin/v2/manifest-reference.md
@@ -1,0 +1,141 @@
+title = "Spin Application Manifest Reference"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/manifest-reference.md"
+
+---
+- [Format](#format)
+- [Manifest Fields](#manifest-fields)
+- [The `trigger` Table](#the-trigger-table)
+  - [The `trigger` Table for HTTP Applications](#the-trigger-table-for-http-applications)
+  - [The `trigger` Table for Redis Applications](#the-trigger-table-for-redis-applications)
+- [The `variables` Table](#the-variables-table)
+- [The `component` Tables](#the-component-tables)
+  - [The `component.trigger` Table for HTTP Applications](#the-componenttrigger-table-for-http-applications)
+  - [The `component.trigger` Table for Redis Applications](#the-componenttrigger-table-for-redis-applications)
+  - [The `component.build` Table](#the-componentbuild-table)
+- [Next Steps](#next-steps)
+
+This page describes the contents of the Spin manifest file, typically called `spin.toml`.
+
+## Format
+
+The manifest is a TOML file, and follows standard TOML syntax.  See the [TOML documentation](https://toml.io/) for information about the TOML syntax.
+
+## Manifest Fields
+
+| Name                    | Required?  | Type        | Value    | Example   |
+|-------------------------|------------|-------------|----------|-----------|
+| `spin_manifest_version` | Required   | String      | The version of the file format that the rest of the manifest follows. Currently, this value must be `"1"`. | `"1"` |
+| `name`                  | Required   | String      | The name of the application. This may be any string of alphanumeric characters, hyphens and underscores. | `"hello-world"` |
+| `version`               | Required   | String      | The version of the application. The must be a string of the form `major.minor.patch`, where each element is a number. | `"1.0.5"` |
+| `description`           | Optional   | String      | A human-readable description of the application. | `"The best app for all your world-greeting needs"` |
+| `authors`               | Optional   | Array of strings | The authors of the applications. If present, this must ba an array, even if it has only one entry. | `["Jane Q Hacker (<dev@example.com>)"]` |
+| `trigger`               | Required   | Table       | The trigger for the application - that is, the kind of event that the application responds to. The table must contain the `type` field, and may contain others depending on the value of `type`. See [The `trigger` Table](#the-trigger-table) for details. | `{ type = "http", base = "/" }` |
+| `variables`             | Optional   | Table       | Dynamic configuration variables which the user can set when they run the application. See [The `variables` Table](#the-variables-table) below. | `[variables]`<br />`message = { default = "hello" }` |
+| `component`             | Required   | Table array | A manifest must contain at least one `component` table. `component` is always an array, even if there is only one component, so always use double square brackets.  See [The `component` Tables](#the-component-tables) below. | `[[component]]`<br />`id = "hello"` |
+
+## The `trigger` Table
+
+The `trigger` table specifies the events that the application responds to.  The `type` field is always required, but the other fields depend on the `type`.  This section describes the built-in `http` and `redis` trigger types.
+
+> Because the `trigger` table usually contains only a few simple fields, you will usually see it written inline using brace notation, rather than written out using square-brackets table syntax.  For example:
+>
+> ```toml
+> trigger = { type = "http", base = "/" }
+> ```
+
+### The `trigger` Table for HTTP Applications
+
+| Name                    | Required?  | Type        | Value    | Example   |
+|-------------------------|------------|-------------|----------|-----------|
+| `type`                  | Required   | String      | Always `"http"` for HTTP applications. | `"http"` |
+| `base`                  | Required   | String      | The base path of the application. All component routes are relative to this. It allows multiple applications to be mounted under the same host. | `"/"` |
+
+### The `trigger` Table for Redis Applications
+
+| Name                    | Required?  | Type        | Value    | Example   |
+|-------------------------|------------|-------------|----------|-----------|
+| `type`                  | Required   | String      | Always `"redis"` for Redis applications. | `"redis"` |
+| `address`               | Required   | String      | The address of the Redis instance the components are using the message subscriptions. Use the `redis:` URL scheme. | `"redis://localhost:6379"` |
+
+## The `variables` Table
+
+The keys of `variables` table are user-defined.  The value of each key is another table with the fields shown in the following table.
+
+> Because each `variables` value usually contains only a few simple fields, you will usually see the table entries written inline with the values written using brace notation, rather than fully written out using square-brackets table syntax for each variable.  For example:
+>
+> ```toml
+> [variables]
+> vessel = { default = "teapot" }
+> token = { required = true, secret = true }
+> ```
+
+| Name                    | Required?  | Type        | Value    | Example   |
+|-------------------------|------------|-------------|----------|-----------|
+| `default`               | Optional   | String      | The value of the variable if no value is supplied at runtime. If specified, the value must be a string. If not specified, `required` must be `true`. | `"teapot"` |
+| `required`              | Optional   | Boolean     | Whether a value must be supplied at runtime. If not specified, `required` defaults to `false`, and `default` must be provided | `false` |
+| `secret`                | Optional   | Boolean     | If set, this variable should be treated as sensitive. | `false` |
+
+## The `component` Tables
+
+`component` is a table array, meaning each component is introduced with double-bracket syntax.  Subtables are written using single-bracket syntax or inline JSON syntax.  For example:
+
+```toml
+[[component]]
+id = "hello"
+source = "hello.wasm"
+[component.trigger]
+route = "/hello"
+```
+
+Each table in the `component` array contains the following fields:
+
+| Name                    | Required?  | Type        | Value    | Example   |
+|-------------------------|------------|-------------|----------|-----------|
+| `id`                    | Required   | String      | An identifier for this component, unique within the application. This may be any string of alphanumeric characters, hyphens and underscores. | `"cart-api"` |
+| `description`           | Optional   | String      | A human-readable description of the component. | `"The shopping cart API"` |
+| `source`                | Required   | String or table | The Wasm module which should handle the component. This must be built to work with the application trigger. It can be in one of the following formats: | |
+|                         |            | String      | * The path to a Wasm file (relative to the manifest file) | `dist/cart.wasm` |
+|                         |            | Table       | * The URL of a Wasm file downloadable over HTTP. This must be a table containing a `url` field for the Wasm file, and a `digest` field contains a SHA256 hex digest, used to check integrity. | `{ url = "https://example.com/example.wasm", digest = "sha256:6503...2375" }` |
+| `files`                 | Optional   | Array of strings and/or tables | The files to be made available to the Wasm module at runtime. This is an array, and each element of the array is either: | `[ "images/*.jpg", { source = "assets/images", destination = "/pictures" } ]` |
+|                         |            | String      | * A file path or glob pattern, relative to the manifest file. The matching file or files will be available in the Wasm module at the same relative paths. | `"images/*.jpg"` |
+|                         |            | Table       | * A directory to be made available to the Wasm module at a specific path. This must be a table containing a `source` field for the directory relative to the manifest file, and a `destination` field containing the absolute path at which to make it available. | `{ source = "assets/images", destination = "/pictures" }` |
+| `exclude_files`         | Optional   | Array of strings | Any files or glob patterns that should _not_ be available to the Wasm module at runtime, even though they match a `files` entry. | `[assets/images/test/**/*.*]` |
+| `allowed_http_hosts`    | Optional   | Array of strings | The host names or addresses to which the Wasm module is allowed to send HTTP requests. If the name includes a port, the Wasm module can send requests only to that port; otherwise, the Wasm module can send requests only to the default port for the scheme it uses. The special string `insecure:allow-all` permits the module to send HTTP requests to _any_ host, but is intended for development use only; some deployment environments may decline to honour it. | `["example.com", "localhost:8081"]` |
+| `key_value_stores`      | Optional   | Array of strings | An array of key-value stores that the Wasm module is allowed to read or write. A store named `default` is provided by the Spin runtime, though modules must still be permitted to access it. In current versions of Spin, `"default"` is the only store allowed. | `["default"]` |
+| `environment`           | Optional   | Table       | Environment variables to be set for the Wasm module. This is a table. The table keys are user-defined; the values must be strings. | `{ DB_URL = "mysql://spin:spin@localhost/dev" }` |
+| `trigger`               | Required   | Table       | Specifies how this component is triggered. This is a table, whose contents of are trigger-specific; see below. | `[component.trigger]`<br />`route = "/..."` |
+| `build`                 | Optional   | Table       | The command that `spin build` uses to build this component. See [The `component.build` Table](#the-componentbuild-table) below. | `[component.build]`<br />`command = "npm run build"` |
+| `config`                | Optional   | Table       | Dynamic configuration values to be made available to this component. The table keys are user-defined; the values must be strings, and may use template notation as described under [Dynamic Configuration](dynamic-configuration). | `[component.config]`<br />`api_base_url = "https://{{ api_host }}/v1"` |
+
+### The `component.trigger` Table for HTTP Applications
+
+| Name                    | Required?  | Type        | Value    | Example   |
+|-------------------------|------------|-------------|----------|-----------|
+| `route`                 | Required   | String      | The route which this component handles. Requests to the route will cause the component to execute. This may be an exact route (`/example`), which matches on the given path, or a wildcard route indicated by the suffix `/...` (`/example/...`), which matches any route under this prefix. If two routes overlap, requests are directed to the matching route with the longest prefix - see [the HTTP trigger documentation](http-trigger) for details and examples. | `"/api/cart/..."` |
+| `executor`              | Optional   | Table       | How Spin should invoke the component. If present, this is a table.  The `type` key is required and may have the values `"spin"` or `"wagi"`. If omitted. the default is `{ type = "spin"}`. See [the HTTP trigger documentation](http-trigger) for details. | `{ type = "wagi" }` |
+|                         |            |             | If `type = "spin"` there are no other keys defined. In this case, Spin calls the component using a standard Wasm component interface. Components built using Spin SDKs or Spin interface files use this convention. | `{ type = "spin" }` |
+|                         |            |             | If `type = "wagi"`, Spin calls the component's "main" (`_start`) function using [a CGI-like interface](https://github.com/deislabs/wagi). Components built using languages or toolchains that do not support Wasm interfaces will need to be called in this way. In this case, the following additional keys may be set:<br/><br/>* `argv` (optional): The string representation of the `argv` list that should be passed into the handler. `${SCRIPT_NAME}` will be replaced with the script name, and `${ARGS}` will be replaced with the query parameters of the request, formatted as arguments. The default is to follow the CGI specification, and pass `${SCRIPT_NAME} ${ARGS}`<br/><br/>* `entrypoint` (optional): The name of the function to call as the entry point to this handler. By default, it is `_start` (which in most languages translates to `main` in the source code).<br/><br/>See [the HTTP trigger documentation](http-trigger) for details. | `{ type = "wagi" }` |
+
+### The `component.trigger` Table for Redis Applications
+
+| Name                    | Required?  | Type        | Value    | Example   |
+|-------------------------|------------|-------------|----------|-----------|
+| `channel`               | Required   | String      | The Redis channel which this component handles. Messages on this channel will cause the component to execute. | `"purchases"` |
+
+### The `component.build` Table
+
+| Name                    | Required?  | Type        | Value    | Example   |
+|-------------------------|------------|-------------|----------|-----------|
+| `command`               | Required   | String      | The command to execute on `spin build`. | `"cargo build --target wasm32-wasi --release"` |
+| `workdir`               | Optional   | String      | The directory in which to execute `command`, relative to the manifest file. The default is the directory containing the manifest file. An example of where this is needed is a multi-component application where each component is its own source tree in its own directory. | `"my-project"` |
+| `watch`                 | Optional   | Array of strings | The files or glob patterns which `spin watch` should monitor to determine if the component Wasm file needs to be rebuilt. These are relative to `workdir`, or to the directory containing the manifest file if `workdir` is not present. | `["src/**/*.rs", "Cargo.toml"]` |
+
+## Next Steps
+
+- Learn about [writing Spin applications and their manifests](writing-apps)
+- Learn about [dynamic and runtime configuration](dynamic-configuration)
+- See more information about the [HTTP trigger](http-trigger)
+- See more information about the [Redis trigger](redis-trigger)

--- a/content/spin/v2/other-languages.md
+++ b/content/spin/v2/other-languages.md
@@ -1,0 +1,100 @@
+title = "Building Spin components in other languages"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/other-languages.md"
+
+---
+- [AssemblyScript](#assemblyscript)
+- [C/C++](#cc)
+- [C# and .NET Languages](#c-and-net-languages)
+- [Grain](#grain)
+- [Python](#python)
+- [Ruby](#ruby)
+- [Zig](#zig)
+
+> This document is continuously evolving as we improve language SDKs and add
+> more examples on how to build Spin components in various programming languages.
+
+> See the document on writing [Rust](./rust-components.md) and [Go](./go-components.md)
+> components for Spin for detailed guides.
+
+WebAssembly is becoming [a popular compilation target for programming languages](https://www.fermyon.com/wasm-languages/webassembly-language-support), and as language toolchains add support for the
+[WebAssembly component model](https://github.com/WebAssembly/component-model),
+building Spin components will also become supported.
+
+As a general rule:
+
+- if your language supports the
+[WebAssembly component model](https://github.com/WebAssembly/component-model),
+building Spin components is supported either through an official Spin SDK
+(such as [the Spin SDK for Rust](./rust-components.md)), or through using
+bindings generators like [`wit-bindgen`](https://github.com/bytecodealliance/wit-bindgen)
+(for languages such as C and C++)
+- if your language compiles to WASI, but doesn't have support for the component
+model, you can build [Spin HTTP components](./http-trigger.md) that use the
+Wagi executor — for example in languages such as
+[Grain](https://github.com/deislabs/hello-wagi-grain),
+[AssemblyScript](https://github.com/deislabs/hello-wagi-as), or
+[Python](https://github.com/fermyon/wagi-python).
+- if your language doesn't currently compile to WASI, there is no way to
+build and run Spin components in that programming language
+
+> Make sure to check out [a more complex Spin application with components built
+in multiple programming languages](https://github.com/fermyon/spin-kitchensink/).
+
+## AssemblyScript
+
+[AssemblyScript](https://www.assemblyscript.org/) is a TypeScript-based language that compiles directly to WebAssembly.
+AssemblyScript has WASI/Wagi support, and so can be used with Spin.
+
+- The [AssemblyScript entry in the Wasm Language Guide](https://www.fermyon.com/wasm-languages/assemblyscript) includes a full example
+- The [Spin Kitchen Sink](https://github.com/fermyon/spin-kitchensink) repo has an AssemblyScript demo
+- An [example AssemblyScript app](https://github.com/deislabs/hello-wagi-as) designed for Wagi runs on Spin
+
+## C/C++
+
+C and C++ are both broadly supported in the WebAssembly ecosystem. WASI/Wagi support means that both can be used to write Spin apps.
+
+- The [C entry in the Wasm Language Guide](https://www.fermyon.com/wasm-languages/c-lang) has examples.
+- The [C++ entry in the Wasm Language Guide](https://www.fermyon.com/wasm-languages/cpp) has specific caveats for writing C++ (like exception handling)
+- The [yo-wasm](https://github.com/deislabs/yo-wasm) project makes setting up C easier.
+
+## C# and .NET Languages
+
+.NET has experimental support for WASI, so many (if not all) .NET languages, including C# and F#, can be used to write Spin applications.
+
+- The [C# entry in the Wasm Language Guide](https://www.fermyon.com/wasm-languages/c-sharp) has a full example.
+- The [Spin Kitchen Sink repo](https://github.com/fermyon/spin-kitchensink) has two C# examples and one F# example.
+
+## Grain
+
+[Grain](https://grain-lang.org/), a new functional programming language, has WASI/Wagi support and can be used to write Spin apps.
+
+- The [Grain entry in the Wasm Language Guide](https://www.fermyon.com/wasm-languages/grain) has details
+- A simple [Hello World example](https://github.com/deislabs/hello-wagi-grain) shows how to use Grain
+- For a production-quality example. the [Wagi Fileserver](https://github.com/deislabs/wagi-fileserver) is written in Grain
+
+## Python
+
+Python's interpreter can be compiled to WebAssembly, and it has WASI support. It is known to work for Spin.
+
+- The [Spin Kitchen Sink](https://github.com/fermyon/spin-kitchensink) repo includes a Python example
+- The [Python entry in the Wasm Language Guide](https://www.fermyon.com/wasm-languages/python) lists two implementations
+- There is a Fermyon blog post about [using Python with WAGI](https://www.fermyon.com/blog/python-wagi)
+- The [Python docs](https://pythondev.readthedocs.io/wasm.html) have a page on WebAssembly
+- SingleStore also has [a Python build](https://github.com/singlestore-labs/python-wasi) that uses mainline Python
+
+## Ruby
+
+Upstream [Ruby](https://www.ruby-lang.org/en/) officially supports WebAssembly and WASI, and we here at Fermyon have successfully run Ruby apps in Spin.
+
+- The [Ruby entry in the Wasm Language Guide](https://www.fermyon.com/wasm-languages/ruby) has the latest information
+- [Ruby's 3.2.0 Preview 1 release notes](https://www.ruby-lang.org/en/news/2022/04/03/ruby-3-2-0-preview1-released/) detail WASI support
+
+## Zig
+
+Zig is a low-level systems language that has support for Wasm and WASI, and can be used to write Spin apps.
+
+- The [Zig entry in the Wasm Language Guide](https://www.fermyon.com/wasm-languages/zig) covers the basics
+- Zig's [0.4 release notes](https://ziglang.org/download/0.4.0/release-notes.html#WebAssembly-Support) explain WebAssembly support

--- a/content/spin/v2/plugin-authoring.md
+++ b/content/spin/v2/plugin-authoring.md
@@ -1,0 +1,144 @@
+title = "Creating Spin Plugins"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/plugin-authoring.md"
+
+---
+- [What Are Spin Plugins?](#what-are-spin-plugins)
+- [How to Find and Use a Spin Plugin](#how-to-find-and-use-a-spin-plugin)
+- [Authoring a Spin Plugin](#authoring-a-spin-plugin)
+  - [Environment Variables Available to the Plugin Executable](#environment-variables-available-to-the-plugin-executable)
+  - [Packaging a Plugin](#packaging-a-plugin)
+  - [Creating a Spin Plugin Manifest](#creating-a-spin-plugin-manifest)
+  - [Installing a Local Plugin](#installing-a-local-plugin)
+  - [Contributing a Plugin](#contributing-a-plugin)
+
+Spin plugins add new functionality or subcommands to Spin without modifying the
+Spin codebase. They make Spin easily extensible while keeping it lightweight.
+Spin plugins can add new triggers to Spin (such as the [example timer
+trigger](https://github.com/fermyon/spin/blob/main/examples/spin-timer/trigger-timer.json)),
+enable new language SDKs (such as
+[`js2wasm`](https://github.com/fermyon/spin-plugins/blob/main/manifests/js2wasm/js2wasm.json)),
+and more.
+
+This document will cover what Spin plugins are, how to use a plugin, and how to
+create a plugin.
+
+## What Are Spin Plugins?
+
+A Spin plugin is an executable that is added to Spin's plugins directory
+(`$XDG_DATA_HOME/spin/plugins`) upon a `spin plugins install <plugin-name>`. The
+plugin is then ready to be used. If the plugin is an extension to the Spin CLI,
+it can now be executed directly as a subcommand: `spin <plugin-name>`. If the
+plugin is a trigger plugin, it will be executed during `spin up` when an app
+using that trigger is run. 
+
+While for now plugins are assumed to be executables, in the future, support for
+plugging in WebAssembly modules may be desirable.
+
+## How to Find and Use a Spin Plugin
+
+Spin maintains a centralized catalogue of available Spin plugins in the [Spin
+plugins repository](https://github.com/fermyon/spin-plugins). During plugin
+installation, if it does not already exist, Spin fetches the remote catalogue
+and creates a local snapshot. To ensure that the local snapshot is up to date,
+it is best to run `spin plugins update` before installing any plugins. 
+
+To list available plugins, run `spin plugins list`. Now, decide which plugin to
+install. For example, the `js2wasm` plugin, which is needed in order to build
+JavaScript Spin applications, can be installed by running:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin plugins install js2wasm
+```
+
+With the plugin installed, you can now call `spin js2wasm` to run it. In this
+case, for example, you might call it from your JavaScript application's npm
+build script. Learn more about building Spin components in JavaScript
+[here](/spin/javascript-components.md).
+
+To upgrade installed plugins to newer versions, run `spin plugin update` to
+fetch the latest plugins to the local catalogue and `spin plugin upgrade` to perform the
+upgrade on the installed plugins.
+
+## Authoring a Spin Plugin
+
+Spin plugins are implemented as a manifest that points to one or more `.tar.gz` archives which contain the plugin executables. So, to create a plugin you must:
+
+1. Create tar archives of the executables for the platforms you want to support
+2. Compose a manifest that describes the plugin and lists the URLs for those tar archives
+
+### Environment Variables Available to the Plugin Executable
+
+Your plugin may need to know information about the instance of Spin it's running in. For example, suppose your plugin wants to call `spin build`. The trouble is that you don't know if it's on the user's system PATH. Suppose, further, that your plugin would prefer to call `spin build -c` (to build only a specific component) if it's available but can fall back to `spin build` (to build everything) if it's not. The `-c` option only exists in Spin 1.4 and above, so this optimization requires that you know which version of Spin you're running in.
+
+To help with this, when a user uses Spin to run your plugin, Spin sets a number of environment variables on the plugin process. Your code can use these environment variables to find out things like the path to the Spin binary and which version of Spin it is. When your plugin runs, the parent Spin process will set these to the right values for the _user's_ instance of Spin. In the example above, when your plugin wants to run `spin build`, it can consult the `SPIN_BIN_PATH` environment variable for the program path, and be confident that the `SPIN_VERSION` environment variable matches the Spin binary at that location.
+
+The variables Spin sets are:
+
+| Name               | Meaning                                                                                                               | Example |
+|--------------------|-----------------------------------------------------------------------------------------------------------------------|---------|
+| SPIN_BIN_PATH      | The path to the Spin executable that the user is running. Use this if your plugin issues commands using the Spin CLI. | /Users/alice/.cargo/bin/spin |
+| SPIN_BRANCH        | The Git branch from which the Spin executable was built.                                                              | main |
+| SPIN_BUILD_DATE    | The date on which the Spin executable was built, in yyyy-mm-dd format.                                                | 2023-05-15 |
+| SPIN_COMMIT_DATE   | The date of the Git commit from which the Spin executable was built, in yyyy-mm-dd format.                            | 2023-05-15 |
+| SPIN_COMMIT_SHA    | The SHA of the Git commit from which the Spin executable was built.                                                   | 49fb11b |
+| SPIN_DEBUG         | Whether the Spin executable is a debug build.                                                                         | false |
+| SPIN_TARGET_TRIPLE | The processor and operating system for which the Spin executable was built, in Rust target-triple format.             | aarch64-apple-darwin |
+| SPIN_VERSION       | The version of Spin. This can be used to detect features availability, or to determine pre-stable command syntax.     | 1.3.0 |
+| SPIN_VERSION_MAJOR | The major version of Spin.                                                                                            | 1 |
+| SPIN_VERSION_MINOR | The minor version of Spin.                                                                                            | 3 |
+| SPIN_VERSION_PRE   | The prerelease version string, or empty if this is a released version of Spin.                                        | pre0 |
+
+> These variables aren't set if the launching Spin instance is version 1.3 or earlier. If you depend on these variables, set the `spinCompatibility` entry in the manifest to require 1.4 or above.
+
+### Packaging a Plugin
+
+After creating your plugin executable, package it along with its license as a
+`tar.gz` archive. Note that the `name` field in the plugin manifest must match
+both the binary and license name. See the [`spin-plugins`
+repository
+README](https://github.com/fermyon/spin-plugins#spin-plugin-naming-conventions)
+for more details on naming conventions.
+
+Refer to the aptly named [`example`
+plugin](https://github.com/fermyon/spin-plugins/tree/main/example) for an
+example of how to build a plugin.
+
+### Creating a Spin Plugin Manifest
+
+A Spin plugin manifest is a JSON file that conforms to the [a specific JSON
+schema](https://github.com/fermyon/spin-plugins/blob/main/json-schema/spin-plugin-manifest-schema-0.1.json).
+A manifest defines a plugin’s name, version, license, homepage (i.e. GitHub
+repo), compatible Spin version, and gives a short description of the plugin. It
+also lists the URLs of the tar archives of the plugin for various operating
+systems and platforms. The URL can point to the local path to the file by using
+the file scheme `file://`, for example, `file:///tmp/my-plugin.tar.gz`.
+
+To ensure your plugin manifest is valid, follow the steps in the [`spin-plugins`
+repository
+README](https://github.com/fermyon/spin-plugins#validating-plugin-schemas).
+
+### Installing a Local Plugin
+
+By default, Spin will look in the plugins catalogue for a plugin. However, when
+developing and testing a plugin, it is unlikely to be in the the catalogue. For
+both installs and upgrades, the `--file` or `--url` flags can be used to point
+to specific local or remote plugin manifests. For example, a local manifest
+called `practice.json` can be installed and run as follows:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin plugin install --file practice.json
+$ spin practice
+```
+
+### Contributing a Plugin
+
+If you think the community would benefit from your newly created plugin, create
+a PR to add it to the [Spin plugins
+catalogue](https://github.com/fermyon/spin-plugins/tree/main/manifests)!

--- a/content/spin/v2/python-components.md
+++ b/content/spin/v2/python-components.md
@@ -1,0 +1,341 @@
+title = "Building Spin Components in Python"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/python-components.md"
+
+---
+- [Spin's Python Plugin](#spins-python-plugin)
+- [Spin's Python HTTP Request Handler Template](#spins-python-http-request-handler-template)
+- [Structure of a Python Component](#structure-of-a-python-component)
+- [A Simple HTTP Components Example](#a-simple-http-components-example)
+  - [Building and Running the Application](#building-and-running-the-application)
+- [An Outbound HTTP Example](#an-outbound-http-example)
+  - [Configuration](#configuration)
+  - [Building and Running the Application](#building-and-running-the-application-1)
+- [An Outbound Redis Example](#an-outbound-redis-example)
+  - [Configuration](#configuration-1)
+  - [Building and Running the Application](#building-and-running-the-application-2)
+- [Storing Data in the Spin Key-Value Store](#storing-data-in-the-spin-key-value-store)
+- [Storing Data in SQLite](#storing-data-in-sqlite)
+- [AI Inferencing From Python Components](#ai-inferencing-from-python-components)
+
+With <a href="https://www.python.org/" target="_blank">Python</a> being a very popular language, Spin provides support for building components with Python; [using an experimental SDK](https://github.com/fermyon/spin-python-sdk). The development of the Python SDK is continually being worked on to improve user experience and also add new features. 
+
+> This guide assumes you have Spin installed. If this is your first encounter with Spin, please see the [Quick Start](quickstart), which includes information about installing Spin with the Python templates, installing required tools, and creating Python applications.
+
+> This guide assumes you are familiar with the Python programming language, but if you are just getting started, be sure to check out <a href="https://docs.python.org/3/" target="_blank">the official Python documentation</a> and comprehensive <a href="https://docs.python.org/3/reference/" target="_blank">language reference</a>.
+
+**Please note:** There is a blog article [introducing the release of this Spin Python SDK](https://www.fermyon.com/blog/spin-python-sdk) if you are interested in some further reading; in addition to this technical documentation.
+
+## Spin's Python Plugin
+
+To compile Python programs to Spin components, you need to install a Spin plugin called `py2wasm`. The following commands will ensure that you have the latest version of the plugin installed:
+
+<!-- @selectiveCpy -->
+
+```bash
+# Fetch all of the latest Spin plugins from the spin-plugins repository
+$ spin plugin update
+# Install py2wasm plugin
+$ spin plugin install py2wasm
+```
+
+**Please note:** For more information about managing `spin plugins`, see the [plugins section](/common/cli-reference#plugins) in the Spin Command Line Interface (CLI) documentation.
+
+## Spin's Python HTTP Request Handler Template
+
+Spin's Python HTTP Request Handler Template can be installed from [spin-python-sdk repository](https://github.com/fermyon/spin-python-sdk/tree/main/) using the following command:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin templates install --git https://github.com/fermyon/spin-python-sdk --update
+```
+
+The above command will install the `http-py` template and produce an output similar to the following:
+
+<!-- @nocpy -->
+
+```text
+Copying remote template source
+Installing template http-py...
+Installed 1 template(s)
+
++---------------------------------------------+
+| Name      Description                       |
++=============================================+
+| http-py   HTTP request handler using Python |
++---------------------------------------------+
+```
+
+**Please note:** For more information about managing `spin templates`, see the [templates section](/common/cli-reference#templates) in the Spin Command Line Interface (CLI) documentation.
+
+## Structure of a Python Component
+
+A new Python component can be created using the following command:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin new http-py hello-world --accept-defaults
+```
+
+This creates a directory of the following structure:
+
+<!-- @nocpy -->
+
+```text
+hello-world/
+├── app.py
+├── Pipfile
+└── spin.toml
+```
+
+The `spin.toml` file will look similar to the following:
+
+<!-- @nocpy -->
+
+```toml
+spin_manifest_version = "1"
+authors = ["Fermyon Engineering <engineering@fermyon.com>"]
+description = ""
+name = "hello-world"
+trigger = { type = "http", base = "/" }
+version = "0.1.0"
+
+[[component]]
+id = "hello-world"
+source = "app.wasm"
+[component.trigger]
+route = "/..."
+[component.build]
+command = "spin py2wasm app -o app.wasm"
+```
+
+## A Simple HTTP Components Example
+
+In Spin, HTTP components are triggered by the occurrence of an HTTP request and must return an HTTP response at the end of their execution. Components can be built in any language that compiles to WASI. If you would like additional information about building HTTP applications you may find [the HTTP trigger page](./http-trigger.md) useful.
+
+Building a Spin HTTP component using the Python SDK means writing a single function that takes an HTTP request as a parameter, and returns an HTTP response. Here is an example of the default Python code which the previous `spin new` created for us; a simple example of a request/response:
+
+```
+from spin_http import Response
+
+def handle_request(request):
+    return Response(200,
+                    {"content-type": "text/plain"},
+                    bytes(f"Hello from the Python SDK", "utf-8"))
+```
+
+The important things to note in the implementation above:
+
+- the `handle_request` function is the entry point for the Spin component.
+- the component returns a `spin_http.Response`.
+
+The source code for this Python HTTP component example is in the `app.py` file. The `app.py` file is compiled into a `.wasm` module thanks to the `py2wasm` plugin. This all happens behind the scenes. 
+
+### Building and Running the Application
+
+All you need to do is run the `spin build` command from within the project's directory; as shown below:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ cd hello-world
+$ spin build
+```
+
+Essentially, we have just created a new Spin compatible module which can now be run using the `spin up` command, as shown below:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin up
+```
+
+With Spin running our application in our terminal, we can now go ahead (grab a new terminal) and call the Spin application via an HTTP request:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ curl -i localhost:3000/hello
+
+HTTP/1.1 200 OK
+content-type: text/plain
+content-length: 25
+
+Hello from the Python SDK
+```
+
+> **Please note:** All examples from this documentation page can be found in [the Python SDK repository on GitHub](https://github.com/fermyon/spin-python-sdk/tree/main/examples). If you are following along with these examples and don't get the desired result perhaps compare your own code with our previously built examples (mentioned above). Also please feel free to reach out on [Discord](https://discord.gg/AAFNfS7NGf) if you have any questions or need any additional support. 
+
+## An Outbound HTTP Example
+
+This next example will create an outbound request, to obtain a random fact about animals, which will be returned to the calling code. If you would like to try this out, you can go ahead and update your existing `app.py` file from the previous step; using the following source code:
+
+```python
+from spin_http import Request, Response, http_send
+
+
+def handle_request(request):
+
+    response = http_send(
+        Request("GET", "https://random-data-api.fermyon.app/animals/json", {}, None))
+
+    return Response(200,
+                    {"content-type": "text/plain"},
+                    bytes(f"Here is an animal fact: {str(response.body, 'utf-8')}", "utf-8"))
+```
+
+### Configuration
+
+The Spin framework protects your code from making outbound requests to just any URL. For example, if we try to run the above code **without any additional configuration**, we will correctly get the following error `AssertionError: HttpError::DestinationNotAllowed`. To allow our component to request the `random-data-api.fermyon.app` domain, all we have to do is add that domain to the specific component of the application that is making the request. Here is an example of an updated `spin.toml` file where we have added `allowed_http_hosts`:
+
+<!-- @nocpy -->
+
+```toml
+spin_manifest_version = "1"
+authors = ["Fermyon Engineering <engineering@fermyon.com>"]
+description = ""
+name = "hello-world"
+trigger = { type = "http", base = "/" }
+version = "0.1.0"
+
+[[component]]
+id = "hello-world"
+source = "app.wasm"
+allowed_http_hosts = ["random-data-api.fermyon.app"]
+[component.trigger]
+route = "/..."
+[component.build]
+command = "spin py2wasm app -o app.wasm"
+```
+
+### Building and Running the Application
+
+If we re-build the application with this new configuration and re-run, we will get our new animal fact:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin build
+$ spin up
+```
+
+A new request now correctly returns an animal fact from the API endpoint.
+
+<!-- @selectiveCpy -->
+
+```bash
+$ curl -i localhost:3000/hello
+
+HTTP/1.1 200 OK
+content-type: text/plain
+content-length: 130
+
+Here is an animal fact: {"timestamp":1684299253331,"fact":"Reindeer grow new antlers every year"}   
+```
+
+## An Outbound Redis Example
+
+In this final example, we talk to an existing Redis instance. You can find the official [instructions on how to install Redis here](https://redis.io/docs/getting-started/installation/). We also gave a quick run-through on setting up Redis with Spin in our previous article called [Persistent Storage in Webassembly Applications](https://www.fermyon.com/blog/persistent-storage-in-webassembly-applications), so please take a look at that blog if you need a hand.
+
+### Configuration
+
+After installing Redis on localhost, we simply add the `config = { redis_address = "redis://127.0.0.1:6379" }` to the `spin.toml` file, as shown below:
+
+<!-- @nocpy -->
+
+```toml
+spin_manifest_version = "1"
+authors = ["Fermyon Engineering <engineering@fermyon.com>"]
+description = ""
+name = "hello-world"
+trigger = { type = "http", base = "/" }
+version = "0.1.0"
+
+[[component]]
+id = "hello-world"
+source = "app.wasm"
+config = { redis_address = "redis://127.0.0.1:6379" }
+[component.trigger]
+route = "/..."
+[component.build]
+command = "spin py2wasm app -o app.wasm"
+```
+
+If you are still following along, please go ahead and update your `app.py` file one more time, as follows:
+
+```python
+from spin_http import Response
+from spin_redis import redis_del, redis_get, redis_incr, redis_set, redis_sadd, redis_srem, redis_smembers
+from spin_config import config_get
+
+
+def handle_request(request):
+
+    redis_address = config_get("redis_address")
+    redis_set(redis_address, "foo", b"bar")
+    value = redis_get(redis_address, "foo")
+    redis_del(redis_address, ["testIncr"])
+    redis_incr(redis_address, "testIncr")
+
+    redis_sadd(redis_address, "testSets", ["hello", "world"])
+    content = redis_smembers(redis_address, "testSets")
+    redis_srem(redis_address, "testSets", ["hello"])
+
+    assert value == b"bar", f"expected \"bar\", got \"{str(value, 'utf-8')}\""
+
+    return Response(200,
+                    {"content-type": "text/plain"},
+                    bytes(f"Executed outbound Redis commands: {request.uri}", "utf-8"))
+```
+
+### Building and Running the Application
+
+After we re-build and re-run, again, we can make one final request to our Spin application:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin build
+$ spin up
+```
+
+This latest request correctly returns the correct output, in accordance with our Python source code from above:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ curl -i localhost:3000/hello
+
+HTTP/1.1 200 OK
+content-type: text/plain
+content-length: 40
+date = "2023-11-02T16:00:00Z"
+
+Executed outbound Redis commands: /hello
+```
+
+If we go into our Redis CLI on localhost we can see that the value `foo` which was set in the Python source code ( `redis_set(redis_address, "foo", b"bar")` ) is now correctly set to the value of `bar`:
+
+<!-- @nocpy -->
+
+```bash
+redis-cli
+127.0.0.1:6379> get foo
+"bar"
+```
+
+## Storing Data in the Spin Key-Value Store
+
+Spin has a key-value store built in. For information about using it from Python, see [the key-value store API guide](kv-store-api-guide).
+
+## Storing Data in SQLite
+
+For more information about using SQLite from Python, see [SQLite storage](sqlite-api-guide).
+
+## AI Inferencing From Python Components
+
+For more information about using Serverless AI from Python, see the [Serverless AI](serverless-ai-api-guide) API guide.

--- a/content/spin/v2/quickstart.md
+++ b/content/spin/v2/quickstart.md
@@ -1,0 +1,860 @@
+title = "Taking Spin for a spin"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+enable_shortcodes = true
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/quickstart.md"
+keywords = "quickstart"
+
+---
+- [Install Spin](#install-spin)
+- [Install the Prerequisites](#install-the-prerequisites)
+  - [Install a Template](#install-a-template)
+  - [Install the Tools](#install-the-tools)
+- [Create Your First Application](#create-your-first-application)
+- [Build Your Application](#build-your-application)
+- [Run Your Application](#run-your-application)
+- [Deploy Your Application to Fermyon Cloud](#deploy-your-application-to-fermyon-cloud)
+  - [Log in to Fermyon Cloud](#log-in-to-fermyon-cloud)
+  - [Deploy the Application](#deploy-the-application)
+- [Next Steps](#next-steps)
+
+Let's get Spin and take it from nothing to a "hello world" application!
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/GqpZ9Kw0K3E" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
+## Install Spin
+
+{{ tabs "os" }}
+
+{{ startTab "Linux"}}
+
+Download the `spin` binary along with a starter set of templates and plugins using the `install.sh` script hosted on this site:
+
+<!-- @selectiveCpy -->
+
+<pre class="bash spin-install" id="spin-install-quick"><code>$ curl -fsSL https://developer.fermyon.com/downloads/install.sh | bash
+</code></pre>
+
+Then move the `spin` binary somewhere in your path, so you can run it from anywhere. For example:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ sudo mv ./spin /usr/local/bin/spin
+```
+
+{{ blockEnd }}
+
+{{ startTab "macOS"}}
+
+Download the `spin` binary along with a starter set of templates and plugins using the `install.sh` script hosted on this site:
+
+<!-- @selectiveCpy -->
+
+<pre class="bash spin-install" id="spin-install-quick"><code>$ curl -fsSL https://developer.fermyon.com/downloads/install.sh | bash
+</code></pre>
+
+Then move the `spin` binary somewhere in your path, so you can run it from anywhere. For example:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ sudo mv ./spin /usr/local/bin/spin
+```
+
+{{ blockEnd }}
+
+{{ startTab "Windows"}}
+
+Download <a href="https://github.com/fermyon/spin/releases/latest" class="spin-install" id="spin-install-windows">the Windows binary release of Spin</a> from GitHub.
+
+Unzip the binary release and place the `spin.exe` in your system path.
+
+{{ blockEnd }}
+{{ blockEnd }}
+
+[See more options for installing Spin.](install)
+
+## Install the Prerequisites
+
+### Install a Template
+
+The quickest and most convenient way to start a new application is to install and use a Spin template for your preferred language:
+
+{{ tabs "sdk-type" }}
+
+{{ startTab "Rust"}}
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin templates install --git https://github.com/fermyon/spin --update
+Copying remote template source
+Installing template redis-rust...
+Installing template http-rust...
+... other templates omitted ...
++------------------------------------------------------------------------+
+| Name                Description                                        |
++========================================================================+
+| ... other templates omitted ...                                        |
+| http-rust           HTTP request handler using Rust                    |
+| redis-rust          Redis message handler using Rust                   |
+| ... other templates omitted ...                                        |
++------------------------------------------------------------------------+
+```
+
+Note: The Rust templates are in a repo that contains several other languages; they will all be installed together.
+
+{{ blockEnd }}
+
+{{ startTab "TypeScript" }}
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin templates install --git https://github.com/fermyon/spin-js-sdk --update
+Copying remote template source
+Installing template http-js...
+Installing template http-ts...
++------------------------------------------------------------------------+
+| Name                Description                                        |
++========================================================================+
+| http-js             HTTP request handler using Javascript              |
+| http-ts             HTTP request handler using Typescript              |
++------------------------------------------------------------------------+
+```
+
+{{ blockEnd }}
+
+{{ startTab "Python" }}
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin templates install --git https://github.com/fermyon/spin-python-sdk --update
+Copying remote template source
+Installing template http-py...
++---------------------------------------------+
+| Name      Description                       |
++=============================================+
+| http-py   HTTP request handler using Python |
++---------------------------------------------+
+```
+
+{{ blockEnd }}
+
+{{ startTab "TinyGo" }}
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin templates install --git https://github.com/fermyon/spin --update
+Copying remote template source
+Installing template redis-go...
+Installing template http-go...
++------------------------------------------------------------------------+
+| Name                Description                                        |
++========================================================================+
+| ... other templates omitted ...                                        |
+| http-go             HTTP request handler using (Tiny)Go                |
+| redis-go            Redis message handler using (Tiny)Go               |
+| ... other templates omitted ...                                        |
++------------------------------------------------------------------------+
+```
+
+Note: The Go templates are in a repo that contains several other languages; they will all be installed together.
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+### Install the Tools
+
+Some languages require additional tool support for Wasm:
+
+{{ tabs "sdk-type" }}
+
+{{ startTab "Rust"}}
+
+You'll need the `wasm32-wasi` target for Rust:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ rustup target add wasm32-wasi
+```
+
+[Learn more in the language guide.](rust-components)
+
+{{ blockEnd }}
+
+{{ startTab "TypeScript" }}
+
+You'll need the Spin `js2wasm` plugin:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin plugins update
+$ spin plugins install js2wasm --yes
+```
+
+[Learn more in the language guide.](javascript-components)
+
+{{ blockEnd }}
+
+{{ startTab "Python" }}
+
+You'll need the Spin `py2wasm` plugin:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin plugins update
+$ spin plugins install py2wasm --yes
+```
+
+[Learn more in the language guide.](python-components)
+
+{{ blockEnd }}
+
+{{ startTab "TinyGo" }}
+
+You'll need the TinyGo compiler, as the standard Go compiler does not yet support the WASI standard.  See the [TinyGo installation guide](https://tinygo.org/getting-started/install/).
+
+[Learn more in the language guide.](go-components)
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+## Create Your First Application
+
+Now you are ready to create your first Spin application:
+
+{{ tabs "sdk-type" }}
+
+{{ startTab "Rust"}}
+
+Use the `spin new` command and the `http-rust` template to scaffold a new Spin application:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin new
+Pick a template to start your application with:
+  http-c (HTTP request handler using C and the Zig toolchain)
+  http-csharp (HTTP request handler using C# (EXPERIMENTAL))
+  http-go (HTTP request handler using (Tiny)Go)
+  http-grain (HTTP request handler using Grain)
+> http-rust (HTTP request handler using Rust)
+  http-swift (HTTP request handler using SwiftWasm)
+  http-zig (HTTP request handler using Zig)
+  redis-go (Redis message handler using (Tiny)Go)
+  redis-rust (Redis message handler using Rust)
+
+Enter a name for your new application: hello_rust
+Project description: My first Rust Spin application
+HTTP base: /
+HTTP path: /...
+```
+
+This command created a directory with the necessary files needed to build and run a Rust Spin application.  Change to that directory, and look at the files.  It looks very much like a normal Rust library project:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ cd hello_rust
+$ tree
+.
+├── .cargo
+│   └── config.toml
+├── .gitignore
+├── Cargo.toml
+├── spin.toml
+└── src
+    └── lib.rs
+```
+
+The additional `spin.toml` file is the manifest file, which tells Spin what events should trigger what components.  In this case our trigger is HTTP, for a Web application, and we have only one component, at the route `/...`.  This is a wildcard that matches any route:
+
+<!-- @nocpy -->
+
+```toml
+spin_manifest_version = "1"
+authors = ["You <you@yourself.net>"]
+description = "My first Rust Spin application"
+name = "hello_rust"
+trigger = { type = "http", base = "/" }
+version = "0.1.0"
+
+[[component]]
+id = "hello-rust"
+source = "target/wasm32-wasi/release/hello_rust.wasm"
+allowed_http_hosts = []
+[component.trigger]
+route = "/..."
+[component.build]
+command = "cargo build --target wasm32-wasi --release"
+```
+
+This represents a simple Spin HTTP application (triggered by an HTTP request), with
+a single component called `hello-rust`. This component is on the route `/...`, which is a wildcard
+meaning it will match any route.  When the application gets an HTTP request, Spin will map its route
+to the `hello-rust` component, and execute the associated `hello_rust.wasm`
+WebAssembly module.
+
+[Learn more about the manifest here.](./writing-apps)
+
+Now let's have a look at the code. Below is the complete source
+code for a Spin HTTP component written in Rust — a regular Rust function that
+takes an HTTP request as a parameter and returns an HTTP response, and it is
+annotated with the `http_component` macro which identifies it as the entry point
+for HTTP requests:
+
+```rust
+use anyhow::Result;
+use spin_sdk::{
+    http::{Request, Response},
+    http_component,
+};
+
+/// A simple Spin HTTP component.
+#[http_component]
+fn handle_hello_rust(req: Request) -> Result<Response> {
+    println!("{:?}", req.headers());
+    Ok(http::Response::builder()
+        .status(200)
+        .header("foo", "bar")
+        .body(Some("Hello, Fermyon".into()))?)
+}
+```
+
+{{ blockEnd }}
+
+{{ startTab "TypeScript"}}
+
+Use the `spin new` command and the `http-ts` template to scaffold a new Spin application.  (If you prefer JavaScript to TypeScript, the `http-js` template is very similar.):
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin new
+Pick a template to start your application with:
+  http-js (HTTP request handler using Javascript)
+> http-ts (HTTP request handler using Typescript)
+Enter a name for your new application: hello_typescript
+Project description: My first TypeScript Spin application
+HTTP base: /
+HTTP path: /...
+```
+
+This command created a directory with the necessary files needed to build and run a TypeScript Spin application.  Change to that directory, and look at the files.  It looks similar to a lot of NPM projects:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ cd hello_typescript
+$ tree
+.
+├── package.json
+├── README.md
+├── spin.toml
+├── src
+│   └── index.ts
+├── tsconfig.json
+└── webpack.config.js
+```
+
+The additional `spin.toml` file is the manifest file, which tells Spin what events should trigger what components.  In this case our trigger is HTTP, for a Web application, and we have only one component, at the route `/...`.  This is a wildcard that matches any route:
+
+<!-- @nocpy -->
+
+```toml
+spin_manifest_version = "1"
+authors = ["You <you@yourself.net>"]
+description = "My first TypeScript Spin application"
+name = "hello_typescript"
+trigger = { type = "http", base = "/" }
+version = "0.1.0"
+
+[[component]]
+id = "hello-typescript"
+source = "target/spin-http-js.wasm"
+exclude_files = ["**/node_modules"]
+[component.trigger]
+route = "/..."
+[component.build]
+command = "npm run build"
+```
+
+This represents a simple Spin HTTP application (triggered by an HTTP request), with
+a single component called `hello-typescript`. This component is on the route `/...`, which is a wildcard
+meaning it will match any route.  When the application gets an HTTP request, Spin will map its route
+to the `hello-typescript` component, and execute the associated `spin-http-js.wasm`
+WebAssembly module.
+
+[Learn more about the manifest here.](./writing-apps)
+
+Now let's have a look at the code. Below is the complete source
+code for a Spin HTTP component written in TypeScript — a regular function named `handleRequest` that
+takes an HTTP request as a parameter and returns an HTTP response.  (The
+JavaScript version looks slightly different, but is still a function with
+the same signature.)  The Spin `js2wasm` plugin looks for the `handleRequest` function
+by name when building your application into a Wasm module:
+
+```javascript
+import { HandleRequest, HttpRequest, HttpResponse} from "@fermyon/spin-sdk"
+
+const encoder = new TextEncoder()
+
+export const handleRequest: HandleRequest = async function(request: HttpRequest): Promise<HttpResponse> {
+    return {
+      status: 200,
+      headers: { "foo": "bar" },
+      body: encoder.encode("Hello from TS-SDK").buffer
+    }
+}
+```
+
+{{ blockEnd }}
+
+{{ startTab "Python"}}
+
+Use the `spin new` command and the `http-py` template to scaffold a new Spin application.
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin new
+Pick a template to start your application with:
+> http-py (HTTP request handler using Python)
+Enter a name for your new application: hello_python
+Description: My first Python Spin application
+HTTP base: /
+HTTP path: /...
+```
+
+This command created a directory with the necessary files needed to build and run a Python Spin application.  Change to that directory, and look at the files.  It contains a minimal Python application:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ cd hello_python
+$ tree
+.
+├── app.py
+├── Pipfile
+├── README.md
+└── spin.toml
+```
+
+The additional `spin.toml` file is the manifest file, which tells Spin what events should trigger what components.  In this case our trigger is HTTP, for a Web application, and we have only one component, at the route `/...`.  This is a wildcard that matches any route.
+
+<!-- @nocpy -->
+
+```toml
+spin_manifest_version = "1"
+authors = ["You <you@yourself.net>"]
+description = "My first Python Spin application"
+name = "hello_python"
+trigger = { type = "http", base = "/" }
+version = "0.1.0"
+
+[[component]]
+id = "hello-python"
+source = "app.wasm"
+[component.trigger]
+route = "/..."
+[component.build]
+command = "spin py2wasm app -o app.wasm"
+```
+
+This represents a simple Spin HTTP application (triggered by an HTTP request), with
+a single component called `hello-python`. This component is on the route `/...`, which is a wildcard
+meaning it will match any route.  When the application gets an HTTP request, Spin will map its route
+to the `hello-python` component, and execute the associated `app.wasm`
+WebAssembly module.
+
+[Learn more about the manifest here.](./writing-apps)
+
+Now let's have a look at the code. Below is the complete source
+code for a Spin HTTP component written in Python — a regular function named `handle_request` that
+takes an HTTP request as a parameter and returns an HTTP response.  The Spin `py2wasm` plugin looks for the `handle_request` function by name when building your application into a Wasm module.
+
+```python
+from spin_http import Response
+
+def handle_request(request):
+    return Response(200,
+                    [("content-type", "text/plain")],
+                    bytes(f"Hello from the Python SDK", "utf-8"))
+```
+
+{{ blockEnd }}
+
+{{ startTab "TinyGo"}}
+
+Use the `spin new` command and the `http-go` template to scaffold a new Spin application.
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin new
+Pick a template to start your application with:
+  http-c (HTTP request handler using C and the Zig toolchain)
+  http-empty (HTTP application with no components)
+> http-go (HTTP request handler using (Tiny)Go)
+  http-grain (HTTP request handler using Grain)
+  http-php (HTTP request handler using PHP)
+  http-rust (HTTP request handler using Rust)
+Enter a name for your new application: hello_go
+Description: My first Go Spin application
+HTTP base: /
+HTTP path: /...
+```
+
+This command created a directory with the necessary files needed to build and run a Go Spin application using the TinyGo compiler.  Change to that directory, and look at the files.  It looks very much like a normal Go project:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ cd hello_go
+$ tree
+.
+├── go.mod
+├── go.sum
+├── main.go
+└── spin.toml
+```
+
+The additional `spin.toml` file is the manifest file, which tells Spin what events should trigger what components.  In this case our trigger is HTTP, for a Web application, and we have only one component, at the route `/...`.  This is a wildcard that matches any route.
+
+<!-- @nocpy -->
+
+```toml
+spin_manifest_version = "1"
+authors = ["You <you@yourself.net>"]
+description = "My first Go Spin application"
+name = "hello_go"
+trigger = { type = "http", base = "/" }
+version = "0.1.0"
+
+[[component]]
+id = "hello-go"
+source = "main.wasm"
+allowed_http_hosts = []
+[component.trigger]
+route = "/..."
+[component.build]
+command = "tinygo build -target=wasi -gc=leaking -no-debug -o main.wasm main.go"
+```
+
+This represents a simple Spin HTTP application (triggered by an HTTP request), with
+a single component called `hello-go`. This component is on the route `/...`, which is a wildcard
+meaning it will match any route.  When the application gets an HTTP request, Spin will map its route
+to the `hello-go` component, and execute the associated `main.wasm`
+WebAssembly module.
+
+[Learn more about the manifest here.](./writing-apps)
+
+Now let's have a look at the code. Below is the complete source
+code for a Spin HTTP component written in Go. Notice where the work is done.  The
+`main` function is empty (and Spin never calls it).  Instead, the `init` function
+sets up a callback, and passes that callback to `spinhttp.Handle` to register it as
+the handler for HTTP requests.  You can learn more about this structure
+in the [Go language guide](go-components).
+
+```go
+package main
+
+import (
+        "fmt"
+        "net/http"
+
+        spinhttp "github.com/fermyon/spin/sdk/go/http"
+)
+
+func init() {
+        spinhttp.Handle(func(w http.ResponseWriter, r *http.Request) {
+                w.Header().Set("Content-Type", "text/plain")
+                fmt.Fprintln(w, "Hello Fermyon!")
+        })
+}
+
+func main() {}
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+## Build Your Application
+
+The Spin template creates starter source code.  Now you need to turn that into a Wasm module.  The template puts build instructions for each component into the manifest.  Use the `spin build` command to run them:
+
+{{ tabs "sdk-type" }}
+
+{{ startTab "Rust"}}
+
+```bash
+$ spin build
+Executing the build command for component hello-rust: cargo build --target wasm32-wasi --release
+    Updating crates.io index
+    Updating git repository `https://github.com/fermyon/spin`
+    Updating git repository `https://github.com/bytecodealliance/wit-bindgen`
+   Compiling anyhow v1.0.69
+   Compiling version_check v0.9.4
+   # ...
+   Compiling spin-sdk v0.10.0 
+   Compiling hello-rust v0.1.0 (/home/ivan/testing/start/hello_rust)
+    Finished release [optimized] target(s) in 11.94s
+Successfully ran the build command for the Spin components.
+```
+
+If the build fails, check:
+
+* Are you in the `hello_rust` directory?
+* Did you successfully [install the `wasm32-wasi` target](#install-the-tools)?
+* Is your version of Rust up to date (`cargo --version`)?  The Spin SDK needs Rust 1.64 or above.
+
+If you would like to know what build command Spin runs for a component, you can find it in the manifest, in the `component.build` section:
+
+```toml
+[component.build]
+command = "cargo build --target wasm32-wasi --release"
+```
+
+You can always run this command manually; `spin build` is a shortcut to save you having to remember it.
+
+{{ blockEnd }}
+
+{{ startTab "TypeScript"}}
+
+As normal for NPM projects, before you build for the first time, you must run `npm install`:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ npm install
+
+added 134 packages, and audited 135 packages in 2s
+
+18 packages are looking for funding
+  run `npm fund` for details
+
+found 0 vulnerabilities
+```
+
+Then run `spin build`:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin build
+Executing the build command for component hello-typescript: npm run build
+
+> hello-typescript@1.0.0 build
+> npx webpack --mode=production && mkdir -p target && spin js2wasm -o target/spin-http-js.wasm dist/spin.js
+
+asset spin.js 4.57 KiB [emitted] (name: main)
+runtime modules 670 bytes 3 modules
+./src/index.ts 2.85 KiB [built] [code generated]
+webpack 5.75.0 compiled successfully in 1026 ms
+
+Starting to build Spin compatible module
+Preinitiating using Wizer
+Optimizing wasm binary using wasm-opt
+Spin compatible module built successfully
+Successfully ran the build command for the Spin components.
+```
+
+If the build fails, check:
+
+* Are you in the `hello_typescript` directory?
+* Did you run `npm install` before building`?
+* Did you install the `js2wasm` plugin?
+
+If you would like to know what build command Spin runs for a component, you can find it in the manifest, in the `component.build` section:
+
+```toml
+[component.build]
+command = "npm run build"
+```
+
+You can always run this command manually; `spin build` is a shortcut.
+
+{{ blockEnd }}
+
+{{ startTab "Python"}}
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin build
+Executing the build command for component hello-python: spin py2wasm app -o app.wasm
+Spin-compatible module built successfully
+Successfully ran the build command for the Spin components.
+```
+
+If the build fails, check:
+
+* Are you in the `hello_python` directory?
+* Did you install the `py2wasm` plugin?
+
+If you would like to know what build command Spin runs for a component, you can find it in the manifest, in the `component.build` section:
+
+```toml
+[component.build]
+command = "spin py2wasm app -o app.wasm"
+```
+
+You can always run this command manually; `spin build` is a shortcut.
+
+{{ blockEnd }}
+
+{{ startTab "TinyGo"}}
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin build
+Executing the build command for component hello-go: tinygo build -target=wasi -gc=leaking -no-debug -o main.wasm main.go
+go: downloading github.com/fermyon/spin/sdk/go v0.10.0
+Successfully ran the build command for the Spin components.
+```
+
+If the build fails, check:
+
+* Are you in the `hello_go` directory?
+* Did you successfully [install TinyGo](#install-the-tools)?
+* Are your versions of Go and TinyGo up to date?  The Spin SDK needs TinyGo 0.27 or above.
+* Set Environment Variable `CGO_ENABLED=1`. (Since the Go SDK is built using CGO, it requires the CGO_ENABLED=1 environment variable to be set.)
+
+If you would like to know what build command Spin runs for a component, you can find it in the manifest, in the `component.build` section:
+
+```toml
+[component.build]
+command = "tinygo build -target=wasi -gc=leaking -no-debug -o main.wasm main.go"
+```
+
+You can always run this command manually; `spin build` is a shortcut to save you having to remember it.
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+> `spin build` can be used to build all components defined in the Spin manifest
+> file at the same time, and also has a flag that starts the application after
+> finishing the compilation, `spin build --up`.
+>
+> For more details, see the [page about building Spin applications](./build.md).
+
+## Run Your Application
+
+Now that you have created the application and built the component, you can _spin up_
+the application (pun intended):
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin up
+Serving http://127.0.0.1:3000
+Available Routes:
+  hello-typescript: http://127.0.0.1:3000 (wildcard)
+```
+
+If you would like to see what Spin is doing under the hood, set the RUST_LOG environment variable for detailed logs, before running `spin up`:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ export RUST_LOG=spin=trace
+```
+
+> The variable is `RUST_LOG` no matter what language your application is written in, because this is setting the log level for Spin itself.
+
+Spin instantiates all components from the application manifest, and
+creates the router configuration for the HTTP trigger according to the routes in the manifest. The
+component can now be invoked by making requests to `http://localhost:3000/`
+(or any path under that, since it's a wildcard):
+
+<!-- @selectiveCpy -->
+
+```bash
+$ curl -i localhost:3000
+HTTP/1.1 200 OK
+foo: bar
+content-length: 14
+date = "2023-11-02T16:00:00Z"
+
+Hello, Fermyon
+```
+
+> The `curl` output may vary based on which language SDK you use. 
+
+Congratulations! You just created, built and ran your first Spin application!
+
+## Deploy Your Application to Fermyon Cloud
+
+`spin up` runs your application locally. Now it's time to put it on the Web via [Fermyon Cloud](https://cloud.fermyon.com).
+
+> Fermyon Cloud's Starter tier is free, and doesn't require you to enter any kind of payment instrument. You only need a [GitHub account](https://docs.github.com/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/remembering-your-github-username-or-email).
+
+### Log in to Fermyon Cloud
+
+Before deploying your application to Fermyon Cloud, you have to log in, using the `spin login` command. This generates a code to authorize your current device against the Fermyon Cloud, and prints a link that will take you to where you enter the code. (You will need to be logged into your GitHub account; if you're not, it will prompt you to log in.) Follow the instructions in the prompt to complete the authorization process.
+
+`spin login` prints a confirmation message when authorization completes:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin login
+
+Copy your one-time code:
+
+XXXXXXXX
+
+...and open the authorization page in your browser:
+
+https://cloud.fermyon.com/device-authorization
+
+Waiting for device authorization...
+Device authorized!
+```
+
+### Deploy the Application
+
+Now let's deploy the application:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin deploy
+```
+
+The deployment process prints progress information as your application uploads and is rolled out to the cloud:
+
+<!-- @nocpy -->
+
+```console
+Uploading hello_typescript version 0.1.0+XXXXXXXX to Fermyon Cloud...
+Deploying...
+Waiting for application to become ready... ready
+Available Routes:
+  hello-typescript: https://hello-typescript-XXXXXXXX.fermyon.app (wildcard)
+```
+
+You can Ctrl+Click on the link in the terminal to visit the web application you just deployed.
+
+> In the example output above, `hello_typescript` is a placeholder for your application name - you'll see whatever you entered as the application name when you ran `spin new` earlier. The `XXXXXXXX` fragment is randomly generated to make a unique URL.
+
+Congratulations again - you've now deployed your first Spin application to [Fermyon Cloud](https://cloud.fermyon.com)!
+
+## Next Steps
+
+- Learn more about [writing Spin components and manifests](writing-apps)
+- Learn how to [build your Spin application code](build)
+- Learn more about [Fermyon Cloud](/cloud/index)

--- a/content/spin/v2/rdbms-storage.md
+++ b/content/spin/v2/rdbms-storage.md
@@ -1,0 +1,81 @@
+title = "Relational Database Storage"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+enable_shortcodes = true
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/rdbms-storage.md"
+
+---
+- [Using MySQL and PostgreSQL From Applications](#using-mysql-and-postgresql-from-applications)
+
+Spin provides two interfaces for relational (SQL) databases:
+
+* A built-in [SQLite database](/spin/sqlite-api-guide), which is always available and requires no management on your part.
+* "Bring your own database" support for MySQL and PostgreSQL, where you host and manage the database outside of Spin.
+
+This page covers the "bring your own database" scenario.  See [SQLite Storage](/spin/sqlite-api-guide) for the built-in service.
+
+{{ details "Why do I need a Spin interface? Why can't I just use my language's database libraries?" "The current version of the WebAssembly System Interface (WASI) doesn't provide a sockets interface, so database libraries that depend on sockets can't be built to Wasm. The Spin interface means Wasm modules can bypass this limitation by asking Spin to make the database connection on their behalf." }}
+
+## Using MySQL and PostgreSQL From Applications
+
+The Spin SDK surfaces the Spin MySQL and PostgreSQL interfaces to your language. The set of operations is the same across both databases:
+
+| Operation  | Parameters                          | Returns             | Behavior |
+|------------|-------------------------------------|---------------------|----------|
+| `query`    | address, statement, SQL parameters  | database records    | Runs the specified statement against the database, returning the query results as a set of rows. |
+| `execute`  | address, statement, SQL parameters  | integer (not MySQL) | Runs the specified statement against the database, returning the number of rows modified by the statement.  (MySQL does not return the modified row count.) |
+
+The exact detail of calling these operations from your application depends on your language:
+
+{{ tabs "sdk-type" }}
+
+{{ startTab "Rust"}}
+
+MySQL functions are available in the `spin_sdk::mysql` module, and PostgreSQL functions in the `spin_sdk::pg` module. The function names match the operations above. This example shows MySQL:
+
+```rust
+use spin_sdk::mysql::{self, Decode, ParameterValue};
+
+let params = vec![ParameterValue::Int32(id)];
+let rowset = mysql::query(&address, "SELECT id, name FROM pets WHERE id = ?", &params)?;
+
+match rowset.rows.first() {
+    None => /* no rows matched query */,
+    Some(row) => {
+        let name = String::decode(&row[1])?;
+    }
+}
+```
+
+**Notes**
+
+* Parameters are instances of the `ParameterValue` enum; you must wrap raw values in this type.
+* A row is a vector of the `DbValue` enum. Use the `Decode` trait to access conversions to common types.
+* Using PostgreSQL works in the same way, except that you `use` the `spin_sdk::pg` module instead of `spin_sdk::mysql`.
+* Modified row counts are returned as `u64`. (MySQL `execute` does not return the modified row count.)
+* All functions wrap the return in `anyhow::Result`.
+
+You can find complete examples for using relational databases in the Spin repository on GitHub ([MySQL](https://github.com/fermyon/spin/tree/main/examples/rust-outbound-mysql), [PostgreSQL](https://github.com/fermyon/spin/tree/main/examples/rust-outbound-pg)).
+
+{{ blockEnd }}
+
+{{ startTab "TypeScript"}}
+
+The JavaScript/TypeScript SDK doesn't surface the MySQL or PostgreSQL APIs. However, you can use hosted relational database services that are accessible over HTTP. For an example, see the JavaScript SDK repository on GitHub ([TypeScript](https://github.com/fermyon/spin-js-sdk/tree/main/examples/typescript/planetscale), [JavaScript](https://github.com/fermyon/spin-js-sdk/tree/main/examples/javascript/planetscale)).
+
+{{ blockEnd }}
+
+{{ startTab "Python"}}
+
+The Python SDK doesn't currently surface the MySQL or PostgreSQL APIs.
+
+{{ blockEnd }}
+
+{{ startTab "TinyGo"}}
+
+The Go SDK doesn't currently surface the MySQL or PostgreSQL APIs.
+
+{{ blockEnd }}
+
+{{ blockEnd }}

--- a/content/spin/v2/redis-outbound.md
+++ b/content/spin/v2/redis-outbound.md
@@ -1,0 +1,148 @@
+title = "Redis Storage"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+enable_shortcodes = true
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/redis-outbound.md"
+
+---
+- [Using Redis From Applications](#using-redis-from-applications)
+
+Spin provides an interface for you to read and write the Redis key/value store, and to publish Redis pub-sub messages.
+
+{{ details "Why do I need a Spin interface? Why can't I just use my language's Redis library?" "The current version of the WebAssembly System Interface (WASI) doesn't provide a sockets interface, so Redis libraries that depend on sockets can't be built to Wasm. The Spin interface means Wasm modules can bypass this limitation by asking Spin to make the Redis connection on their behalf." }}
+
+## Using Redis From Applications
+
+The Spin SDK surfaces the Spin Redis interface to your language. The set of operations is common across all SDKs:
+
+| Operation  | Parameters | Returns | Behavior |
+|------------|------------|---------|----------|
+| Single value operations                      |
+| `get`        | address, key        | bytes   | Returns the value of `key`. If the key does not exist, returns a zero-length array. |
+| `set`        | address, key, bytes | -       | Sets the value of `key`, overwriting any existing value. |
+| `incr`       | address, key        | integer | Increments the value at `key` by 1. If the key does not exist, its value is set to 0 first (and immediately incremented to 1). If the current value isn't an integer, or a string that represents an integer, it errors and the value is not changed. |
+| `del`        | address, list of keys | -     | Removes the specified keys. Keys that don't exist are ignored (they do _not_ cause an error). |
+| Set value operations                         |
+| `sadd`       | address, key, list of strings | integer | Adds the strings to the set of values of `key`, and returns the number of newly added values. If the key does not exist, its value is set to the set of values |
+| `smembers`   | address, key        | list of strings | Returns the set of values of `key`. if the key does not exist, this is an empty set. |
+| `srem`       | address, key, list of strings | integer | Removes the strings from the set of values of `key`, and returns the number of newly removed values. If the key does not exist, this does nothing. |
+| Pub-sub operations                           |
+| `publish`    | address, channel, bytes | - | Publishes a message to the specified channel, with the specified payload bytes. |
+| General operations                           |
+| `execute`    | address, command, list of argument values | list of results | Executes the specified command with the specified arguments. This is a general-purpose 'escape hatch' if you need a command that isn't covered by the built-in operations. |
+
+The exact detail of calling these operations from your application depends on your language:
+
+{{ tabs "sdk-type" }}
+
+{{ startTab "Rust"}}
+
+Redis functions are available in the `spin_sdk::redis` module. The function names match the operations above. For example:
+
+```rust
+use spin_sdk::redis;
+
+let value = redis::get(&address, &key)?;
+```
+
+**General Notes**
+
+* Address and key parameters are of type `&str`.
+* Bytes parameters are of type `&[u8]` and return values are `Vec<u8>`.
+* Numeric return values are of type `i64`.
+* All functions wrap the return in `anyhow::Result`.
+
+**`del` Operation**
+
+* The list of keys is passed as `&[&str]`.
+
+**Set Operations**
+
+* List arguments are passed as `&[&str]` and returned as `Vec<String>`.
+
+**`execute` Operation**
+
+* The arguments and results are enums, representing integers, binary payloads, and (for results) status and nil values.
+
+You can find a complete Rust code example for using outbound Redis from an HTTP component in the [Spin repository on GitHub](https://github.com/fermyon/spin/tree/main/examples/rust-outbound-redis). Please also see this, related, [outbound Redis (using Rust) section](/spin/rust-components#storing-data-in-redis-from-rust-components). 
+
+{{ blockEnd }}
+
+{{ startTab "TypeScript"}}
+
+Redis functions are available on the `Redis` object. The function names match the operations above. For example:
+
+```javascript
+import {Redis} from "@fermyon/spin-sdk"
+
+const value = Redis.get(address, key);
+```
+
+**General Notes**
+
+* The `spinSdk` object is always available at runtime. Code checking and completion are available in TypeScript at design time if the module imports anything from the `@fermyon/spin-sdk` package.
+* Address and key parameters are strings.
+* Bytes parameters and return values are buffers (TypeScript `ArrayBuffer`).
+* Lists are passed and returned as arrays.
+* If a Spin SDK function fails, it throws an [Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error).
+
+**`execute` Operation**
+
+* The arguments and results can be either numbers or buffers. (In TypeScript they are union types, e.g. `BigInt | ArrayBuffer`.)
+
+You can find a complete TypeScript example for using outbound Redis from an HTTP component in the [JavaScript SDK repository on GitHub](https://github.com/fermyon/spin-js-sdk/tree/main/examples/typescript/outbound_redis). Please also see this, related, [outbound Redis (using TypeScript) section](/spin/javascript-components#storing-data-in-redis-from-jsts-components).
+
+{{ blockEnd }}
+
+{{ startTab "Python"}}
+
+Redis functions are available in the `spin_redis` module. The function names are prefixed `redis_`. For example:
+
+```python
+from spin_redis import redis_get
+
+value = redis_get(address, key)
+```
+
+**General Notes**
+
+* Address and key parameters are strings (`str`).
+* Bytes parameters and return values are `bytes`. (You can pass literal strings using the `b` prefix, e.g. `redis_set(address, key, b"hello")`.)
+* Numeric return values are of type `int64`.
+* Lists are passed and returned as Python lists.
+* Errors are signalled through exceptions.
+
+You can find a complete Python code example for using outbound Redis from an HTTP component in the [Python SDK repository on GitHub](https://github.com/fermyon/spin-python-sdk/tree/main/examples/outbound_redis). Please also see this, related, [outbound Redis (using Python) section](/spin/python-components#an-outbound-redis-example).
+
+{{ blockEnd }}
+
+{{ startTab "TinyGo"}}
+
+Redis functions are available in the `github.com/fermyon/spin/sdk/go/redis` package. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/redis). The function names are TitleCased. For example:
+
+```go
+import (
+	"github.com/fermyon/spin/sdk/go/redis"
+)
+
+payload, err := redis.Get(address, key)
+```
+
+**General Notes**
+
+* Address and key parameters are strings.
+* Bytes parameters are byte slices (`[]byte`).
+* Lists are passed as slices. For example, `redis.Del` takes the keys to delete as a `[]string`.
+* Errors are return through the usual Go multiple return values mechanism.
+
+**`execute` Operation**
+
+* The arguments are passed as `[]redis.RedisParameter`. You can construct `RedisParameter` instances around an `interface{}` but must provide a `Kind`. For example, `hello := redis.RedisParameter{Kind: redis.RedisParameterKindBinary, Val: []byte("hello")}`.
+* The results are returned as `[]redis.Result`. You can use the `Kind` member of `redis.Result` to interpret the `Val`.
+
+You can find a complete TinyGo example for using outbound Redis from an HTTP component in the [Spin repository on GitHub](https://github.com/fermyon/spin/tree/main/examples/tinygo-outbound-redis). Please also see this, related, [outbound Redis (using TinyGo) section](/spin/go-components#storing-data-in-redis-from-go-components). 
+
+{{ blockEnd }}
+
+{{ blockEnd }}

--- a/content/spin/v2/redis-trigger.md
+++ b/content/spin/v2/redis-trigger.md
@@ -1,0 +1,181 @@
+title = "The Spin Redis trigger"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+enable_shortcodes = true
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/redis-trigger.md"
+
+---
+- [Specifying an Application as Redis](#specifying-an-application-as-redis)
+- [Mapping a Channel to a Component](#mapping-a-channel-to-a-component)
+- [Redis Components](#redis-components)
+	- [The Message Handler](#the-message-handler)
+- [Inside Redis Components](#inside-redis-components)
+
+Pub-sub (publish-subscribe) messaging is a popular architecture for asynchronous message processing. Spin has built-in support to creating and running applications in response to messages on [pub-sub Redis channels](https://redis.io/topics/pubsub).
+
+The Redis trigger in Spin subscribes to messages from a given Redis instance, and dispatches those messages to components for handling.
+
+> This page deals with the Redis trigger for subscribing to pub-sub messages. For information about reading and writing the Redis key-value store, or for publishing messages, see the Language Guides.
+
+## Specifying an Application as Redis
+
+Every Spin application has a trigger specified in the manifest, which declares the type of events it responds to.
+For Redis applications, the application trigger has `type = "redis"`:
+
+<!-- @nocpy -->
+
+```toml
+# spin.toml
+trigger = { type = "redis", address = "redis://localhost:6379" }
+```
+
+The Redis trigger also requires an `address` field.  This is the address of the Redis instance to monitor.  Specify it using the `redis:` URL scheme.
+
+> If you create an application from a Redis template, the trigger will be already set up for you.
+
+By default, Spin does not authenticate to Redis. You can work around this by providing a password in the `redis://` URL.  For example: `address = "redis://:p4ssw0rd@localhost:6379"`
+
+> Do not use passwords in code committed to version control systems.
+
+> We plan to offer secrets-based authentication in future versions of Spin.
+
+In addition, each component must have Redis-specific configuration in its `[component.trigger]` table.
+
+## Mapping a Channel to a Component
+
+Each component handles one channel, specified in the `channel` field of the component `trigger` table.  For example, Spin will trigger this component when it receives a message on the `purchaseorders` channel:
+
+<!-- @nocpy -->
+
+```toml
+[component.trigger]
+channel = "purchaseorders"
+```
+
+> Spin subscribes only to the channels that are mapped to components. Other channels are ignored.
+
+## Redis Components
+
+Spin runs Redis components using the [WebAssembly component model](https://github.com/WebAssembly/component-model).  In this model, the Wasm module exports a well-known function that Spin calls to handle the Redis message.
+
+### The Message Handler
+
+The exact signature of the Redis handler, and how a function is identified to be exported as the handler, will depend on your language.
+
+{{ tabs "sdk-type" }}
+
+{{ startTab "Rust"}}
+
+In Rust, the handler is identified by the `#[spin_sdk::redis_component]` attribute.  It takes a `bytes::Bytes`, representing the raw payload of the Redis message, and returns an `anyhow::Result` indicating success or an error with details.  This example just logs the payload as a string:
+
+```rust
+use anyhow::Result;
+use bytes::Bytes;
+use spin_sdk::redis_component;
+use std::str::from_utf8;
+
+/// A simple Spin Redis component.
+#[redis_component]
+fn on_message(message: Bytes) -> Result<()> {
+    println!("{}", from_utf8(&message)?);
+    Ok(())
+}
+```
+
+{{ blockEnd }}
+
+{{ startTab "TypeScript"}}
+
+The JavaScript/TypeScript SDK doesn't currently support Redis components.  Please [let us know](https://github.com/fermyon/spin-js-sdk/issues) if this is important to you.
+
+{{ blockEnd }}
+
+{{ startTab "Python"}}
+
+The Python SDK doesn't currently support Redis components.  Please [let us know](https://github.com/fermyon/spin-python-sdk/issues) if this is important to you.
+
+{{ blockEnd }}
+
+{{ startTab "TinyGo"}}
+
+In Go, you register the handler as a callback in your program's `init` function.  Call `redis.Handle` (from the Spin SDK `redis` package), passing your handler as the sole argument.  Your handler takes a single byte slice (`[]byte`) argument, and may return an error or `nil`.
+
+> The do-nothing `main` function is required by TinyGo but is not used; the action happens in the `init` function and handler callback.
+
+This example just logs the payload as a string:
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/fermyon/spin/sdk/go/redis"
+)
+
+func init() {
+	redis.Handle(func(payload []byte) error {
+		fmt.Println(string(payload))
+		return nil
+	})
+}
+
+func main() {}
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+## Inside Redis Components
+
+For the most part, you'll build Redis component modules using a language SDK (see the Language Guides section), such as a Rust crate or Go package.  If you're interested in what happens inside the SDK, or want to implement Redis components in another language, read on!
+
+> The WebAssembly component model is in its early stages, and over time the triggers and application entry points will undergo changes, both in the definitions of functions and types, and in the binary representations of those definitions and of primitive types (the so-called Application Binary Interface or ABI).  However, Spin ensures binary compatibility over the course of any given major release.  For example, a component built using the Spin 1.0 SDK will work on any version of Spin in the 1.x range.
+
+The Redis component interface is defined using a WebAssembly Interface (WIT) file.  ([Learn more about the evolving WIT standard here.](https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md)).  You can find the latest WITs for Spin Redis components at [https://github.com/fermyon/spin/blob/main/wit/ephemeral](https://github.com/fermyon/spin/blob/main/wit/ephemeral).
+
+The core Redis types are defined in [https://github.com/fermyon/spin/blob/main/wit/ephemeral/redis-types.wit](https://github.com/fermyon/spin/blob/main/wit/ephemeral/redis-types.wit), though note that not all of these are used in the pub-sub Redis trigger:
+
+<!-- @nocpy -->
+
+```fsharp
+// General purpose error.
+enum error {
+    success,
+    error,
+}
+
+// The message payload.
+type payload = list<u8>
+
+// Remaining types are not used in the trigger
+```
+
+> The same Redis types are also used to model the API for sending outbound Redis requests.
+
+The entry point for Spin Redis components is then defined in [https://github.com/fermyon/spin/blob/main/wit/ephemeral/spin-redis.wit](https://github.com/fermyon/spin/blob/main/wit/ephemeral/spin-redis.wit):
+
+<!-- @nocpy -->
+
+```fsharp
+// wit/ephemeral/spin-redis.wit
+
+use * from redis-types
+
+// The entry point for a Redis handler.
+handle-redis-message: func(message: payload) -> expected<unit, error>
+```
+
+This is the function signature that all Redis components must implement, and
+which is used by Spin when instantiating and invoking the component.
+
+This interface (`spin-redis.wit`) can be directly used together with the
+[Bytecode Alliance `wit-bindgen` project](https://github.com/bytecodealliance/wit-bindgen)
+to build a component that Spin can invoke.
+
+This is exactly how Spin SDKs, such as the [Rust](rust-components) and [Go](go-components) SDKs, are built.
+As more languages add support for the component model, we plan to add support for them in the same way.
+
+> WIT and the ABI are evolving standards.  The latest version of `wit-bindgen` creates binary implementations that do not work with current language implementation of the WebAssembly System Interface (WASI).  Spin remains pinned to an older implementation of `wit-bindgen` until the next generation of the component model stabilizes and achieves language-level support.

--- a/content/spin/v2/registry-tutorial.md
+++ b/content/spin/v2/registry-tutorial.md
@@ -1,0 +1,124 @@
+title = "Spin Apps in Registries"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+enable_shortcodes = true
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/registry-tutorial.md"
+
+---
+- [Spin Registry Support](#spin-registry-support)
+- [Prerequisites](#prerequisites)
+- [Publishing and Running Spin Applications Using Registries (Video)](#publishing-and-running-spin-applications-using-registries-video)
+- [Set Up Your GHCR Instance](#set-up-your-ghcr-instance)
+- [Push a Spin App to GHCR](#push-a-spin-app-to-ghcr)
+- [Pull a Spin App From GHCR](#pull-a-spin-app-from-ghcr)
+- [Run a Spin App From GHCR](#run-a-spin-app-from-ghcr)
+- [Conclusion](#conclusion)
+- [Next Steps](#next-steps)
+
+## Spin Registry Support
+
+With Spin's registry support, you can package and save your Spin application as an artifact in a registry like [GitHub Container Registry (GHCR)](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) or [DockerHub](https://hub.docker.com/) and then run your Spin app from these registries.
+
+## Prerequisites
+
+First, follow [this guide](/spin/install) to ensure you have the latest version of Spin installed (this tutorial refers to Spin 1.0 and above). You can check the Spin version using the following command:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin --version
+```
+
+## Publishing and Running Spin Applications Using Registries (Video)
+
+The following video shows you how to push a Spin app to GHCR, and then run that artifact with Spin or with Docker. The video also contains additional information about signing and verifying your GHCR artifacts.
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/ijTEf8wDkqU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
+The rest of this page shows you how to use GHCR artifacts locally with Spin. 
+
+## Set Up Your GHCR Instance
+
+To use a GHCR instance, you need to set up authentication. Follow [these steps](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic) to generate a personal access token and then use it to sign into your GHCR. You should see the following message to confirm your login attempt to GHCR was successful:
+
+<!-- @nocpy -->
+
+```bash
+> Login Succeed
+```
+
+## Push a Spin App to GHCR
+
+Let's use this full-stack [TypeScript and ReactJS Spin app](https://github.com/radu-matei/spin-react-fullstack) to walk through this tutorial. If you have a Spin app already feel free to navigate to that directory and skip the step below. 
+
+Fork and clone the app [GitHub repository](https://github.com/radu-matei/spin-react-fullstack.git):
+
+ <!-- @selectiveCpy -->
+
+ ```bash
+$ git clone https://github.com/USERNAME/spin-react-fullstack.git
+```
+
+Now, switch to that directory and rebuild the application:
+
+ <!-- @selectiveCpy -->
+
+ ```bash
+$ cd spin-react-fullstack
+$ spin build
+```
+
+Now we're ready to push the application. Run the `spin registry push` command to push your application to the registry: 
+
+ <!-- @selectiveCpy -->
+
+ ```bash
+$ spin registry push ghcr.io/USERNAME/spin-react-fullstack:v1
+```
+
+> **Note:** You can find more information on `spin registry` options and subcommands in the [Spin CLI Reference documentation](/common/cli-reference#oci-registry).
+
+You now have a Spin application stored in your registry. You can see the artifact under packages in the [GitHub UI](https://docs.github.com/en/packages/learn-github-packages/viewing-packages#viewing-a-repositorys-packages).
+
+## Pull a Spin App From GHCR
+
+Now that we've successfully pushed a Spin app, let's see if we can pull it. To do so, run the following command: 
+
+ <!-- @selectiveCpy -->
+ 
+ ```bash
+$ spin registry pull ghcr.io/USERNAME/spin-react-fullstack:v1
+```
+
+## Run a Spin App From GHCR
+
+Lastly, let's run this Spin application:
+
+<!-- @selectiveCpy -->
+
+ ```bash
+$ spin up -f ghcr.io/USERNAME/spin-react-fullstack:v1
+```
+
+## Conclusion
+
+Congratulations on completing this tutorial! You have now successfully built, pushed, pulled, and run a Spin app using GHCR. Behind the scenes, Spin uses [OCI artifacts](https://github.com/opencontainers/artifacts) project to distribute Spin apps across container registries. To learn more about how this feature works, take a look at [our proposal](https://github.com/fermyon/spin/blob/main/docs/content/sips/008-using-oci-registries.md) and [the implementation](https://github.com/fermyon/spin/pull/1014). 
+
+## Next Steps
+
+- If you're interested in shaping how registry support will look in the next version, please share your thoughts in [our Discord community](https://discord.gg/AAFNfS7NGf)
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "VideoObject",
+  "name": "Building & Running Spin Applications with Docker",
+  "description": "Since Spin 1.0, you can build and share your Spin applications as fully compliant OCI images; even allowing Docker and Docker Compose to pull and run them.",
+  "thumbnailUrl": "https://www.fermyon.com/static/image/twc-spin.png",
+  "uploadDate": "2023-04-27T08:00:00+00:00",
+  "duration": "PT8M07S",
+  "contentUrl": "https://www.youtube.com/watch?v=ijTEf8wDkqU",
+  "embedUrl": "https://www.youtube.com/embed/ijTEf8wDkqU"
+}
+</script>

--- a/content/spin/v2/running-apps.md
+++ b/content/spin/v2/running-apps.md
@@ -1,0 +1,139 @@
+title = "Running Spin Applications"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+enable_shortcodes = true
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/running-apps.md"
+
+---
+- [Specifying the Application to Run](#specifying-the-application-to-run)
+  - [Testing HTTP Applications](#testing-http-applications)
+- [Application Output](#application-output)
+- [Persistent Logs](#persistent-logs)
+- [Trigger-Specific Options](#trigger-specific-options)
+- [Monitoring Applications for Changes](#monitoring-applications-for-changes)
+- [Next Steps](#next-steps)
+
+Once you have created and built your application, it's ready to run.  To run an application, use the `spin up` command.
+
+## Specifying the Application to Run
+
+By default, `spin up` looks for a file named `spin.toml` in the current directory.
+
+If your manifest is named something different, or isn't in your current directory, use the `-f` (`--from`) flag. You also use `-f` to run remote applications.
+
+| `-f` Value                      | `spin up` Behavior  |
+|---------------------------------|---------------------|
+| File name: `-f demo.toml`       | Runs the specified manifest file |
+| Directory name: `-f demo/`      | Looks for a `spin.toml` file in that directory and runs that |
+| Registry reference: `-f ghcr.io/fermyon/example:v1` | Pulls the application from the registry and runs that |
+
+> If Spin misunderstands a registry reference as a file name, or vice versa, you can use `--from-file` or `--from-registry` instead of `-f` to disambiguate.
+
+> If you see the error `failed to resolve content at "example.wasm"` (where `example.wasm` is the module file of a component), check that the application has been built.
+
+> If your application doesn't run, you can [run `spin doctor`](/spin/troubleshooting-application-dev.md) to check for problems with your Spin configuration and tools.
+
+### Testing HTTP Applications
+
+By default, HTTP applications listen on `localhost:3000`.  You can override this with the `--listen` option.  Spin prints links to the application components to make it easy to open them in the browser or copy them to `curl` commands for testing.
+
+## Application Output
+
+By default, Spin prints application output, and any of its own error messages, to the console.
+
+To hide application output, pass the `--quiet` flag:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin up --quiet
+```
+
+To limit application output to specific components, pass the `--follow` flag:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin up --follow cart --follow cart-api
+```
+
+## Persistent Logs
+
+By default:
+
+* If you run an application from the file system (a TOML file), Spin saves a copy of the application output and error messages.  This is saved in the `.spin/logs` directory, under the directory containing the manifest file.
+* If you run an application from a registry reference, Spin does not save a copy of the application output and error messages; they are only printed to the console.
+
+To control logging, pass the `--log-dir` flag.  The logs will be saved to the specified directory (no matter whether the application is local or remote).
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin up --log-dir ~/dev/bugbash
+```
+
+## Trigger-Specific Options
+
+Some trigger types support additional `spin up` flags.  For example, HTTP applications can have a `--listen` flag to specify an address and port to listen on.  See the [HTTP trigger](http-trigger) and [Redis trigger](redis-trigger) pages for more details.
+
+## Monitoring Applications for Changes
+
+Spin's `watch` command rebuilds and restarts Spin applications whenever files change. You can use the `spin watch` [command](https://developer.fermyon.com/common/cli-reference#watch) in place of the `spin build` and `spin up` commands, to build, run and then keep your Spin application running without manual intervention while staying on the latest code and files.
+
+> The `watch` command accepts valid Spin [up](https://developer.fermyon.com/common/cli-reference#up) options and passes them through to `spin up` for you when running/rerunning the Spin application.
+E.g. `spin watch --listen 127.0.0.1:3001`
+
+By default, Spin watch monitors:
+
+* The application manifest (`spin.toml` file)
+* Any files specified in the `component.build.watch` sections of the `spin.toml` file
+* Any files specified in the `component.files` sections of the `spin.toml` file
+* The files specified in the `component.source` sections of the `spin.toml` file
+
+If any of these change, Spin will rebuild the application if necessary, then restart the application with the new files.
+
+> Spin watch does not consider changes to a file's metadata (file permissions or when it was last modified) as a change.
+
+The following `spin.toml` configuration (belonging to a Spin `http-rust` application) is configured to ensure that the application is both **rebuilt** (via `cargo build --target wasm32-wasi --release`) and **rerun** whenever changes occur in any Rust source (`.rs`) files, the `Cargo.toml` file or the `spin.toml` file, itself. When changes occur in either the Wasm binary file (`target/wasm32-wasi/release/test.wasm`) or the text file (`my-files/changing-file.txt`) the application is only **rerun** using the initial `spin up` command:
+
+<!-- @nocpy -->
+
+ ```toml
+[[component]]
+// -- snip
+files = ["my-files/changing-file.txt"]
+source = "target/wasm32-wasi/release/test.wasm"
+[component.build]
+command = "cargo build --target wasm32-wasi --release"
+# Example watch configuration for a Rust application
+watch = ["src/**/*.rs", "Cargo.toml"]
+```
+
+If the `build` section specifies a `workdir`, then `watch` patterns are relative to that directory. Otherwise, `watch` patterns are relative to the directory containing the `spin.toml` file.
+
+If you would prefer Spin watch to only rerun the application (without a rebuild) when changes occur, you can use the `--skip-build` option when running the `spin watch` command.  In this case, Spin will ignore the `component.build.watch` section, and monitor only the `spin.toml`, `component.source` and `component.files`.
+
+The table below outlines exactly which files `spin watch` will monitor for changes depending on how you run the command. `spin watch` uses the configuration found on every component in your application.
+
+| Files                   | `spin watch` monitors for changes              | `spin watch --skip-build` monitors for changes |
+| ----------------------- | ---------------------------------------------- | ---------------------------------------------- |
+| Application manifest `spin.toml`   | Yes                                            | Yes                                            |
+| `component.build.watch` | Yes                                            | No                                             |
+| `component.files`       | Yes                                            | Yes                                            |
+| `component.source`      | No (Yes if the component has no build command) | Yes  
+
+Spin watch waits up to 100 milliseconds before responding to filesystem events, then processes all events that occurred in that interval together. This is so that if you make several changes close together (for example, using a Save All command), you get them all processed in one rebuild/reload cycle, rather than going through a cycle for each one. You can override the interval by passing in the `--debounce` option; e.g. `spin watch --debounce 1000` will make Spin watch respond to filesystem events at most once per second.
+
+> Note: If the build step (`spin build`) fails, `spin up` will not be run.
+
+Passing the `--clear` flag clears the screen anytime a rebuild or rerun occurs. Spin watch does not clear the screen between rebuild and rerun as this provides you with an opportunity to see any warnings.
+
+For additional information about Spin's `watch` feature, please see the [Spin watch - live reload for Wasm app development](https://www.fermyon.com/blog/spin-watch-live-reloading) blog article.
+
+## Next Steps
+
+- Learn how to [create and update a Spin application](writing-apps)
+- Learn about how to [configure your application at runtime](dynamic-configuration)
+- See how to [package and distribute your application](spin-oci)
+- Try deploying your application to run in the [Fermyon Cloud](/cloud/quickstart)

--- a/content/spin/v2/rust-components.md
+++ b/content/spin/v2/rust-components.md
@@ -1,0 +1,514 @@
+title = "Building Spin components in Rust"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/rust-components.md"
+
+---
+- [Prerequisites](#prerequisites)
+  - [Install the Templates](#install-the-templates)
+  - [Install the Tools](#install-the-tools)
+- [HTTP Components](#http-components)
+- [Redis Components](#redis-components)
+- [Sending Outbound HTTP Requests](#sending-outbound-http-requests)
+- [Storing Data in Redis From Rust Components](#storing-data-in-redis-from-rust-components)
+- [Storing Data in the Spin Key-Value Store](#storing-data-in-the-spin-key-value-store)
+  - [Serializing Objects to the Key-Value Store](#serializing-objects-to-the-key-value-store)
+- [Storing Data in SQLite](#storing-data-in-sqlite)
+- [Storing Data in Relational Databases](#storing-data-in-relational-databases)
+- [Using External Crates in Rust Components](#using-external-crates-in-rust-components)
+- [AI Inferencing From Rust Components](#ai-inferencing-from-rust-components)
+- [Troubleshooting](#troubleshooting)
+- [Manually Creating New Projects With Cargo](#manually-creating-new-projects-with-cargo)
+- [Read the Rust Spin SDK Documentation](#read-the-rust-spin-sdk-documentation)
+
+Spin aims to have best-in-class support for building components in Rust, and
+writing such components should be familiar for Rust developers.
+
+> This guide assumes you have Spin installed. If this is your first encounter with Spin, please see the [Quick Start](quickstart), which includes information about installing Spin with the Rust templates, installing required tools, and creating Rust applications.
+
+> This guide assumes you are familiar with the Rust programming language,
+> but if you are just getting started, be sure to check [the
+official resources for learning Rust](https://www.rust-lang.org/learn).
+
+> All examples from this page can be found in [the Spin repository on GitHub](https://github.com/fermyon/spin/tree/main/examples).
+
+## Prerequisites
+
+### Install the Templates
+
+You don't need the Spin Rust templates to work on Rust components, but they speed up creating new applications and components.  You can install them as follows:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin templates install --git https://github.com/fermyon/spin --update
+Copying remote template source
+Installing template redis-rust...
+Installing template http-rust...
+... other templates omitted ...
++------------------------------------------------------------------------+
+| Name                Description                                        |
++========================================================================+
+| ... other templates omitted ...                                        |
+| http-rust           HTTP request handler using Rust                    |
+| redis-rust          Redis message handler using Rust                   |
+| ... other templates omitted ...                                        |
++------------------------------------------------------------------------+
+```
+
+Note: The Rust templates are in a repo that contains several other languages; they will all be installed together.
+
+### Install the Tools
+
+To build Spin components, you'll need the `wasm32-wasi` target for Rust.
+
+<!-- @selectiveCpy -->
+
+```bash
+$ rustup target add wasm32-wasi
+```
+
+> If you get a lot of strange errors when you try to build your first Rust component, check that you have this target installed by running `rustup target list --installed`. This is the most common source of problems when starting out with Rust in Spin!
+
+## HTTP Components
+
+In Spin, HTTP components are triggered by the occurrence of an HTTP request, and
+must return an HTTP response at the end of their execution. Components can be
+built in any language that compiles to WASI, but Rust has improved support
+for writing Spin components with the Spin Rust SDK.
+
+> Make sure to read [the page describing the HTTP trigger](./http-trigger.md) for more
+> details about building HTTP applications.
+
+Building a Spin HTTP component using the Rust SDK means writing a single function
+that takes an HTTP request as a parameter, and returns an HTTP response — below
+is a complete implementation for such a component:
+
+```rust
+use anyhow::Result;
+use spin_sdk::{
+    http::{Request, Response},
+    http_component,
+};
+
+/// A simple Spin HTTP component.
+#[http_component]
+fn hello_world(req: Request) -> Result<Response> {
+    println!("{:?}", req);
+    Ok(http::Response::builder()
+        .status(200)
+        .header("foo", "bar")
+        .body(Some("Hello, Fermyon!".into()))?)
+}
+```
+
+The important things to note in the implementation above:
+
+- the `spin_sdk::http_component` macro marks the function as the
+  entry point for the Spin component
+- the function signature — `fn hello_world(req: Request) -> Result<Response>` —
+  the Spin HTTP component uses the HTTP objects from the popular Rust crate
+  [`http`](https://crates.io/crates/http), and the request and response bodies
+  are optionally using [`bytes::Bytes`](https://crates.io/crates/bytes)
+  (`spin_sdk::http::Request` is a type alias for `http::Request<Option<Bytes>>`)
+- the component returns a Rust `anyhow::Result`, so if there is an error processing the request, it returns an `anyhow::Error`.
+
+## Redis Components
+
+Besides the HTTP trigger, Spin has built-in support for a Redis trigger —
+which will connect to a Redis instance and will execute Spin components for
+new messages on the configured channels.
+
+> See the [Redis trigger](./redis-trigger.md) for details about the Redis trigger.
+
+Writing a Redis component in Rust also takes advantage of the SDK:
+
+```rust
+use anyhow::Result;
+use bytes::Bytes;
+use spin_sdk::redis_component;
+
+/// A simple Spin Redis component.
+#[redis_component]
+fn on_message(message: Bytes) -> Result<()> {
+    println!("{}", std::str::from_utf8(&message)?);
+    Ok(())
+}
+```
+
+- the `spin_sdk::redis_component` macro marks the function as the
+  entry point for the Spin component
+- in the function signature — `fn on_message(msg: Bytes) -> anyhow::Result<()>` —
+`msg` contains the payload from the Redis channel
+- the component returns a Rust `anyhow::Result`, so if there is an error
+processing the request, it returns an `anyhow::Error`.
+
+The component can be built with Cargo by executing:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ cargo build --target wasm32-wasi --release
+```
+
+The manifest for a Redis application must contain the address of the Redis
+instance the trigger must connect to:
+
+<!-- @nocpy -->
+
+```toml
+spin_manifest_version = "1"
+name = "spin-redis"
+trigger = { type = "redis", address = "redis://localhost:6379" }
+version = "0.1.0"
+
+[[component]]
+id = "echo-message"
+source = "target/wasm32-wasi/release/spinredis.wasm"
+[component.trigger]
+channel = "messages"
+```
+
+This application will connect to `redis://localhost:6379`, and for every new
+message on the `messages` channel, the `echo-message` component will be executed:
+
+<!-- @selectiveCpy -->
+
+```bash
+# first, start redis-server on the default port 6379
+$ redis-server --port 6379
+# then, start the Spin application
+$ spin up --file spin.toml
+# the application log file will output the following
+INFO spin_redis_engine: Connecting to Redis server at redis://localhost:6379
+INFO spin_redis_engine: Subscribed component 0 (echo-message) to channel: messages
+```
+
+For every new message on the  `messages` channel:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ redis-cli
+127.0.0.1:6379> publish messages "Hello, there!"
+```
+
+Spin will instantiate and execute the component we just built, which will emit the `println!` message to the application log file:
+
+```
+INFO spin_redis_engine: Received message on channel "messages"
+Hello, there!
+```
+
+> You can find a complete example for a Redis triggered component in the
+> [Spin repository on GitHub](https://github.com/fermyon/spin/tree/main/examples/redis-rust).
+
+## Sending Outbound HTTP Requests
+
+If allowed, Spin components can send outbound HTTP requests.
+Let's see an example of a component that makes a request to
+[an API that returns random animal facts](https://random-data-api.fermyon.app/animals/json) and
+inserts a custom header into the response before returning:
+
+```rust
+use anyhow::Result;
+use spin_sdk::{
+    http::{Request, Response},
+    http_component,
+};
+
+/// Send an HTTP request and return the response.
+#[http_component]
+fn send_outbound(_req: Request) -> Result<Response> {
+    let mut res = spin_sdk::outbound_http::send_request(
+        http::Request::builder()
+            .method("GET")
+            .uri("https://random-data-api.fermyon.app/animals/json")
+            .body(None)?,
+    )?;
+    res.headers_mut()
+        .insert("spin-component", "rust-outbound-http".try_into()?);
+    println!("{:?}", res);
+    Ok(res)
+}
+```
+
+> The `http::Request::builder()` method is provided by the Rust `http` crate. The `http` crate is already added to projects using the Spin `http-rust` template. If you create a project without using this template, you'll need to add the `http` crate yourself via `cargo add http`.
+
+Before we can execute this component, we need to add the `random-data-api.fermyon.app`
+domain to the application manifest `allowed_http_hosts` list containing the list of
+domains the component is allowed to make HTTP requests to:
+
+<!-- @nocpy -->
+
+```toml
+# spin.toml
+spin_manifest_version = "1"
+name = "spin-hello-world"
+trigger = { type = "http", base = "/" }
+version = "1.0.0"
+
+[[component]]
+id = "hello"
+source = "target/wasm32-wasi/release/spinhelloworld.wasm"
+allowed_http_hosts = ["random-data-api.fermyon.app"]
+[component.trigger]
+route = "/outbound"
+```
+
+Running the application using `spin up --file spin.toml` will start the HTTP
+listener locally (by default on `localhost:3000`), and our component can
+now receive requests in route `/outbound`:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ curl -i localhost:3000/outbound
+HTTP/1.1 200 OK
+date = "2023-11-02T16:00:00Z"
+content-type: application/json; charset=utf-8
+content-length: 185
+server: spin/0.1.0
+
+{"timestamp":1684299253331,"fact":"Reindeer grow new antlers every year"}   
+```
+
+> Without the `allowed_http_hosts` field populated properly in `spin.toml`,
+> the component would not be allowed to send HTTP requests, and sending the
+> request would result in a "Destination not allowed" error.
+
+> You can set `allowed_http_hosts = ["insecure:allow-all"]` if you want to allow
+> the component to make requests to any HTTP host. This is **NOT** recommended
+> for any production or publicly-accessible application.
+
+We just built a WebAssembly component that sends an HTTP request to another
+service, manipulates that result, then responds to the original request.
+This can be the basis for building components that communicate with external
+databases or storage accounts, or even more specialized components like HTTP
+proxies or URL shorteners.
+
+## Storing Data in Redis From Rust Components
+
+Using the Spin's Rust SDK, you can use the Redis key/value store and to publish
+messages to Redis channels. This can be used from both HTTP and Redis triggered
+components.
+
+Let's see how we can use the Rust SDK to connect to Redis:
+
+```rust
+use anyhow::{anyhow, Result};
+use spin_sdk::{
+    http::{internal_server_error, Request, Response},
+    http_component, redis,
+};
+
+// The environment variable set in `spin.toml` that points to the
+// address of the Redis server that the component will publish
+// a message to.
+const REDIS_ADDRESS_ENV: &str = "REDIS_ADDRESS";
+
+// The environment variable set in `spin.toml` that specifies
+// the Redis channel that the component will publish to.
+const REDIS_CHANNEL_ENV: &str = "REDIS_CHANNEL";
+
+/// This HTTP component demonstrates fetching a value from Redis
+/// by key, setting a key with a value, and publishing a message
+/// to a Redis channel. The component is triggered by an HTTP
+/// request served on the route configured in the `spin.toml`.
+#[http_component]
+
+fn publish(_req: Request) -> Result<Response> {
+    let address = std::env::var(REDIS_ADDRESS_ENV)?;
+    let channel = std::env::var(REDIS_CHANNEL_ENV)?;
+
+    // Get the message to publish from the Redis key "mykey"
+    let payload = redis::get(&address, "mykey").map_err(|_| anyhow!("Error querying Redis"))?;
+
+    // Set the Redis key "spin-example" to value "Eureka!"
+    redis::set(&address, "spin-example", &b"Eureka!"[..])
+        .map_err(|_| anyhow!("Error executing Redis set command"))?;
+
+    // Set the Redis key "int-key" to value 0
+    redis::set(&address, "int-key", format!("{:x}", 0).as_bytes())
+        .map_err(|_| anyhow!("Error executing Redis set command"))?;
+    let int_value = redis::incr(&address, "int-key")
+        .map_err(|_| anyhow!("Error executing Redis incr command",))?;
+    assert_eq!(int_value, 1);
+
+    // Publish to Redis
+    match redis::publish(&address, &channel, &payload) {
+        Ok(()) => Ok(http::Response::builder().status(200).body(None)?),
+        Err(_e) => internal_server_error(),
+    }
+}
+```
+
+This HTTP component demonstrates fetching a value from Redis by key, setting a
+key with a value, and publishing a message to a Redis channel. The component is
+triggered by an HTTP request served on the route configured in the `spin.toml`:
+
+<!-- @nocpy -->
+
+```toml
+[[component]]
+environment = { REDIS_ADDRESS = "redis://127.0.0.1:6379", REDIS_CHANNEL = "messages" }
+[component.trigger]
+route = "/publish"
+```
+
+This HTTP component can be paired with a Redis component, triggered on new
+messages on the `messages` Redis channel.
+
+> You can find a complete example for using outbound Redis from an HTTP component
+> in the [Spin repository on GitHub](https://github.com/fermyon/spin/tree/main/examples/rust-outbound-redis).
+
+## Storing Data in the Spin Key-Value Store
+
+Spin has a key-value store built in. For information about using it from Rust, see [the key-value store tutorial](kv-store).
+
+### Serializing Objects to the Key-Value Store
+
+The Spin key-value API stores and retrieves only lists of bytes. The Rust SDK provides helper functions that allow you to store and retrieve [Serde](https://docs.rs/serde/latest/serde) serializable values in a typed way. The underlying storage format is JSON (and is accessed via the `get_json` and `set_json` helpers). 
+
+To use the `get_json` and `set_json` helpers, you must enable the Spin SDK's optional `json` feature in your `Cargo.toml` file. To make your objects serializable, you will also need a reference to `serde`. The relevant `Cargo.toml` entries look like this:
+
+```
+[dependencies]
+// --snip --
+serde = {version = "1.0.163", features = ["derive"]}
+spin-sdk = {git = "https://github.com/fermyon/spin", version = "1.2.0", features = ["json"]}
+// --snip --
+```
+
+The Rust code below shows how to store and retrieve serializable objects from the key-value store (note how the example below implements Serde's `derive` feature):
+
+```rust
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use spin_sdk::{
+    http::{Request, Response},
+    http_component,
+    key_value::Store,
+};
+
+// Define a serializable User type
+#[derive(Serialize, Deserialize)]
+struct User {
+    fingerprint: String,
+    location: String,
+}
+
+#[http_component]
+fn handle_request(_req: Request) -> Result<Response> {
+    // Open the default key-value store
+    let store = Store::open_default()?;
+
+    // Create an instance of a User object and populate the values
+    let user = User {
+        fingerprint: "0x1234".to_owned(),
+        location: "Brisbane".to_owned(),
+    };
+    // Store the User object using the "my_json" key
+    store.set_json("my_json", &user)?;
+    // Retrieve the user object from the key-value store, using the "my_json" key
+    let retrieved_user: User = store.get_json("my_json")?;
+    // Return the user's fingerprint as the response body
+    Ok(http::Response::builder()
+        .status(200)
+        .body(Some(retrieved_user.fingerprint.into()))?)
+}
+```
+
+Once built and running (using `spin build` and `spin up`) you can test the above example in your browser (by visiting localhost:3000) or via curl, as shown below:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ curl localhost:3000
+HTTP/1.1 200 OK
+
+0x1234
+```
+
+## Storing Data in SQLite
+
+For more information about using SQLite from Rust, see [SQLite storage](sqlite-api-guide).
+
+## Storing Data in Relational Databases
+
+Spin provides clients for MySQL and PostgreSQL. For information about using them from Rust, see [Relational Databases](rdbms-storage).
+
+## Using External Crates in Rust Components
+
+In Rust, Spin components are regular libraries that contain a function
+annotated using the `http_component` macro, compiled to the
+[`wasm32-wasi` target](https://doc.rust-lang.org/stable/nightly-rustc/rustc_target/spec/wasm32_wasi/index.html).
+This means that any [crate](https://crates.io) that compiles to `wasm32-wasi` can
+be used when implementing the component.
+
+## AI Inferencing From Rust Components
+
+For more information about using Serverless AI from Rust, see the [Serverless AI](serverless-ai-api-guide) API guide.
+
+## Troubleshooting
+
+If you bump into issues building and running your Rust component, here are some common causes of problems:
+
+- Make sure `cargo` is present in your path
+- Make sure the [Rust](https://www.rust-lang.org/) version is recent.
+  - To check: run  `cargo --version`.  The Spin SDK needs Rust 1.64 or above.
+  - To update: run `rustup update`.
+- Make sure the `wasm32-wasi` compiler target is installed.
+  - To check: run `rustup target list --installed` and check that `wasm32-wasi` is on the list.
+  - To install: run `rustup target add wasm32-wasi`.
+- Make sure you are building in `release` mode.  Spin manifests refer to your Wasm file by a path, and the default path corresponds to `release` builds.
+  - To build manually: run `cargo build --release --target wasm32-wasi`.
+  - If you're using `spin build` and the templates, this should be set up correctly for you.
+- Make sure that the `source` field in the component manifest match the path and name of the Wasm file in `target/wasm32-wasi/release`. These could get out of sync if you renamed the Rust package in its `Cargo.toml`.
+
+## Manually Creating New Projects With Cargo
+
+The recommended way of creating new Spin projects is by starting from a template.
+This section shows how to manually create a new project with Cargo.
+
+When creating a new Spin project with Cargo, you should use the `--lib` flag:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ cargo init --lib
+```
+
+A `Cargo.toml` with standard Spin dependencies looks like this:
+
+<!-- @nocpy -->
+
+```toml
+[package]
+name = "your-app"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+# Required to have a `cdylib` (dynamic library) to produce a Wasm module.
+crate-type = [ "cdylib" ]
+
+[dependencies]
+# Useful crate to handle errors.
+anyhow = "1"
+# Crate to simplify working with bytes.
+bytes = "1"
+# General-purpose crate with common HTTP types.
+http = "0.2"
+# The Spin SDK.
+spin-sdk = { git = "https://github.com/fermyon/spin" }
+# Crate that generates Rust Wasm bindings from a WebAssembly interface.
+wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba" }
+```
+
+> `wit-bindgen` evolves rapidly to track draft standards.  Very recent versions of `wit-bindgen` are unlikely to work correctly with Spin.  So the dependency must be pinned to a specific `rev`.  Over time, Spin expects to track "peninsulas of stability" in the evolving standards.
+
+## Read the Rust Spin SDK Documentation
+
+Although you learned a lot by following the concepts and samples shown here, you can dive even deeper and read the [Rust Spin SDK documentation](https://fermyon.github.io/rust-docs/spin/main/spin_sdk/index.html).

--- a/content/spin/v2/see-what-people-have-built-with-spin.md
+++ b/content/spin/v2/see-what-people-have-built-with-spin.md
@@ -1,0 +1,76 @@
+title = "Built With Spin"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/see-what-people-have-built-with-spin.md"
+
+---
+- [Like Button](#like-button)
+- [Social App](#social-app)
+- [Static Content Server](#static-content-server)
+- [Bots](#bots)
+- [URL Shortener and QR Code Generator](#url-shortener-and-qr-code-generator)
+- [Content Management System (CMS)](#content-management-system-cms)
+- [The Finicky Whiskers Game](#the-finicky-whiskers-game)
+- [Accessing External APIs](#accessing-external-apis)
+- [Next Steps](#next-steps)
+
+Spin can be used to build many different types of applications. The following blog articles show how different applications are built with Spin.
+
+## Like Button
+
+[How I Built a Like Button for My Blog with Spin](https://www.fermyon.com/blog/how-i-built-a-like-button-for-my-blog-with-spin)
+
+## Social App
+
+The 'Building a Social App with Spin' series covers the process and decision-making of building an authenticated, dynamic, database-backed application and API, right the way from downloading Spin and setting up the project to deploying the finished application to the cloud.
+
+* [Part 1: Project Setup and first API](https://www.fermyon.com/blog/building-a-social-app-with-spin-1)
+* [Part 2: Vue.js App and Token Verification](https://www.fermyon.com/blog/building-a-social-app-with-spin-2)
+* [Part 3: Post API and Spin SDK Bindings](https://www.fermyon.com/blog/building-a-social-app-with-spin-3)
+* [Part 3.5: Go Postgres Usage](https://www.fermyon.com/blog/building-a-social-app-with-spin-3-5)
+* [Part 4: Key-Value Storage and Fermyon Cloud](https://www.fermyon.com/blog/building-a-social-app-with-spin-4)
+
+## Static Content Server
+
+[Serving Static Content via WebAssembly](https://www.fermyon.com/blog/serving-static-content-via-webassembly)
+
+## Bots
+
+[Bots With Spin and Fermyon Cloud](https://www.fermyon.com/blog/bots-with-spin-and-fermyon-cloud)
+
+## URL Shortener and QR Code Generator
+
+[Shortlink and QR Code Generator](https://www.fermyon.com/blog/component-reuse)
+
+## Content Management System (CMS)
+
+[Build Your Own Content Management System (CMS) From a Template](https://www.fermyon.com/blog/build-you-own-cms-from-a-template)
+
+## The Finicky Whiskers Game
+
+The 'Finicky Whiskers' series covers the journey of creating a game with an architecture designed to [re-think microservices](https://www.fermyon.com/blog/rethinking-microservices) and showcase how WebAssembly modules can be started, executed, and shut down in the blink of an eye.
+
+> Finicky Whiskers was built to be the world's most adorable manual load generator, so it's not necessarily an model of how to use Spin most efficiently! But the series may be useful for decomposing an application into Spin microservices, and as a look at how Spin and containers can work together. As a bonus, if you are interested, you can play the game [here](https://finickywhiskers.com/index.html).
+
+* [Part 1: The World's Most Adorable Manual Load Generator](https://www.fermyon.com/blog/finicky-whiskers-part-1-intro)
+* [Part 2: Serving the HTML, CSS, and Static Assets](https://www.fermyon.com/blog/finicky-whiskers-part-2-fileserver)
+* [Part 3: The Microservices](https://www.fermyon.com/blog/finicky-whiskers-part-3-microservices)
+* [Part 4: Spin, Containers, Nomad, and Infrastructure](https://www.fermyon.com/blog/finicky-whiskers-part-4-infrastructure)
+
+## Accessing External APIs
+
+Chances are whatever you are building will want to talk to other endpoints on the web. If so, Spin's HTTP library can help. The following article explains how to access external APIs from within Spin applications.
+
+- [Accessing external APIs](https://www.fermyon.com/blog/spin-rest-apis)
+
+## NoOps SQLite Storage Using Javascript
+
+Check out our [NoOps and Serverless Are the Perfect Pair](https://www.fermyon.com/blog/noops-and-serverless-are-the-perfect-pair) blog article that provides a NoOps SQLite Storage example (using Javascript).
+
+## Next Steps
+
+- Try [running your application locally](running-apps)
+- Learn about how to [configure your application at runtime](dynamic-configuration)
+- Look up details in the [application manifest reference](manifest-reference)
+- Try deploying a Spin application to the [Fermyon Cloud](/cloud/quickstart)

--- a/content/spin/v2/serverless-ai-api-guide.md
+++ b/content/spin/v2/serverless-ai-api-guide.md
@@ -1,0 +1,176 @@
+title = "Serverless AI API"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+enable_shortcodes = true
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/serverless-ai-api-guide.md"
+
+---
+- [Using Serverless AI From Applications](#using-serverless-ai-from-applications)
+  - [Configuration](#configuration)
+  - [File Structure](#file-structure)
+- [Serverless AI Interface](#serverless-ai-interface)
+
+The nature of AI and LLM workloads on already trained models lends itself very naturally to a serverless-style architecture. As a framework for building and deploying serverless applications, Spin provides an interface for you to perform AI inference within Spin applications. 
+
+## Using Serverless AI From Applications 
+
+### Configuration
+
+By default, a given component of a Spin application will not have access to any Serverless AI models. Access must be provided explicitly via the Spin application's manifest (the `spin.toml` file).  For example, an individual component in a Spin application could be given access to the llama2-chat model by adding the following `ai_models` configuration inside the specific `[[component]]` section:
+
+<!-- @nocpy -->
+
+```toml
+// -- snip --
+
+[[component]]
+ai_models = ["codellama-instruct"]
+
+// -- snip --
+```
+
+> Spin supports "llama2-chat" and "codellama-instruct" for inferencing and "all-minilm-l6-v2" for generating embeddings.
+
+### File Structure
+
+By default, the Spin framework will expect any already trained model files (which are configured as per the previous section) to be downloaded by the user and made available inside a `.spin/ai_models/` file path of a given application. For example:
+
+```bash
+code-generator-rs/.spin/ai_models/codellama-instruct
+```
+
+See the [serverless AI Tutorial](/spin/serverless-ai-tutorial) documentation for more concrete examples of implementing the Fermyon Serverless AI API, in your favorite language.
+
+> Embeddings models are slightly more complicated; it is expected that both a `tokenizer.json` and a `model.safetensors` are located in the directory named after the model. For example, for the `foo-bar-baz` model, Spin will look in the `.spin/ai-models/foo-bar-baz` directory for `tokenizer.json` and a `model.safetensors`.
+
+## Serverless AI Interface
+
+The Spin SDK surfaces the Serverless AI interface to a variety of different languages. See the [Language Support Overview](/spin/language-support-overview) to see if your specific language is supported.
+
+The set of operations is common across all supporting language SDKs:
+
+| Operation | Parameters | Returns | Behavior |
+|:-----|:----------------|:-------|:----------------|
+| `infer`  | model`string`<br /> prompt`string`| `string`  | The `infer` is performed on a specific model.<br /> <br />The name of the model is the first parameter provided (i.e. `llama2-chat`, `codellama-instruct`, or other; passed in as a `string`).<br /> <br />The second parameter is a prompt; passed in as a `string`.<br />|
+| `infer_with_options`  | model`string`<br /> prompt`string`<br /> params`list` | `string`  | The `infer_with_options` is performed on a specific model.<br /> <br />The name of the model is the first parameter provided (i.e. `llama2-chat`, `codellama-instruct`, or other; passed in as a `string`).<br /><br /> The second parameter is a prompt; passed in as a `string`.<br /><br /> The third parameter is a mix of float and unsigned integers relating to inferencing parameters in this order: <br /><br />- `max-tokens` (unsigned 32 integer) Note: the backing implementation may return less tokens. <br /> Default is 100<br /><br /> - `repeat-penalty` (float 32) The amount the model should avoid repeating tokens. <br /> Default is 1.1<br /><br /> - `repeat-penalty-last-n-token-count` (unsigned 32 integer) The number of tokens the model should apply the repeat penalty to. <br /> Default is 64<br /><br /> - `temperature` (float 32) The randomness with which the next token is selected. <br /> Default is 0.8<br /><br /> - `top-k` (unsigned 32 integer) The number of possible next tokens the model will choose from. <br /> Default is 40<br /><br /> - `top-p` (float 32) The probability total of next tokens the model will choose from. <br /> Default is 0.9<br /><br /> The result from `infer_with_options` is a `string` |
+| `generate-embeddings`  | model`string`<br /> prompt`list<string>`| `string`  | The `generate-embeddings` is performed on a specific model.<br /> <br />The name of the model is the first parameter provided (i.e. `all-minilm-l6-v2`, passed in as a `string`).<br /> <br />The second parameter is a prompt; passed in as a `list` of `string`s.<br /><br /> The result from `generate-embeddings` is a two-dimension array containing float32 type values only |
+
+The exact detail of calling these operations from your application depends on your language:
+
+{{ tabs "sdk-type" }}
+
+{{ startTab "Rust"}}
+
+To use Serverless AI functions, the `llm` module from the Spin SDK provides the methods. The following snippet is from the [Rust code generation example](https://github.com/fermyon/ai-examples/tree/main/code-generator-rs):
+
+<!-- @nocpy -->
+
+```rust
+use spin_sdk::{
+    http::{Request, Response},
+    llm,
+};
+
+// -- snip --
+
+fn handle_code(req: Request) -> Result<Response> {
+    // -- snip --
+
+    let result = llm::infer_with_options(
+        llm::InferencingModel::CodellamaInstruct,
+        &prompt,
+        llm::InferencingParams {
+            max_tokens: 400,
+            repeat_penalty: 1.1,
+            repeat_penalty_last_n_token_count: 64,
+            temperature: 0.8,
+            top_k: 40,
+            top_p: 0.9,
+        },
+    )?;
+
+    // -- snip --	
+}
+
+```
+
+**General Notes**
+
+The `infer_with_options` examples, operation:
+
+- The above example takes the model name `llm::InferencingModel::CodellamaInstruct` as input. From an interface point of view, the model name is technically an alias for a string (to maximize future compatibility as users want to support more and different types of models).
+- The second parameter is a prompt (string) from whoever/whatever is making the request to the `handle_code()` function.
+- A third, optional, parameter which is an interface allows you to specify parameters such as `max_tokens`, `repeat_penalty`, `repeat_penalty_last_n_token_count`, `temperature`, `top_k` and `top_p`.  
+- The return value (the `inferencing-result` record) contains a text field of type `string`. Ideally, this would be a `stream` that would allow streaming inferencing results back to the user, but alas streaming support is not yet ready for use so we leave that as a possible future backward incompatible change.
+
+{{ blockEnd }}
+
+{{ startTab "Typescript"}}
+
+To use Serverless AI functions, the `Llm` module from the Spin SDK provides two methods: `infer` and `generateEmbeddings`. For example: 
+
+```javascript
+import { EmbeddingModels, HandleRequest, HttpRequest, HttpResponse, InferencingModels, Llm} from "@fermyon/spin-sdk"
+
+export const handleRequest: HandleRequest = async function (request: HttpRequest): Promise<HttpResponse> {
+    let embeddings = Llm.generateEmbeddings(EmbeddingModels.AllMiniLmL6V2, ["someString"])
+    console.log(embeddings.embeddings)
+    let result = Llm.infer(InferencingModels.Llama2Chat, prompt)
+    return {
+        status: 200,
+        headers: {"content-type":"text/plain"},
+        body: result.text
+    }
+}
+```
+
+**General Notes**
+
+`infer` operation:
+
+- It takes in the following arguments - model name, prompt and a optional third parameter for inferencing options. 
+- The model name is a string. There are enums for the inbuilt models (llama2-chat and codellama) in `InferencingModels`.
+- The optional third parameter which is an interface allows you to specify parameters such as `maxTokens`, `repeatPenalty`, `repeatPenaltyLastNTokenCount`, `temperature`, `topK`, `topP`.  
+- The return value is a `string`.
+
+`generateEmbeddings` operation:
+
+- It takes two arguments - model name and list of strings to generate the embeddings for. 
+- The model name is a string. There are enums for the inbuilt models (AllMiniLmL6V2) in `EmbeddingModels`.
+- The return value is of the type `number[][] 
+
+{{ blockEnd }}
+
+{{ startTab "Python"}}
+
+```python
+from spin_http import Response
+from spin_llm import llm_infer
+
+
+def handle_request(request):
+    prompt="You are a stand up comedy writer. Tell me a joke."
+    result=llm_infer("llama2-chat", prompt)
+    return Response(200,
+                    {"content-type": "text/plain"},
+                    bytes(result.text, "utf-8"))
+```
+
+**General Notes**
+
+`llm_infer` operation:
+
+- It takes in the following arguments - model name and `prompt`. 
+- The model name is passed in as a string (as shown above; `"llama2-chat"`).
+- The return value is a `string`.
+
+{{ blockEnd }}
+
+{{ startTab "TinyGo"}}
+
+The TinyGo SDK doesn't currently surface the Serverless AI API. 
+
+{{ blockEnd }}
+
+{{ blockEnd }}

--- a/content/spin/v2/spin-application-structure.md
+++ b/content/spin/v2/spin-application-structure.md
@@ -1,0 +1,207 @@
+title = "Application Structure"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+enable_shortcodes = true
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/spin-application-structure.md"
+keywords = "structure"
+
+---
+
+As mentioned in this [blog post](https://www.fermyon.com/blog/spin-application-structure), we are often asked about how to structure Spin applications that involve multiple source code components. There are a few nuances to this discussion, such as the use of different application trigger types and how to modify an existing application's structure. These nuances are discussed in the blog post and also in [this video](https://www.youtube.com/watch?v=QQD-qodabSc). This page, however, will focus only on creating multi-component Spin applications from scratch using the http-empty template. This template serves as the foundation for the recommended Spin application structure when creating applications that respond to HTTP requests.
+
+## Recommended Application Structure
+
+If we start with a blank canvas and use the `http-empty` template we will get a new Spin application:
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin new http-empty
+Enter a name for your new application: myapp
+Description: My application
+HTTP base: /
+```
+
+The above command will provide an empty structure, as shown below:
+
+<!-- @nocpy -->
+
+```console
+└── myapp
+    └── spin.toml
+```
+
+To add new components to the application, we simply move into the `myapp` directory and begin to add components using the `spin add` subcommand:
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin add http-rust
+Enter a name for your new component: first-http-rust-component
+Description: The first of many new components
+HTTP path: /first/...
+$ spin add http-rust
+Enter a name for your new component: second-http-rust-component
+Description: The second of many new components
+HTTP path: /second/...
+```
+
+After adding two new components, we can see the visual representation of our application. Notice the symmetry; there is no hierarchy or nesting of components:
+
+<!-- @nocpy -->
+
+```console
+.
+├── first-http-rust-component
+│   ├── Cargo.toml
+│   └── src
+│       └── lib.rs
+├── second-http-rust-component
+│   ├── Cargo.toml
+│   └── src
+│       └── lib.rs
+└── spin.toml
+```
+
+To customize each of the two components, we can modify the `lib.rs` (Rust source code) of each component:
+
+```rust
+/// A simple Spin HTTP component.
+#[http_component]
+fn handle_first_http_rust_component(req: Request) -> Result<Response> {
+    println!("{:?}", req.headers());
+    Ok(http::Response::builder()
+        .status(200)
+        .header("foo", "bar")
+        .body(Some("Hello, First Component".into()))?)
+}
+```
+
+```rust
+/// A simple Spin HTTP component.
+#[http_component]
+fn handle_second_http_rust_component(req: Request) -> Result<Response> {
+    println!("{:?}", req.headers());
+    Ok(http::Response::builder()
+        .status(200)
+        .header("foo", "bar")
+        .body(Some("Hello, Second Component".into()))?)
+}
+```
+
+As an additional example of adding more components, let's add a new static file server component:
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin add static-fileserver
+Enter a name for your new component: assets
+HTTP path: /static/...
+Directory containing the files to serve: assets
+```
+
+After the static file server component is added, we create the `assets` directory (our local directory containing the files to serve) and then add some static content into the `assets` directory to be served:
+
+<!-- @selectiveCpy -->
+
+```console
+$ mkdir assets
+$ cp ~/Desktop/my-static-image.jpg assets
+$ cp ~/Desktop/old.txt assets
+$ cp ~/Desktop/new.txt assets
+```
+
+> The above commands are just an example that assumes you have the image (`my-static-image.jpg`) and two text files (`old.txt` & `new.txt`) on your Desktop.
+
+Why stop there? We can add even more functionality to our application. Let's now add a `redirect` component to redirect requests made to `/static/old.txt` and forward those through to `/static/new.txt`:
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin add redirect
+Enter a name for your new component: additional-component-redirect
+Redirect from: /static/old.txt
+Redirect to: /static/new.txt
+```
+
+We now have 4 separate components scaffolded for us by Spin. Note the application manifest (the `spin.toml` file) is correctly configured based on our `spin add` commands:
+
+<!-- @nocpy -->
+
+```toml
+spin_manifest_version = "1"
+authors = ["tpmccallum <tim.mccallum@fermyon.com>"]
+description = "My application"
+name = "myapp"
+trigger = { type = "http", base = "/" }
+version = "0.1.0"
+
+[[component]]
+id = "first-http-rust-component"
+source = "first-http-rust-component/target/wasm32-wasi/release/first_http_rust_component.wasm"
+allowed_http_hosts = []
+[component.trigger]
+route = "/first/..."
+[component.build]
+command = "cargo build --target wasm32-wasi --release"
+workdir = "first-http-rust-component"
+watch = ["src/**/*.rs", "Cargo.toml"]
+
+[[component]]
+id = "second-http-rust-component"
+source = "second-http-rust-component/target/wasm32-wasi/release/second_http_rust_component.wasm"
+allowed_http_hosts = []
+[component.trigger]
+route = "/second/..."
+[component.build]
+command = "cargo build --target wasm32-wasi --release"
+workdir = "second-http-rust-component"
+watch = ["src/**/*.rs", "Cargo.toml"]
+
+[[component]]
+source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.0.2/spin_static_fs.wasm", digest = "sha256:65456bf4e84cf81b62075e761b2b0afaffaef2d0aeda521b245150f76b96421b" }
+id = "assets"
+files = [ { source = "assets", destination = "/" } ]
+[component.trigger]
+route = "/static/..."
+
+[[component]]
+source = { url = "https://github.com/fermyon/spin-redirect/releases/download/v0.0.1/redirect.wasm", digest = "sha256:d57c3d91e9b62a6b628516c6d11daf6681e1ca2355251a3672074cddefd7f391" }
+id = "additional-component-redirect"
+environment = { DESTINATION = "/static/new.txt" }
+[component.trigger]
+route = "/static/old.txt"
+executor = { type = "wagi" }
+```
+
+Also, note that the application's folder structure, scaffolded for us by Spin via the spin add commands, is symmetrical and shows no nesting of components:
+
+<!-- @nocpy -->
+
+```console
+├── assets
+│   ├── my-static-image.jpg
+│   ├── new.txt
+│   └── old.txt
+├── first-http-rust-component
+│   ├── Cargo.toml
+│   └── src
+│       └── lib.rs
+├── second-http-rust-component
+│   ├── Cargo.toml
+│   └── src
+│       └── lib.rs
+└── spin.toml
+```
+
+This is the recommended Spin application structure.
+
+## Next Steps
+
+- Learn about how to [build your Spin application code](build)
+- Try [running your application locally](running-apps)
+- Discover how Spin application authors [design and organise applications](see-what-people-have-built-with-spin)
+- Learn about how to [configure your application at runtime](dynamic-configuration)
+- Look up details in the [application manifest reference](manifest-reference)
+- Try deploying a Spin application to the [Fermyon Cloud](/cloud/quickstart)

--- a/content/spin/v2/sqlite-api-guide.md
+++ b/content/spin/v2/sqlite-api-guide.md
@@ -1,0 +1,266 @@
+title = "SQLite Storage"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+enable_shortcodes = true
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/sqlite-api-guide.md"
+
+---
+- [Granting SQLite Database Permissions to Components](#granting-sqlite-database-permissions-to-components)
+- [Using SQLite Storage From Applications](#using-sqlite-storage-from-applications)
+- [Preparing an SQLite Database](#preparing-an-sqlite-database)
+- [Custom SQLite Databases](#custom-sqlite-databases)
+  - [Granting Access to Custom SQLite Databases](#granting-access-to-custom-sqlite-databases)
+
+Spin provides an interface for you to persist data in an SQLite database managed by Spin. This database allows Spin developers to persist relational data across application invocations.
+
+{{ details "Why do I need a Spin interface? Why can't I just use my own external database?" "You can absolutely still use your own external database either with the [MySQL or Postgres APIs](/spin/rdbms-storage). However, if you're interested in quick, local relational storage without any infrastructure set-up then Spin's SQLite database is a great option." }}
+
+## Granting SQLite Database Permissions to Components
+
+By default, a given component of an app will not have access to any SQLite databases. Access must be granted specifically to each component via the component manifest.  For example, a component could be given access to the default store using:
+
+```toml
+[component]
+sqlite_databases = ["default"]
+```
+
+> Note: To deploy your Database application to Fermyon Cloud using `spin cloud deploy`, see the [NoOps SQL Database](https://developer.fermyon.com/cloud/noops-sql-db#accessing-private-beta) section in the documentation. It covers signing up for the private beta and setting up your Cloud database tables and initial data.
+
+## Using SQLite Storage From Applications
+
+The Spin SDK surfaces the Spin SQLite database interface to your language.
+
+The set of operations is common across all SDKs:
+
+| Operation  | Parameters | Returns | Behavior |
+|------------|------------|---------|----------|
+| `open`  | name | connection  | Open the database with the specified name. If `name` is the string "default", the default database is opened, provided that the component that was granted access in the component manifest from `spin.toml`. Otherwise, `name` must refer to a store defined and configured in a [runtime configuration file](/spin/dynamic-configuration.md#sqlite-storage-runtime-configuration) supplied with the application.|
+| `execute` | connection, sql, parameters | database records | Executes the SQL statement and returns the results of the statement. SELECT statements typically return records or scalars. INSERT, UPDATE, and DELETE statements typically return empty result sets, but may return values in some cases. The `execute` operation recognizes the [SQLite dialect of SQL](https://www.sqlite.org/lang.html). |
+| `close` | connection | - | Close the specified `connection`. |
+
+The exact detail of calling these operations from your application depends on your language:
+
+{{ tabs "sdk-type" }}
+
+{{ startTab "Rust"}}
+
+SQLite functions are available in the `spin_sdk::sqlite` module. The function names match the operations above. For example:
+
+```rust
+use anyhow::Result;
+use serde::Serialize;
+use spin_sdk::{
+    http::{Request, Response},
+    http_component,
+    sqlite::{Connection, Error, ValueParam},
+};
+
+#[http_component]
+fn handle_request(req: Request) -> Result<Response> {
+    let connection = Connection::open_default()?;
+
+    let execute_params = [
+        ValueParam::Text("Try out Spin SQLite"),
+        ValueParam::Text("Friday"),
+    ];
+    connection.execute(
+        "INSERT INTO todos (description, due) VALUES (?, ?)",
+        execute_params.as_slice(),
+    )?;
+
+    let rowset = connection.execute(
+        "SELECT id, description, due FROM todos",
+        &[]
+    )?;
+
+    let todos: Vec<_> = rowset.rows().map(|row|
+        ToDo {
+            id: row.get::<u32>("id").unwrap(),
+            description: row.get::<&str>("description").unwrap().to_owned(),
+            due: row.get::<&str>("due").unwrap().to_owned(),
+        }
+    ).collect();
+
+    let body = serde_json::to_vec(&todos)?;
+    Ok(http::Response::builder().status(200).body(Some(body.into()))?)
+}
+
+// Helper for returning the query results as JSON
+#[derive(Serialize)]
+struct ToDo {
+    id: u32,
+    description: String,
+    due: String,
+}
+```
+
+**General Notes** 
+* All functions are on the `spin_sdk::sqlite::Connection` type.
+* Parameters are instances of the `ValueParam` enum; you must wrap raw values in this type.
+* The `execute` function returns a `QueryResult`. To iterate over the rows use the `rows()` function. This returns an iterator; use `collect()` if you want to load it all into a collection.
+* The values in rows are instances of the `ValueResult` enum.  However, you can use `row.get(column_name)` to extract a specific column from a row.  `get` casts the database value to the target Rust type. If the compiler can't infer the target type, write `row.get::<&str>(column_name)` (or whatever the desired type is).
+* All functions wrap the return in `Result`, with the error type being `spin_sdk::sqlite::Error`.
+
+{{ blockEnd }}
+
+{{ startTab "Typescript"}}
+
+To use SQLite functions, use the `Sqlite.open` or `Sqlite.openDefault` function to obtain a `Connection` object. `Connection` provides the `execute` method as described above. For example:
+
+```javascript
+import {Sqlite} from "@fermyon/spin-sdk"
+
+const conn = Sqlite.openDefault();
+const result = conn.execute("SELECT * FROM todos WHERE id > (?);", [1]);
+const json = JSON.stringify(result.rows);
+```
+
+**General Notes**
+* The `spinSdk` object is always available at runtime. Code checking and completion are available in TypeScript at design time if the module imports anything from the `@fermyon/spin-sdk` package.
+* Parameters are JavaScript values (numbers, strings, byte arrays, or nulls). Spin infers the underlying SQL type.
+* The `execute` function returns an object with `rows` and `columns` properties. `columns` is an array of strings representing column names. `rows` is an array of rows, each of which is an array of JavaScript values (as above) in the same order as `columns`.
+* The `Connection` object doesn't surface the `close` function.
+* If a Spin SDK function fails, it throws an [Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error).
+
+{{ blockEnd }}
+
+{{ startTab "Python"}}
+
+To use SQLite functions, use the `spin_sqlite` module in the Python SDK. The `sqlite_open` and `sqlite_open_default` functions return a connection object. The connection object provides the `execute` method as described above. For example:
+
+```python
+from spin_http import Response
+from spin_sqlite import sqlite_open_default
+
+def handle_request(request):
+    conn = sqlite_open_default()
+    result = conn.execute("SELECT * FROM todos WHERE id > (?);", [1])
+    rows = result.rows()
+    return Response(200,
+                    {"content-type": "application/json"},
+                    bytes(str(rows), "utf-8"))
+```
+
+**General Notes**
+* Parameters are Python values (numbers, strings, and lists). Spin infers the underlying SQL type.
+* The `execute` method returns an object with `rows` and `columns` methods. `columns` returns a list of strings representing column names. `rows` is an array of rows, each of which is an array of Python values (as above) in the same order as `columns`.
+* The connection object doesn't surface the `close` function.
+* Errors are surfaced as exceptions.
+
+{{ blockEnd }}
+
+{{ startTab "TinyGo"}}
+
+The Go SDK is implemented as a driver for the standard library's [database/sql](https://pkg.go.dev/database/sql) interface.
+
+```go
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	spinhttp "github.com/fermyon/spin/sdk/go/http"
+	"github.com/fermyon/spin/sdk/go/sqlite"
+)
+
+type Todo struct {
+	ID          string
+	Description string
+	Due         string
+}
+
+func init() {
+	spinhttp.Handle(func(w http.ResponseWriter, r *http.Request) {
+		db := sqlite.Open("default")
+		defer db.Close()
+
+		_, err := db.Exec("INSERT INTO todos (description, due) VALUES (?, ?)", "Try out Spin SQLite", "Friday")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		rows, err := db.Query("SELECT id, description, due FROM todos")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		var todos []*Todo
+		for rows.Next() {
+			var todo Todo
+			if err := rows.Scan(&todo.ID, &todo.Description, &todo.Due); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			todos = append(todos, &todo)
+		}
+		json.NewEncoder(w).Encode(todos)
+	})
+}
+
+func main() {}
+```
+
+**General Notes**
+
+A convenience function `sqlite.Open()` is provided to create a database connection. Because the `http.Handle` function is inside the `init()` function the Spin SQLite driver cannot be initialized the same way as other drivers using [sql.Open](https://pkg.go.dev/database/sql#Open).
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+## Preparing an SQLite Database
+
+Although Spin provides SQLite as a built-in database, SQLite still needs you to create its tables.  In most cases, the most convenient way to do this is to use the `spin up --sqlite` option to run whatever SQL statements you need before your application starts.  This is typically used to create or alter tables, but can be used for whatever other maintenance or troubleshooting tasks you need.
+
+You can run a SQL script from a file using the `@filename` syntax:
+
+<!-- @nocpy -->
+
+```bash
+spin up --sqlite @migration.sql
+```
+
+Or you can pass SQL statements directly on the command line as a (quoted) string:
+
+<!-- @nocpy -->
+
+```bash
+spin up --sqlite "CREATE TABLE IF NOT EXISTS todos (id INTEGER PRIMARY KEY AUTOINCREMENT, description TEXT NOT NULL, due TEXT NOT NULL)"
+```
+
+As with runtime operations, this flag uses the [SQLite dialect of SQL](https://www.sqlite.org/lang.html).
+
+You can provide the `--sqlite` flag more than once; Spin runs the statements (or files) in the order you provide them, and waits for each to complete before running the next.
+
+> It's also possible to create tables from your Wasm components using the usual `execute` function. That can end up mingling your "hot path" application logic with database maintenance code; decide which approach is best based on your application's needs.
+
+## Custom SQLite Databases
+
+Spin defines a database named `"default"` and provides automatic backing storage.  If you need to customize Spin with additional databases, or to change the backing storage for the default database, you can do so via the `--runtime-config-file` flag and the `runtime-config.toml` file.  See [SQLite Database Runtime Configuration](/spin/dynamic-configuration#sqlite-storage-runtime-configuration) for details.
+
+### Granting Access to Custom SQLite Databases
+
+As mentioned above, by default, a given component of an app will not have access to any SQLite databases. Access must be granted specifically to each component via the component manifest, using the `component.sqlite_databases` field in the manifest.
+
+Components can be given access to different databases, and may be granted access to more than one database. For example:
+
+```toml
+# c1 has no access to any databases
+[component]
+name = "c1"
+
+# c2 can use the default database, but no custom databases
+[component]
+name = "c2"
+sqlite_databases = ["default"]
+
+# c3 can use the custom databases "marketing" and "sales", which must be
+# defined in the runtime config file, but cannot use the default database
+[component]
+name = "c3"
+sqlite_databases = ["marketing", "sales"]
+```

--- a/content/spin/v2/template-authoring.md
+++ b/content/spin/v2/template-authoring.md
@@ -1,0 +1,142 @@
+title = "Creating Spin templates"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/template-authoring.md"
+
+---
+- [Authoring the Content](#authoring-the-content)
+- [Authoring the Manifest](#authoring-the-manifest)
+- [Supporting `spin add`](#supporting-spin-add)
+- [Hosting Templates in Git](#hosting-templates-in-git)
+
+Spin templates allow a Spin developer to quickly create the skeleton of an
+application or component, ready for the application logic to be filled in.
+
+A template consists of two directories, `content` and `metadata`.
+
+* The `content` directory contains all the files you'd like to be copied into
+  the Spin application directory, such as source code, the `spin.toml` file,
+  standard assets, precompiled modules, etc.  These files can contain placeholders
+  so the user of the template can customise the end result.
+* The `metadata` directory contains the files the control how the template is
+  instantiated.  In this version of Spin, the only file in this directory
+  should be the _template manifest_.
+
+For examples of the directory contents, see the `templates` directory in the
+[Spin GitHub repository](https://github.com/fermyon/spin).
+
+Templates must always be shared in a `templates` directory.  This allows the
+installer to locate them in repos that contain other content.
+
+## Authoring the Content
+
+Copy all the files that you want to be copied as part of the template into
+the `content` directory. If you do nothing more, they will be copied
+verbatim. Often, though, you'll want to allow the user to put their own
+values in - for example, a project name, or an HTTP route.
+
+To do this, replace the text you want the user to be able to substitute
+with an expression of the form `{{parameter-name}}`, where `parameter-name`
+is an identifier of your choice.  **You will need to add an entry to
+the manifest matching this name** - see below.
+
+You can reuse a parameter in more than one place - it will be prompted only once and will get the same value in each place.
+
+You can also transform the user value by specifying a filter after a bar:
+`{{parameter-name | filter-name}}`.  This is particularly useful when you
+want to conform to specific language conventions. The following filters
+are supported:
+
+| Name          | Effect |
+|---------------|--------|
+| `kebab_case`  | Transforms input into kebab case, e.g. `My Application` to `my-application` |
+| `snake_case`  | Transforms input into snake case, e.g. `My Application` to `my_application` |
+| `pascal_case` | Transforms input into Pascal case, e.g. `my appplication` to `MyApplication` |
+
+## Authoring the Manifest
+
+The template manifest is a TOML file. It must be named `spin-template.toml`:
+
+<!-- @nocpy -->
+
+```toml
+manifest_version = "1"
+id = "my-application"
+description = "An application"
+tags = ["my-tag"]
+
+[parameters]
+# Example parameter
+project-name = { type = "string", prompt = "Project name" }
+```
+
+* `manifest_version` specifies the format this manifest follows. It must be `"1"`.
+* `id` is however you want users to refer to your template in `spin new`.
+  It may contain letters, digits, hypens and underscores.
+* `description` is optional. It is shown when displaying the template.
+* `tags` is optional. These are used to enable discoverability via the Spin CLI.
+  For example, `spin new --tag my-tag` will prompt selection for a template containing `"my-tag"`.
+
+The `parameters` table is where you list the placeholders that you edited
+into your content for the user to substitute. You should include an entry
+for each parameter. The key is the parameter name, and the value a JSON
+document that contains at minimum a `type` and `prompt`.  `type` must
+currently be `string`.  `prompt` is displayed when prompting the user
+for the value to substitute.
+
+The document may also have a `default`, which will be displayed to the user
+and can be accepted by pressing Enter. It may also specify constraints
+on what the user is allowed to enter. The following constraints are
+supported:
+
+| Key           | Value and usage |
+|---------------|-----------------|
+| `pattern`     | A regular expression. The user input must match the regular expression to be accepted. |
+
+## Supporting `spin add`
+
+The `spin add` command lets users add your template as a new component in
+an existing application. If you'd like to support this, you'll need to
+add a few items to your metadata.
+
+* In the `metadata` directory, create a folder named `snippets`. In that
+  folder, create a file containing the (templated) manifest _just_ for the
+  component to be added.
+  * Don't include any application-level entries, just the component section.
+  * If your template contains component files, remember they will be copied
+    into a subdirectory, and make sure any paths reflect that.
+* In the `spin-template.toml` file, add a table called `add_component`, with
+  the following entries:
+
+| Key             | Value and usage |
+|-----------------|-----------------|
+| `snippets`      | A subtable with an entry named `component`, whose value is the name of the file containing the component manifest template. (Don't include the `snippets` directory prefix - Spin knows to look in the `snippets` directory.) |
+| `skip_files`    | Optional array of content files that should _not_ be copied when running in "add component" mode. For example, if your template contains a `spin.toml` file, you should use this setting to exclude that, because you want to add a new entry to the existing file, not overwrite it. |
+| `skip_parameters` | Optional array of parameters that Spin should _not_ prompt for when running in "add component" mode. For example, the HTTP templates don't prompt for the base path, because that's defined at the application level, not set on an individual component. |
+
+Here is an example `add_component` table from a HTTP template:
+
+<!-- @nocpy -->
+
+```toml
+[add_component]
+skip_files = ["spin.toml"]
+skip_parameters = ["http-base"]
+[add_component.snippets]
+component = "component.txt"
+```
+
+> For examples from the Spin project, see `http-rust` (can be used in both`spin new` and `spin add`) and `static-fileserver` (`spin add` only).
+
+## Hosting Templates in Git
+
+You can publish templates in a Git repo.  The templates must be in the `/templates`
+directory, with a subdirectory per template.
+
+When a user installs templates from your repo, by default Spin looks for a tag
+to identify a compatible version of the templates.  This tag is of the
+form `spin/templates/vX.Y`, where X is the major version, and Y the minor
+version, of the user's copy of Spin. For example, if the user is on
+Spin 0.3.1, templates will be installed from `spin/templates/v0.3`.  If this
+tag does not exist, Spin installs templates from `HEAD`.

--- a/content/spin/v2/troubleshooting-application-dev.md
+++ b/content/spin/v2/troubleshooting-application-dev.md
@@ -1,0 +1,40 @@
+title = "Troubleshooting Application Development"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+enable_shortcodes = true
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/troubleshooting-application-dev.md"
+
+---
+
+The `spin doctor` command detects problems that could stop your application building and running, and can help to fix them.  These include problems like invalid manifests, missing Wasm files, and missing tools.
+
+To troubleshoot using `spin doctor`, run the command:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin doctor
+```
+
+> If you're not in the application directory, use the `-f` flag to tell the doctor which application to check
+
+Spin performs a series of checks on your application. If it finds a problem, it prints a description and, if possible, offers to fix it. Here's an example where a stray keystroke has messed up the version field in the application manifest:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin doctor
+📟 The Spin Doctor is in.
+🩺 Checking spin.toml...
+
+❗ Diagnosis: Manifest 'spin_manifest_version' must be "1", not "11"
+🩹 The Spin Doctor can help! Would you like to:
+> Set manifest version to "1"
+  Do nothing
+  See more details about the recommended changes
+```
+
+If `spin doctor` detects a problem it can fix, you can choose to accept the fix, skip it to fix manually later, or see more details before choosing.  If `spin doctor` can't fix the problem, it displays the problem so you can make your own decision about how to fix it.
+
+> `spin doctor` is in an early stage of development, and there are many potential problems it doesn't yet check for. Please [raise an issue](https://github.com/fermyon/spin/issues/new?template=suggestion.md) if you have a problem you think `spin doctor` should check for.

--- a/content/spin/v2/upgrade.md
+++ b/content/spin/v2/upgrade.md
@@ -1,0 +1,133 @@
+title = "Upgrade Spin"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+enable_shortcodes = true
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/upgrade.md"
+
+---
+- [Are You on the Latest Version?](#are-you-on-the-latest-version)
+- [Upgrade Spin](#upgrade-spin)
+  - [Cargo](#cargo)
+  - [Installer](#installer)
+  - [Source](#source)
+- [Troubleshooting](#troubleshooting)
+  - [Not Seeing the Latest Version?](#not-seeing-the-latest-version)
+
+## Are You on the Latest Version?
+
+The best way to know if you're on the latest version of Spin is to run `spin --version`:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin --version
+```
+
+You can compare the output from the above command with the [latest release release](https://github.com/fermyon/spin/releases/latest) listed in the Spin GitHub repository (which is also shown in the image below):
+
+![spin version image](https://img.shields.io/github/v/release/fermyon/spin)
+
+## Upgrade Spin
+
+Spin can be installed in many ways, and therefore the upgrade procedure can differ between users. Here are a few suggested ways to upgrade Spin to the latest version. If you're not sure how or where you installed your current version of Spin try using the `which` command on [Linux and macOS](https://linux.die.net/man/1/which) and the `where` command on [Windows](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/where), as shown below:
+
+{{ tabs "os" }}
+
+{{ startTab "Linux"}}
+
+<!-- @selectiveCpy -->
+
+```bash
+$ which spin
+```
+
+{{ blockEnd }}
+
+{{ startTab "macOS"}}
+
+<!-- @selectiveCpy -->
+
+```bash
+$ which spin
+```
+
+{{ blockEnd }}
+
+{{ startTab "Windows"}}
+
+<!-- @selectiveCpy -->
+
+```bash
+$ where spin
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+### Cargo
+
+If you originally followed the documentation's [Cargo install method](/spin/install#using-cargo-to-install-spin), please revisit to reinstall.
+
+> Hint: Your Spin executable will likely be in the following location:
+
+<!-- @nocpy -->
+
+```bash
+~/.cargo/bin/spin
+```
+
+### Installer 
+
+If you originally followed the documentation's [installer script method](/spin/install#installing-spin), please revisit to reinstall.
+
+> Hint: Your Spin executable will likely be in the following location:
+
+<!-- @nocpy -->
+
+```bash
+/usr/local/bin/spin
+```
+
+### Source
+
+If you followed the documentation's [install from source method](/spin/install#building-spin-from-source) please revisit to reinstall.
+
+> Hint: Your Spin executable will likely be in the following location (where you originally cloned the Spin repository):
+
+```bash
+~/spin/target/release/spin
+```
+
+### Homebrew
+
+If you installed Spin using [Homebrew](https://brew.sh/) please use the following commands to upgrade Spin.
+
+<!-- @selectiveCpy -->
+
+```bash
+$ brew update
+$ brew upgrade fermyon/tap/spin
+```
+
+## Troubleshooting
+
+If you have upgraded Spin and don't see the newer version, please consider the following.
+
+### Not Seeing the Latest Version?
+
+It may be possible that you have installed Spin **using more than one** of the above methods. In this case, the Spin executable that runs is the one that is listed first in your `PATH` system variable. 
+
+If you have upgraded Spin yet still see the old version using `spin --version` this can be due to the order of precedence in your `PATH`. Try echoing your path to the screen and checking to see whether the location of your intended Spin executable is listed before or after other pre-existing installation paths:
+
+```bash
+echo $PATH
+/Users/my_user/.cargo/bin:/usr/local/bin
+```
+
+> Paths are separated by the `:` (colon)
+
+In the above case, the [Cargo install method](/spin/install#using-cargo-to-install-spin)'s installation will take precedence over the [installer script method](/spin/install#installing-spin)'s installation. 
+
+In this case, you can either remove the Cargo installation of Spin using `cargo uninstall spin-cli` or update your system path to prioritize the Spin binary path that you prefer.

--- a/content/spin/v2/url-shortener-tutorial.md
+++ b/content/spin/v2/url-shortener-tutorial.md
@@ -1,0 +1,169 @@
+title = "Building a URL Shortener With Spin"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/url-shortener-tutorial.md"
+
+---
+- [A Simple URL Shortener Built With Spin](#a-simple-url-shortener-built-with-spin)
+- [Here Is One We Prepared Earlier](#here-is-one-we-prepared-earlier)
+- [Conclusion](#conclusion)
+
+## A Simple URL Shortener Built With Spin
+
+This tutorial will walk you through building a Spin component that
+redirects short URLs to their configured destinations.
+In essence, this is a simple HTTP component that returns a response that contains
+redirect information based on the user-defined routes.
+
+This is an evolving tutorial. As Spin allows building more complex components
+(through supporting access to services like databases), this tutorial will be
+updated to reflect that.
+
+## Here Is One We Prepared Earlier
+
+The complete implementation for this tutorial [can be found on GitHub](https://github.com/fermyon/url-shortener).
+
+First, our URL shortener allows users to configure their own final URLs —
+currently, that is done through a configuration file that contains multiple
+`[[route]]` entries, each containing the shortened path as `source`, and
+the `destination` URL:
+
+```toml
+[[route]]
+source = "/spin"
+destination = "https://github.com/fermyon/spin"
+
+[[route]]
+source = "/hype"
+destination = "https://www.fermyon.com/blog/how-to-think-about-wasm"
+```
+
+Whenever a request for `https://<domain>/spin` is sent, our component will
+redirect to `https://github.com/fermyon/spin`. Now that we have a basic
+understanding of how the component should behave, let's see how to implement it
+using Spin.
+
+First, we start with [a new Spin component written in Rust](./rust-components.md):
+
+```rust
+/// A Spin HTTP component that redirects requests 
+/// based on the router configuration.
+#[http_component]
+fn redirect(req: Request) -> Result<Response> {
+    let router = Router::default()?;
+    router.redirect(req)
+}
+```
+
+All the component does is create a new router based on the default configuration,
+then use it to redirect the request. Let's see how the router is defined:
+
+```rust
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Route {
+    pub source: String,
+    pub destination: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Router {
+    #[serde(rename = "route")]
+    pub routes: Vec<Route>,
+}
+```
+
+The `Router` structure is a Rust representation of the TOML configuration above.
+
+```rust
+pub fn redirect(self, req: Request) -> Result<Response> {
+    // read the request path from the `spin-path-info` header
+    let path_info = req
+        .headers()
+        .get("spin-path-info")
+        .expect("cannot get path info from request headers");
+    // if the path is not present in the router configuration,
+    // return 404 Not Found.
+    let route = match self.path(path_info.to_str()?) {
+        Some(r) => r,
+        None => return not_found(),
+    };
+    // otherwise, return the redirect to the destination
+    let res = http::Response::builder()
+        .status(http::StatusCode::PERMANENT_REDIRECT)
+        .header(http::header::LOCATION, route.destination)
+        .body(None)?;
+    Ok(res)
+}
+```
+
+The `redirect` function is straightforward — it reads the request path from the
+`spin-path-info` header (make sure to read the [document about the HTTP trigger](./http-trigger.md)
+for an overview of the HTTP headers present in Spin components), selects the
+corresponding destination from the router configuration, then sends the
+HTTP redirect to the new location.
+
+At this point, we can build and run the module with Spin:
+
+```bash
+$ spin build
+$ spin up
+```
+
+And the component can now handle incoming requests:
+
+<!-- @selectiveCpy -->
+
+```bash
+# based on the configuration file, a request
+# to /spin should be redirected
+$ curl -i localhost:3000/spin
+HTTP/1.1 308 Permanent Redirect
+location: https://github.com/fermyon/spin
+content-length: 0
+# based on the configuration file, a request
+# to /hype should be redirected
+$ curl -i localhost:3000/hype
+HTTP/1.1 308 Permanent Redirect
+location: https://www.fermyon.com/blog/how-to-think-about-wasm
+content-length: 0
+# /abc is not present in the router configuration,
+# so this returns a 404.
+$ curl -i localhost:3000/abc
+HTTP/1.1 404 Not Found
+content-length: 9
+
+Not Found
+```
+
+> Notice that you can use the `--listen` option for `spin up` to start the
+> web server on a specific host and port, which you can then bind to a domain.
+
+We can now [publish the application to an OCI registry](./distributing-apps.md) (together
+with router configuration file):
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin registry push ghcr.io/alyssa-p-hacker/url-shortener:v1
+Pushed with digest sha256:3c408a1b29b3098286c7ea5ab22f47248ccfadcc63ad5596ca0d85e3f522c43d
+```
+
+And now we can run the application directly from the registry:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin up -f ghcr.io/alyssa-p-hacker/url-shortener:v1
+
+Serving http://127.0.0.1:3000
+Available Routes:
+  shortener: http://127.0.0.1:3000 (wildcard)
+```
+
+## Conclusion
+
+In this tutorial we built a simple URL shortener as a Spin component.
+In the future we will expand this tutorial by storing the router configuration
+in a database supported by Spin, and potentially create another component that
+can be used to add new routes to the configuration.

--- a/content/spin/v2/variables.md
+++ b/content/spin/v2/variables.md
@@ -1,0 +1,203 @@
+title = "Application Variables"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+enable_shortcodes = true
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/variables.md"
+
+---
+- [Adding Variables to Your Applications](#adding-variables-to-your-applications)
+- [Using Variables From Applications](#using-variables-from-applications)
+
+Spin supports dynamic application variables. Instead of being static, their values can be updated without modifying the application, creating a simpler experience for rotating secrets, updating API endpoints, and more. 
+
+These variables are defined in a Spin application manifest (in the `[variables]` section), and their values can be set or overridden at runtime by a [configuration provider](/spin/dynamic-configuration.md#custom-config-providers). When running Spin locally, the configuration provider can be Hashicorp Vault for secrets, or host environment variables.
+
+For information about defining variables and component configuration keys, such as manifest syntax, naming restrictions, and value template syntax, refer to the [dynamic configuration documentation](/spin/dynamic-configuration.md).
+
+## Adding Variables to Your Applications
+
+Variables are added to an application under the top-level `[variables]` section of an application manifest (`spin.toml`). Each entry must either have a default value or be marked as `required = true`. “Required” entries must be [provided](/spin/dynamic-configuration#custom-config-providers) with a value. 
+
+For example, say an application needs to access a secret. A `[variables]` section could be added to an application's manifest with one entry for a variable named `secret`. Since there is no reasonable default value for a secret, the variable is set as required with `required = true`:
+
+<!-- @nocpy -->
+
+```toml
+# Add this above the [component] section
+[variables]
+secret = { required = true }
+```
+
+Variables are surfaced to a specific component by adding a `[component.config]` section to the component and referencing them within it. The `[component.config]` section contains a mapping of component variables and values. Entries can be static (like `api_host` below) or reference an updatable application variable (like `password` below) using [mustache](https://mustache.github.io/)-inspired string templates. Only components that explicitly use variables in their configuration section will get access to them. This enables only exposing variables (such as secrets) to the desired components of an application.
+
+<!-- @nocpy -->
+
+```toml
+# Add this below the [component.build] section
+[component.config]
+password = "\{{ secret }}"
+api_host = "https://my-api.com"
+```
+
+When a component configuration variable references an application variable, it's value will dynamically update as the application variable changes. For example, if the `secret` variable is provided using the [Spin Vault provider](/spin/dynamic-configuration.md#vault-config-provider), it can be updated by changing the value in HashiCorp Vault. The next time the component gets the value of `password`, the latest value of `secret` will be returned by the provider. See the [next section](#using-variables-from-applications) to learn how to use Spin's configuration SDKs to get configuration variables within applications.
+
+A complete application manifest with a `secret` variable and a component that uses it would look similar to the following, with the `[component.build]` section varying depending on the language used to build the `password_checker` component:
+
+<!-- @nocpy -->
+
+```toml
+spin_manifest_version = "1"
+description = "A Spin app with a dynamically updatable secret"
+name = "password_checker"
+trigger = { type = "http", base = "/" }
+version = "0.1.0"
+
+[variables]
+secret = { required = true }
+
+[[component]]
+id = "password_checker"
+source = "app.wasm"
+[component.trigger]
+route = "/..."
+[component.build]
+command = "spin py2wasm app -o app.wasm"
+[component.config]
+password = "\{{ secret }}"
+api_host = "https://my-api.com"
+```
+
+## Using Variables From Applications
+
+The Spin SDK surfaces the Spin configuration interface to your language. The [interface](https://github.com/fermyon/spin/blob/main/wit/ephemeral/spin-config.wit) consists of one operation:
+
+| Operation  | Parameters                          | Returns             | Behavior |
+|------------|-------------------------------------|---------------------|----------|
+| `get-config`    | Variable name  | Variable value    | Gets the value of the variable from the configured provider |
+
+To illustrate the config API, each of the following examples receives a password via the HTTP request body, compares it to the value stored in the application variable, and returns a JSON response indicating whether the submitted password matched or not. The application manifest associated with the examples would look similar to the one described [in the previous section](#adding-variables-to-your-applications). 
+
+The exact details of calling the config SDK from a Spin application depends on the language:
+
+{{ tabs "sdk-type" }}
+
+{{ startTab "Rust"}}
+
+The config function is available in the `spin_sdk::config` module and is named `get`.
+
+```rust
+use anyhow::Result;
+use spin_sdk::{
+    config,
+    http::{Request, Response},
+    http_component,
+};
+
+#[http_component]
+fn handle_spin_example(req: Request) -> Result<Response> {
+    let password = std::str::from_utf8(req.body().as_ref().unwrap()).unwrap();
+    let expected = config::get("password").expect("could not get variable");
+    let response = if expected == password {
+        "accepted"
+    } else {
+        "denied"
+    };
+    let response_json = format!("\{{\"authentication\": \"{}\"}}", response);
+    Ok(http::Response::builder()
+        .status(200)
+        .header("Content-Type", "application/json")
+        .body(Some(response_json.into()))?)
+}
+
+```
+
+{{ blockEnd }}
+
+{{ startTab "TypeScript"}}
+
+The config function is available in the `Config` package and is named `get`.
+
+```ts
+import { HandleRequest, HttpRequest, HttpResponse, Config } from "@fermyon/spin-sdk"
+
+const decoder = new TextDecoder("utf-8")
+
+export const handleRequest: HandleRequest = async function (request: HttpRequest): Promise<HttpResponse> {
+  const expected = decoder.decode(request.body)
+  let password = Config.get("password")
+  let access = "denied"
+  if (expected === password) {
+      access = "accepted"
+  }
+  let responseJson = `{\"authentication\": \"${access}\"}`;
+
+  return {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    body: responseJson
+  }
+}
+
+```
+
+{{ blockEnd }}
+
+{{ startTab "Python"}}
+
+The config function is available in the `spin_config` package and is named `config_get`.
+
+```py
+from spin_http import Response
+from spin_config import config_get
+
+def handle_request(request):
+    password = request.body.decode("utf-8")
+    expected = config_get("password")
+    access = "denied"
+    if expected == password:
+        access = "accepted"
+    response = f'\{{"authentication": "{access}"}}'
+    return Response(200,
+                    {"content-type": "application/json"},
+                    bytes(response, "utf-8"))
+```
+
+{{ blockEnd }}
+
+{{ startTab "TinyGo"}}
+
+The config function is available in the `github.com/fermyon/spin/sdk/go/config` package and is named `Get`. See [Go package](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/config) for reference documentation.
+
+```go
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	spinconfig "github.com/fermyon/spin/sdk/go/config"
+	spinhttp "github.com/fermyon/spin/sdk/go/http"
+)
+
+spinhttp.Handle(func(w http.ResponseWriter, r *http.Request) {
+    access := "denied"
+    password, err := io.ReadAll(r.Body)
+    if err == nil {
+        expected, err := spinconfig.Get("password")
+        if err != nil {
+            http.Error(w, err.Error(), http.StatusInternalServerError)
+            return
+        }
+        if expected == string(password) {
+            access = "accepted"
+        }
+    }
+    response := fmt.Sprintf("{\"authentication\": \"%s\"}", access)
+    w.Header().Set("Content-Type", "application/json")
+    fmt.Fprintln(w, response)
+})
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}

--- a/content/spin/v2/writing-apps.md
+++ b/content/spin/v2/writing-apps.md
@@ -1,0 +1,406 @@
+title = "Writing Spin Applications"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+enable_shortcodes = true
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/writing-apps.md"
+
+---
+- [Writing an Application Manifest](#writing-an-application-manifest)
+  - [The Application `trigger`](#the-application-trigger)
+  - [The Component `id`](#the-component-id)
+  - [The Component `source`](#the-component-source)
+  - [The Component `trigger`](#the-component-trigger)
+- [Writing a Component Wasm Module](#writing-a-component-wasm-module)
+- [Creating an Application From a Template](#creating-an-application-from-a-template)
+- [Adding a New Component to an Application](#adding-a-new-component-to-an-application)
+- [Including Files with Components](#including-files-with-components)
+- [Adding Environment Variables to Components](#adding-environment-variables-to-components)
+- [Granting Networking Permissions to Components](#granting-networking-permissions-to-components)
+- [Granting Storage Permissions to Components](#granting-storage-permissions-to-components)
+- [Example Manifests](#example-manifests)
+  - [Including a Directory of Files](#including-a-directory-of-files)
+  - [Using Public Components](#using-public-components)
+  - [Customizing the Executor](#customizing-the-executor)
+  - [Setting the Redis Channel to Monitor](#setting-the-redis-channel-to-monitor)
+- [Next Steps](#next-steps)
+
+A Spin application consists of a set of WebAssembly (Wasm) _components_, and a _manifest_ that lists those components with some data about when and how to run them.  This page describes how to write components, manifests, and hence applications.
+
+## Writing an Application Manifest
+
+> You won't normally create a manifest by hand, but will instead [create](#creating-an-application-from-a-template) or [update](#adding-a-new-component-to-an-application) one from a template. Skip to those sections if that's what you want to do. But it's important to know what's inside a manifest for when you need to update component capabilities or troubleshoot a problem.
+
+A Spin _application manifest_ is a [TOML](https://toml.io/) file that contains:
+
+* Identification information about the application
+* What events the application should run in response to (the _trigger_)
+* The Wasm modules of the application and their associated settings (the _components_)
+* Optionally, configuration variables that the user can set when running the application
+
+By convention, the Spin manifest file is usually called `spin.toml`.
+
+This example is the manifest for a simple HTTP application with a single component executed when the `/hello` endpoint is accessed:
+
+<!-- @nocpy -->
+
+```toml
+# General identification information
+spin_manifest_version = "1"
+name = "spin-hello-world"
+version = "1.0.0"
+description = "A simple application that returns hello world."
+# The application trigger. This application responds to HTTP requests
+trigger = { type = "http", base = "/" }
+
+# The single component
+[[component]]
+id = "hello"
+description = "A simple component that returns hello world."
+# The Wasm module to run for the component
+source = "target/wasm32-wasi/release/helloworld.wasm"
+# The component trigger. This component responds to HTTP requests to "/hello"
+[component.trigger]
+route = "/hello"
+# How to build the Wasm module from source
+[component.build]
+command = "cargo build --target wasm32-wasi --release"
+```
+
+You can look up the various fields in the [Manifest Reference](manifest-reference), but let's look at the key fields in more detail.
+
+### The Application `trigger`
+
+The most important field in the application-level section is the `trigger` field.  This tells Spin the _type_ of event that it should hook the application up to.  Spin has built-in support for responding to HTTP requests (`trigger = { type = "http" }`) and Redis messages (`trigger = { type = "redis" }`)
+
+> In current versions of Spin, the trigger type is application-wide. You can't listen for Redis messages and HTTP requests in the same application.
+
+Some triggers have additional application-level configuration options.  For example, the HTTP trigger requires you to provide a `base` field, which tells Spin the "root" route to which all component routes are relative.  See the [HTTP trigger](http-trigger) and [Redis trigger](redis-trigger) documentation for more details.
+
+### The Component `id`
+
+Component `id`s are identifier strings.  While not significant in themselves, they must be unique within the application.  Spin uses the `id` in logging and error messages to tell you which component a message applies to.
+
+<!-- @nocpy -->
+
+```toml
+[[component]]
+id = "hello"
+```
+
+### The Component `source`
+
+Each component has a `source` field which tells Spin where to load the Wasm module from.
+
+For components that you are working on locally, set it to the file path to the compiled Wasm module file.  This must be a relative path from the directory containing `spin.toml`.
+
+<!-- @nocpy -->
+
+```toml
+[[component]]
+source = "dist/cart.wasm"
+```
+
+For components that are published on the Web, provide a `url` field containing the URL of the Wasm module, and a `digest` field indicating the expected SHA256 hash of the module contents.  The digest must be prefixed with the string `sha256:`.  Spin uses the digest to check that the module is what you were expecting, and won't load the module if the content doesn't match.
+
+<!-- @nocpy -->
+
+```toml
+[[component]]
+source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.0.1/spin_static_fs.wasm", digest = "sha256:650376c33a0756b1a52cad7ca670f1126391b79050df0321407da9c741d32375" }
+```
+
+Multiple components can have the same source.  An example is a document archive, where one component might serve user interface assets (CSS, images, etc.) on one route, while another serves the documents themselves on another route - both using the same file server module, but with different settings.
+
+### The Component `trigger`
+
+Each component has a `trigger` field which contains per-component settings (as opposed to the application-level ones on the application's `trigger`).  In particular, this tells Spin when to run _this_ component rather than any other component.  For HTTP applications, the component trigger has a `route` that says which HTTP route the component should handle.  For Redis applications, the component trigger has a `channel` that says which Redis channel's messages the component should handle.  See the [HTTP trigger](http-trigger) and [Redis trigger](redis-trigger) documentation for more details.
+
+<!-- @nocpy -->
+
+```toml
+[[component]]
+[component.trigger]
+route = "/hello"
+```
+
+## Writing a Component Wasm Module
+
+> You won't normally create a component by hand, but will instead [create](#creating-an-application-from-a-template) or [add](#adding-a-new-component-to-an-application) one from a template. Skip to those sections if that's what you want to do. But it's important to know what a component looks like so you can understand where to write your own code.
+
+At the Wasm level, a Spin component is a Wasm module that exports a handler for the application trigger.  At the developer level, a Spin component is a library or program that implements your event handling logic, and uses Spin interfaces, libraries, or tools to associate that with the events handled by Spin.
+
+See the Language Guides section for how to do this in your preferred language. As an example, this is a component written in the Rust language. The `hello_world` function uses an attribute `#[http_component]` to identify the function as handling a Spin HTTP event. The function takes a `Request` and returns a `Result<Response>`:
+
+```rust
+#[http_component]​
+fn hello_world(_req: Request) -> Result<Response> {​
+    Ok(http::Response::builder()​
+        .status(200)​
+        .body(Some("Hello, Fermyon!".into()))?)​
+}​
+```
+
+## Creating an Application From a Template
+
+If you've installed the Spin templates for your preferred language, you can use them to get started without having to write a manifest or the boilerplate code yourself.  To do this, run the `spin new` command, and choose the template that matches the type of application you want to create, and the language you want to use.
+
+{{ tabs "sdk-type" }}
+
+{{ startTab "Rust"}}
+
+Choose the `http-rust` template to create a new HTTP application, or `redis-rust` to create a new Redis application.
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin new
+Pick a template to start your application with:
+  http-c (HTTP request handler using C and the Zig toolchain)
+  http-csharp (HTTP request handler using C# (EXPERIMENTAL))
+  http-go (HTTP request handler using (Tiny)Go)
+  http-grain (HTTP request handler using Grain)
+> http-rust (HTTP request handler using Rust)
+  http-swift (HTTP request handler using SwiftWasm)
+  http-zig (HTTP request handler using Zig)
+  redis-go (Redis message handler using (Tiny)Go)
+  redis-rust (Redis message handler using Rust)
+
+Enter a name for your new application: hello_rust
+Project description: My first Rust Spin application
+HTTP base: /
+HTTP path: /...
+```
+
+{{ blockEnd }}
+
+{{ startTab "TypeScript"}}
+
+Choose the `http-ts` or `http-js` template to create a new HTTP application, according to whether you want to use TypeScript or JavaScript.
+
+> The JavaScript development kit doesn't yet support Redis applications.
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin new
+Pick a template to start your application with:
+  http-js (HTTP request handler using Javascript)
+> http-ts (HTTP request handler using Typescript)
+Enter a name for your new application: hello_typescript
+Project description: My first TypeScript Spin application
+HTTP base: /
+HTTP path: /...
+```
+
+{{ blockEnd }}
+
+{{ startTab "Python"}}
+
+Choose the `http-py` template to create a new HTTP application.
+
+> The Python development kit doesn't yet support Redis applications.
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin new
+Pick a template to start your application with:
+> http-py (HTTP request handler using Python)
+Enter a name for your new application: hello_python
+Description: My first Python Spin application
+HTTP base: /
+HTTP path: /...
+```
+
+{{ blockEnd }}
+
+{{ startTab "TinyGo"}}
+
+Choose the `http-go` template to create a HTTP application, or `redis-go` to create a Redis application.
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin new
+Pick a template to start your application with:
+  http-c (HTTP request handler using C and the Zig toolchain)
+  http-empty (HTTP application with no components)
+> http-go (HTTP request handler using (Tiny)Go)
+  http-grain (HTTP request handler using Grain)
+  http-php (HTTP request handler using PHP)
+  http-rust (HTTP request handler using Rust)
+Enter a name for your new application: hello_go
+Description: My first Go Spin application
+HTTP base: /
+HTTP path: /...
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+All of these templates create a manifest containing a single component, and the source code for a minimal "hello world" component.
+
+## Adding a New Component to an Application
+
+To add a new component to an existing application using a template, run the `spin add` command. This works in a very similar way to `spin new`, except that it expects the `spin.toml` file to already exist, and adds the details for the new component to that `spin.toml`.
+
+> Please take a look at the [Spin application structure](spin-application-structure) documentation, which explains how to achieve the recommended application structure (through the use of Spin templates via the `spin new` and `spin add` commands).
+
+## Including Files with Components
+
+You can include files with a component.  This means that:
+
+1. The Wasm module will be able to read those files at runtime.
+1. When you distribute or deploy the application, those files will be bundled with it so that the component can still access them.
+
+To do this, use the `files` field in the component manifest:
+
+<!-- @nocpy -->
+
+```toml
+[[component]]
+files = [ "images/**/*.jpg", { source = "styles/dist", destination = "/styles" } ]
+```
+
+The `files` field is an array listing the files, patterns and directories you want to include. Each element of the array can be:
+
+* A glob pattern, such as `images/**/*.jpg`.  In this case, the files that match the pattern are available to the Wasm code, at the same paths as they are in your file system. For example, if the glob pattern matches `images/photos/lake.jpg`, the Wasm module can access it using the path `images/photos/lake.jpg`.  Glob patterns are relative to the directory containing `spin.toml`, and must be within that directory.
+* A mapping from a `source` directory to a `destination` directory, such as `{ source = "styles/dist", destination = "/styles" }`.  In this case, the entire contents of the source directory are available to the Wasm code at the destination directory.  In this example, if you have a file named `styles/dist/list/exciting.css`, the Wasm module can access it using the path `/styles/list/exciting.css`.  Source directories are relative to the directory containing `spin.toml`; destination directories must be absolute.
+
+If your files list would match some files or directories that you _don't_ want included, you can use the `exclude_files` field to omit them.
+
+> By default, Spin takes a snapshot of your included files, and components access that snapshot. This ensures that when you test your application, you are checking it with the set of files it will be deployed with. However, it also means that your component does not pick up changes to the files while it is running. When testing a Web site, you might want to be able to edit a HTML or CSS file, and see the changes reflected without restarting Spin. You can tell Spin to give components access to the original, "live" files by passing the `--direct-mounts` flag to `spin up`.
+
+## Adding Environment Variables to Components
+
+Environment variables can be provided to components via the Spin application manifest.
+
+To do this, use the `environment` field in the component manifest:
+
+<!-- @nocpy -->
+
+```toml
+[[component]]
+environment = { PET = "CAT", FOOD = "WATERMELON" }
+```
+
+The field accepts a map of environment variable key/value pairs. They are mapped inside the component at runtime.
+
+The environment variables can then be accessed inside the component. For example, in Rust:
+
+```rs
+#[http_component]
+fn handle_hello_rust(req: Request) -> Result<Response> {
+    let response = format!("My {} likes to eat {}", std::env::var("PET")?, std::env::var("FOOD")?);
+    Ok(http::Response::builder()
+        .status(200)
+        .header("foo", "bar")
+        .body(Some(response.into()))?)
+}
+```
+
+## Granting Networking Permissions to Components
+
+By default, Spin components are not allowed to make outgoing HTTP requests.  This follows the general Wasm rule that modules must be explicitly granted capabilities, which is important to sandboxing.  To grant a component permission to make HTTP requests to a particular host, use the `allowed_http_hosts` field in the component manifest:
+
+<!-- @nocpy -->
+
+```toml
+[[component]]
+allowed_http_hosts = [ "dog-facts.example.com", "api.example.com:8080" ]
+```
+
+The Wasm module can make HTTP requests _only_ to the specified hosts.  If a port is specified, the module can make requests only to that port; otherwise, the module can make requests only on the default HTTP and HTTPS ports.  Requests to other hosts (or other ports) will fail with an error.
+
+For development-time convenience, you can also pass the string `"insecure:allow-all"` in the `allowed_http_hosts` collection.  This allows the Wasm module to make HTTP requests to _any_ host and on any port.  However, once you've determined which hosts your code needs, you should remove this string, and list the hosts instead.  Other Spin implementations may restrict host access, and may disallow components that ask to connect to anything and everything!
+
+## Granting Storage Permissions to Components
+
+By default, Spin components are not allowed to access Spin's storage services.  This follows the general Wasm rule that modules must be explicitly granted capabilities, which is important to sandboxing.  To grant a component permission to use a Spin-provided store, use the `key_value_stores` field in the component manifest:
+
+<!-- @nocpy -->
+
+```toml
+[[component]]
+key_value_stores = [ "default" ]
+```
+
+See [Persisting Data with Spin](kv-store) for more information.
+
+## Example Manifests
+
+This section shows some examples of Spin component manifests.
+
+### Including a Directory of Files
+
+This example shows a Spin HTTP component that includes all the files in `static/` under the application directory, made available to the Wasm module at the `/` path.
+
+<!-- @nocpy -->
+
+```toml
+[[component]]
+source = "modules/spin_static_fs.wasm"
+id = "fileserver"
+files = [ { source = "static/", destination = "/" } ]
+[component.trigger]
+route = "/static/..."
+```
+
+### Using Public Components
+
+This is similar to the file server component above, but gets the Wasm module from a public release instead of a local copy.  Notice that the files are still drawn from a local path.  This is a way in which you can use off-the-shelf component logic with your own application data.
+
+<!-- @nocpy -->
+
+```toml
+[[component]]
+source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.0.1/spin_static_fs.wasm", digest = "sha256:650376c33a0756b1a52cad7ca670f1126391b79050df0321407da9c741d32375" }
+id = "fileserver"
+files = [ { source = "static/", destination = "/" } ]
+[component.trigger]
+route = "/static/..."
+```
+
+### Customizing the Executor
+
+This example shows an HTTP component whose Wasm module, instead of using the default Spin HTTP interface, uses the CGI-like WAGI (WebAssembly Gateway Interface) protocol. Spin can't work out the application model from the component, so the manifest needs to tell Spin to use WAGI instead of its default mode. It does this via the `executor` field. This is specific to the HTTP trigger so it goes under `component.trigger`.
+
+In addition, this module does not provide its WAGI functionality via the default `_start` entry point, but via a custom entry point named `serve-wagi`.  The `executor` table needs to tell Spin this via the `entrypoint` field.  Finally, this component needs to run the WAGI entry point with a specific set of command line arguments, which are expressed in the WAGI executor's `argv` field.
+
+<!-- @nocpy -->
+
+```toml
+[[component]]
+source = "modules/env_wagi.wasm"
+id = "env"
+files = [ "content/**/*" , "templates/*", "scripts/*", "config/*"]
+[component.trigger]
+route = "/..."
+executor = { type = "wagi", argv = "test ${SCRIPT_NAME} ${ARGS} done", entrypoint = "serve-wagi" }
+```
+
+### Setting the Redis Channel to Monitor
+
+The example shows a Redis component.  The manifest sets the `channel` field to say which channel the component should monitor.  In this case, the component is invoked for new messages on the `messages` channel.
+
+<!-- @nocpy -->
+
+```toml
+[[component]]
+id = "echo-message"
+source = "spinredis.wasm"
+[component.trigger]
+channel = "messages"
+```
+
+## Next Steps
+
+- Learn about [Spin application structure](spin-application-structure)
+- Learn about how to [build your Spin application code](build)
+- Try [running your application locally](running-apps)
+- Discover how Spin application authors [design and organise applications](see-what-people-have-built-with-spin)
+- Learn about how to [configure your application at runtime](dynamic-configuration)
+- Look up details in the [application manifest reference](manifest-reference)
+- Try deploying a Spin application to the [Fermyon Cloud](/cloud/quickstart)


### PR DESCRIPTION
Preliminary PR to create a `v2` folder and change dates in all markdown files.

Depending on official release, we might have to re-tweak the dates. You can use the following script to do so:

```bash
#!/bin/bash
for file in developer/content/spin/v2/*.md; do
    if [ -f "$file" ]; then
        sed -i '/^date/s/.*/date = "2023-11-02T16:00:00Z"/' $file
    fi
done
```
