### PR TITLE
Fix references to internal tool

### DIFF
--- a/content/spin/serverless-ai-hello-world.md
+++ b/content/spin/serverless-ai-hello-world.md
@@ -31,8 +31,8 @@ In this tutorial we will:
 
 ### Spin
 
-You will need to [install the latest version of Spin](notion://www.notion.so/fermyon/install#installing-spin). Serverless AI is supported on Spin v1.5 and above
-If you already have Spin installed, [check what version you are on and upgrade](notion://www.notion.so/fermyon/upgrade#are-you-on-the-latest-version) if required.
+You will need to [install the latest version of Spin](./install.md). Serverless AI is supported on Spin v1.5 and above.
+If you already have Spin installed, [check what version you are on and upgrade](./upgrade.md) if required.
 
 ### Dependencies
  


### PR DESCRIPTION
A couple of links to a private tool that we use internally for planning and drafting sneaked through into the public release of a post.  This replaces them with the correct docs links.

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
