### PR TITLE
Redis and stuff

### DIFF
--- a/content/spin/v2/kv-store-api-guide.md
+++ b/content/spin/v2/kv-store-api-guide.md
@@ -61,10 +61,10 @@ fn handle_request(_req: Request) -> Result<Response> {
 **General Notes** 
 
 `set` **Operation**
-- For set, the value argument can be of any type that implements AsRef<[u8]>
+- For set, the value argument can be of any type that implements `AsRef<[u8]>`
 
 `get` **Operation**
-- For get, the return value is of type Vec<u8>. If the key does not exist then Error::NoSuchKey is returned.
+- For get, the return value is of type `Option<Vec<u8>>`. If the key does not exist it returns `None`.
 
 `open` **Operation**
 - The close operation is not surfaced; it is called automatically when the store is dropped.
@@ -98,7 +98,7 @@ export const handleRequest: HandleRequest = async function (request: HttpRequest
 
 `get` **Operation**
 - The result is of the type `ArrayBuffer | null`
-- If the key does not exist, `get` returns `null` (no error is thrown)
+- If the key does not exist, `get` returns `null`
 
 `set` **Operation**
 - The value argument is of the type `ArrayBuffer | string`.

--- a/content/spin/v2/redis-outbound.md
+++ b/content/spin/v2/redis-outbound.md
@@ -7,6 +7,7 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/v2/redis-outb
 
 ---
 - [Using Redis From Applications](#using-redis-from-applications)
+- [Granting Network Permissions to Components](#granting-network-permissions-to-components)
 
 Spin provides an interface for you to read and write the Redis key/value store, and to publish Redis pub-sub messages.
 
@@ -52,6 +53,10 @@ let value = redis::get(&address, &key)?;
 * Bytes parameters are of type `&[u8]` and return values are `Vec<u8>`.
 * Numeric return values are of type `i64`.
 * All functions wrap the return in `anyhow::Result`.
+
+**`get` Operation**
+
+* This returns a `Result<Option<Vec<u8>>>`. If the key is not found, the return value is `Ok(None)`.
 
 **`del` Operation**
 
@@ -146,3 +151,14 @@ You can find a complete TinyGo example for using outbound Redis from an HTTP com
 {{ blockEnd }}
 
 {{ blockEnd }}
+
+## Granting Network Permissions to Components
+
+By default, Spin components are not allowed to make outgoing network requests, including Redis. This follows the general Wasm rule that modules must be explicitly granted capabilities, which is important to sandboxing. To grant a component permission to make network requests to a particular host, use the `allowed_outbound_hosts` field in the component manifest, specifying the host and allowed port:
+
+```toml
+[component.uses-redis]
+allowed_outbound_hosts = ["redis.example.com:6379"]
+```
+
+> Do _not_ include the `redis://` URL prefix.


### PR DESCRIPTION
I'm sorry Tim this was meant to be Redis but it wandered off into KV and I got myself confused.  Hopefully you can make sense of it

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)

✅ content/spin/v2/kv-store-api-guide.md
tpmccallum@192-168-1-4 developer % bart check content/spin/v2/redis-outbound.md 
✅ content/spin/v2/redis-outbound.md
tpmccallum@192-168-1-4 developer % bart check content/spin/v2/rust-components.md 
✅ content/spin/v2/rust-components.md

- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors

![Screenshot 2023-10-27 at 11 33 11](https://github.com/fermyon/developer/assets/9831342/659a5a1e-337a-48bb-86b1-d52b76c3e217)

- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
