### PR TITLE
Update Rust HTTP to latest SDK

### DIFF
--- a/content/spin/v2/rust-components.md
+++ b/content/spin/v2/rust-components.md
@@ -81,7 +81,7 @@ for writing Spin components with the Spin Rust SDK.
 > Make sure to read [the page describing the HTTP trigger](./http-trigger.md) for more
 > details about building HTTP applications.
 
-Building a Spin HTTP component using the Rust SDK means writing a single function decorated with the `#[http_component]` attribute. The function can have one of two forms:
+Building a Spin HTTP component using the Rust SDK means writing a single function decorated with the [`#[http_component]`](https://fermyon.github.io/rust-docs/spin/main/spin_sdk/attr.http_component.html) attribute. The function can have one of two forms:
 
 * takes an HTTP request as a parameter, and returns an HTTP response — shown below
 * taken as parameters _both_ the HTTP request and an object through which to write a response - see [the HTTP trigger page](./http-trigger#authoring-http-components) for an example.
@@ -103,10 +103,10 @@ async fn handle_hello_rust(_req: Request<()>) -> anyhow::Result<impl IntoRespons
 
 The important things to note in the implementation above:
 
-- the `spin_sdk::http_component` macro marks the function as the entry point for the Spin component
+- the [`spin_sdk::http_component`](https://fermyon.github.io/rust-docs/spin/main/spin_sdk/attr.http_component.html) macro marks the function as the entry point for the Spin component
 - the function signature — `fn hello_world(req: Request) -> Result<impl IntoResponse>` —
   the Spin HTTP component uses the HTTP objects from the popular Rust crate
-  [`http`](https://crates.io/crates/http), and allows a flexible set of response types via the `IntoResponse` trait
+  [`http`](https://crates.io/crates/http), and allows a flexible set of response types via the[ `IntoResponse`](https://fermyon.github.io/rust-docs/spin/main/spin_sdk/http/trait.IntoResponse.html) trait
 
 > If you're familiar with Spin 1.x, you will see some changes when upgrading to the Spin 2 SDK. Mostly these provide more flexibility, but you will likely need to change some details such as module paths. If you don't want to modify your code, you can continue using the 1.x SDK - your components will still run.
 


### PR DESCRIPTION
Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)

✅ content/spin/v2/http-trigger.md 
✅ content/spin/v2/rust-components.md

- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)

![Screenshot 2023-10-30 at 07 34 25](https://github.com/fermyon/developer/assets/9831342/9a7dc753-e413-4d72-8f23-db21a2f8ce24)

![Screenshot 2023-10-30 at 07 36 43](https://github.com/fermyon/developer/assets/9831342/637bcd4f-1407-40b9-93d4-e5dfae18d16e)

- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors

![Screenshot 2023-10-30 at 07 31 30](https://github.com/fermyon/developer/assets/9831342/a9502f8b-b546-4d4c-ab85-2005a29cd7e0)

- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
