### PR TITLE
HTTP handling in Spin 2

### DIFF
--- a/content/spin/v2/triggers.md
+++ b/content/spin/v2/triggers.md
@@ -1,0 +1,79 @@
+title = "Triggers"
+template = "spin_main"
+date = "2023-11-02T16:00:00Z"
+enable_shortcodes = true
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/triggers.md"
+
+---
+- [Triggers and Components](#triggers-and-components)
+  - [Mapping a Trigger to a Named Component](#mapping-a-trigger-to-a-named-component)
+  - [Writing the Component Inside the Trigger](#writing-the-component-inside-the-trigger)
+  - [Choosing Between the Approaches](#choosing-between-the-approaches)
+
+A Spin _trigger_ maps an event, such as an HTTP request or a Redis pub-sub message, to a component that handles that event.
+
+An application can contain multiple triggers, but they must all be the same type. For example, an application can contain triggers for multiple HTTP routes, or for multiple Redis pub-sub channels, but can't contain both an HTTP _and_ a Redis trigger.
+
+> If you're familiar with Spin 1.x, note that Spin 2 uses the term "trigger" to refer to each individual route or channel, rather than the trigger type. It's closer to the `[component.trigger]` usage than to the application trigger.
+
+## Triggers and Components
+
+How events are specified depends on the type of trigger involved. For example, an [HTTP trigger](./http-trigger.md) is specified by the route it handles; a [Redis trigger](./redis-trigger.md) is specified by the channel it monitors. A trigger always, however, has a `component` field, specifying the component that handles matching events.  The `component` can be specified in two ways.
+
+### Mapping a Trigger to a Named Component
+
+An application manifest can define _named_ components in the `component` section. Each component is a WebAssembly component file (or reference) plus the supporting resources it needs, and metadata such as build information. The component name is written as part of the TOML `component` declaration. For example:
+
+```toml
+[component.checkout]  # The component's name is "checkout"
+source = "target/wasm32-wasi/release/checkout.wasm"
+allowed_http_hosts = ["payment-processing.example.com"]
+key_value_stores = ["default"]
+[component.checkout.build]
+command = "cargo build --target wasm32-wasi --release"
+```
+
+To map a trigger to a named component, specify its name in the trigger's `component` field:
+
+```toml
+[[trigger.http]]
+route = "/cart/checkout"
+component = "checkout"
+```
+
+### Writing the Component Inside the Trigger
+
+Instead of writing the component in a separate section and referencing it by name, you can write it the same fields _inline_ in the trigger `component` field.  For example:
+
+```toml
+# Using inline table syntax
+[[trigger.http]]
+route = "/cart/..."
+component = { source = "dist/cart.wasm" }
+
+# Nested table syntax
+[[trigger.http]]
+route = "/cart/..."
+[trigger.http.component]
+source = "target/wasm32-wasi/release/checkout.wasm"
+allowed_http_hosts = ["payment-processing.example.com"]
+```
+
+These behave in the same way: the inline table syntax is more compact for short declarations, but the nested table syntax is easier to read when there are many fields or the values are long.
+
+### Choosing Between the Approaches
+
+These ways of writing components achieve the same thing, so which should you choose?
+
+Named components have the following advantages:
+
+* Reuse. If you want two triggers to behave in the same way, they can refer to the same named component. Remember this means they are not just handled by the same Wasm file, but with the same settings.
+* Named. If an error occurs, Spin can tell your the name of the component where the error happened. With inline components, Spin has to synthesize a name. This isn't a big deal in single-component apps, but make diagnostics harder in larger apps.
+
+Inline components have the following advantages:
+
+* Compact, especially when using inline table syntax.
+* One place to look. Both the trigger event and the handling details are always in the same piece of TOML.
+
+If you are not sure, or are not experienced, we recommend using named components at first, and adopting inline components as and when you find cases where you prefer them.

--- a/templates/spin_sidebar.hbs
+++ b/templates/spin_sidebar.hbs
@@ -70,6 +70,10 @@
                     Triggers
                 </label>
                 <ul class="menu-list accordion-menu-item-content">
+                    <!-- TODO: re-enable this when we split the v1 and v2 TOCs
+                    <li><a {{#if (active_content request.spin-path-info "/spin/triggers" )}} class="active" {{/if}}
+                            href="{{site.info.base_url}}/spin/triggers">Triggers</a></li>
+                    -->
                     <li><a {{#if (active_content request.spin-path-info "/spin/http-trigger" )}} class="active" {{/if}}
                             href="{{site.info.base_url}}/spin/http-trigger">The HTTP Trigger</a></li>
                     <li><a {{#if (active_content request.spin-path-info "/spin/redis-trigger" )}} class="active" {{/if}}


### PR DESCRIPTION
This limits itself to inbound HTTP.  I need to do a bit more research to write about outbound HTTP but wanted to get something out there.  There are also other v1 manifests on the Rust language page which I did not get to in this PR; I will pick those up when I write about outbound HTTP, or as part of a general manifestation pass.

~Also this need to move to the v2 folder - I jumped the gun...~  This is v2-ified.  There is a new page, v2/triggers.md, which will need to be added to the v2 TOC once we figure that out - for the time being I left the TOC entry commented out.

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
