### PR TITLE
Rest of Applications section to v2

### DIFF
--- a/content/spin/v2/build.md
+++ b/content/spin/v2/build.md
@@ -28,19 +28,16 @@ To make the build process easier, the `spin build` command allows you to build a
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## Setting Up for `spin build`
 
-To use `spin build`, each component that you want to build must specify the command used to build it in `spin.toml`, as part of its `component.build` table:
+To use `spin build`, each component that you want to build must specify the command used to build it in `spin.toml`, as part of its `component.(name).build` table:
 
 ```toml
-[[component]]
-id = "hello"
-[component.trigger]
-route = "/..."
+[component.hello]
 # This is the section you need for `spin build`
-[component.build]
+[component.hello.build]
 command = "npm run build"
 ```
 
-If you generated the component from a Fermyon-supplied template, the `component.build` section should be set up correctly for you.  You don't need to change or add anything.
+If you generated the component from a Fermyon-supplied template, the `build` section should be set up correctly for you.  You don't need to change or add anything.
 
 > Different components may be built from different languages, and so each component can have its own build command.  In addition, some components may be precompiled into Wasm modules, and don't need a build command at all.  If a component doesn't have a build command, `spin build` just skips it.
 
@@ -61,7 +58,7 @@ The build command typically runs `cargo build` with the `wasm32-wasi` target and
 <!-- @nocpy -->
 
 ```toml
-[component.build]
+[component.hello.build]
 command = "cargo build --target wasm32-wasi --release"
 ```
 
@@ -95,7 +92,7 @@ The build command can then call the NPM script:
 <!-- @nocpy -->
 
 ```toml
-[component.build]
+[component.hello.build]
 command = "npm run build"
 ```
 
@@ -117,7 +114,7 @@ The build command then calls `spin py2wasm` on your application file:
 <!-- @nocpy -->
 
 ```toml
-[component.build]
+[component.hello.build]
 command = "spin py2wasm app -o app.wasm"
 ```
 
@@ -132,7 +129,7 @@ The build command calls TinyGo with the WASI backend and appropriate options:
 <!-- @nocpy -->
 
 ```toml
-[component.build]
+[component.hello.build]
 command = "tinygo build -target=wasi -gc=leaking -no-debug -o main.wasm main.go"
 ```
 
@@ -192,7 +189,7 @@ To have the Rust build `command` run in directory `deep`, we can set the compone
 <!-- @nocpy -->
 
 ```toml
-[component.build]
+[component.deep.build]
 # `command` is the normal build command for this language
 command = "cargo build --target wasm32-wasi --release"
 # This tells Spin to run it in the directory of the build file (in this case Cargo.toml)

--- a/content/spin/v2/running-apps.md
+++ b/content/spin/v2/running-apps.md
@@ -12,6 +12,7 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/v2/running-ap
 - [Persistent Logs](#persistent-logs)
 - [Trigger-Specific Options](#trigger-specific-options)
 - [Monitoring Applications for Changes](#monitoring-applications-for-changes)
+- [The Always Build Option](#the-always-build-option)
 - [Next Steps](#next-steps)
 
 Once you have created and built your application, it's ready to run.  To run an application, use the `spin up` command.
@@ -65,7 +66,7 @@ By default:
 * If you run an application from the file system (a TOML file), Spin saves a copy of the application output and error messages.  This is saved in the `.spin/logs` directory, under the directory containing the manifest file.
 * If you run an application from a registry reference, Spin does not save a copy of the application output and error messages; they are only printed to the console.
 
-To control logging, pass the `--log-dir` flag.  The logs will be saved to the specified directory (no matter whether the application is local or remote).
+To control logging, pass the `--log-dir` flag.  The logs will be saved to the specified directory (no matter whether the application is local or remote):
 
 <!-- @selectiveCpy -->
 
@@ -100,11 +101,11 @@ The following `spin.toml` configuration (belonging to a Spin `http-rust` applica
 <!-- @nocpy -->
 
  ```toml
-[[component]]
+[component.test]
 // -- snip
 files = ["my-files/changing-file.txt"]
 source = "target/wasm32-wasi/release/test.wasm"
-[component.build]
+[component.test.build]
 command = "cargo build --target wasm32-wasi --release"
 # Example watch configuration for a Rust application
 watch = ["src/**/*.rs", "Cargo.toml"]
@@ -118,18 +119,24 @@ The table below outlines exactly which files `spin watch` will monitor for chang
 
 | Files                   | `spin watch` monitors for changes              | `spin watch --skip-build` monitors for changes |
 | ----------------------- | ---------------------------------------------- | ---------------------------------------------- |
-| Application manifest `spin.toml`   | Yes                                            | Yes                                            |
-| `component.build.watch` | Yes                                            | No                                             |
-| `component.files`       | Yes                                            | Yes                                            |
-| `component.source`      | No (Yes if the component has no build command) | Yes  
+| Application manifest `spin.toml`   | Yes                                 | Yes                                            |
+| Component `build.watch` | Yes                                            | No                                             |
+| Component `files`       | Yes                                            | Yes                                            |
+| Component `source`      | No (Yes if the component has no build command) | Yes  
 
 Spin watch waits up to 100 milliseconds before responding to filesystem events, then processes all events that occurred in that interval together. This is so that if you make several changes close together (for example, using a Save All command), you get them all processed in one rebuild/reload cycle, rather than going through a cycle for each one. You can override the interval by passing in the `--debounce` option; e.g. `spin watch --debounce 1000` will make Spin watch respond to filesystem events at most once per second.
 
-> Note: If the build step (`spin build`) fails, `spin up` will not be run.
+> Note: If the build step (`spin build`) fails, `spin up` will not be re-run, and the previous version of the app will remain.
 
 Passing the `--clear` flag clears the screen anytime a rebuild or rerun occurs. Spin watch does not clear the screen between rebuild and rerun as this provides you with an opportunity to see any warnings.
 
 For additional information about Spin's `watch` feature, please see the [Spin watch - live reload for Wasm app development](https://www.fermyon.com/blog/spin-watch-live-reloading) blog article.
+
+> The application manifests shown in the blog post are the version 1 manifest, but the content applies equally to the version 2 format. 
+
+## The Always Build Option
+
+Some people find it frustrating having to remember to build their applications before running `spin up`. If you want to _always_ build your projects when you run them, set the `SPIN_ALWAYS_BUILD` environment variable in your profile or session. If this is set, `spin up` runs [`spin build`](build) before starting your applications.
 
 ## Next Steps
 


### PR DESCRIPTION
Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)

✅ content/spin/v2/build.md
✅ content/spin/v2/running-apps.md
✅ content/spin/v2/spin-application-structure.md

- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors

<img width="294" alt="Screenshot 2023-10-31 at 09 24 42" src="https://github.com/fermyon/developer/assets/9831342/eebea827-3456-4ecc-a579-b739e461080a">

- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
