### PR TITLE
Fix GitHub link in v1 files

### DIFF
--- a/content/spin/v1/ai-sentiment-analysis-api-tutorial.md
+++ b/content/spin/v1/ai-sentiment-analysis-api-tutorial.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2023-09-05T09:00:00Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/ai-sentiment-analysis-api-tutorial.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/ai-sentiment-analysis-api-tutorial.md"
 
 ---
 - [Tutorial Prerequisites](#tutorial-prerequisites)

--- a/content/spin/v1/api-guides-overview.md
+++ b/content/spin/v1/api-guides-overview.md
@@ -2,7 +2,7 @@ title = "API Support Overview"
 template = "spin_main"
 date = "2023-03-03T03:03:03Z"
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/api-guides-overview.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/api-guides-overview.md"
 
 ---
 

--- a/content/spin/v1/build.md
+++ b/content/spin/v1/build.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/build.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/build.md"
 
 ---
 

--- a/content/spin/v1/cache.md
+++ b/content/spin/v1/cache.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/cache.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/cache.md"
 
 ---
 

--- a/content/spin/v1/cli-reference.md
+++ b/content/spin/v1/cli-reference.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-01-01T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/cli-reference.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/cli-reference.md"
 
 ---
 - [spin add](#spin-add)

--- a/content/spin/v1/contributing-docs.md
+++ b/content/spin/v1/contributing-docs.md
@@ -2,7 +2,7 @@ title = "Contributing to Docs"
 template = "spin_main"
 date = "2022-01-01T00:00:01Z"
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/contributing-docs.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/contributing-docs.md"
 keywords = "contribute contributing"
 
 ---
@@ -359,7 +359,7 @@ If you create a new markdown file and/or you notice a file without the explicit 
 
 ```
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/contributing-docs.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/contributing-docs.md"
 ```
 
 ### 6.5 How To Properly Edit CSS Styles

--- a/content/spin/v1/contributing-spin.md
+++ b/content/spin/v1/contributing-spin.md
@@ -2,7 +2,7 @@ title = "Contributing to Spin"
 template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/contributing-spin.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/contributing-spin.md"
 
 ---
 - [Making Code Contributions to Spin](#making-code-contributions-to-spin)

--- a/content/spin/v1/deploying-to-fermyon.md
+++ b/content/spin/v1/deploying-to-fermyon.md
@@ -2,7 +2,7 @@ title = "Deploying Spin Applications to Fermyon"
 template = "spin_main"
 date = "2022-05-20T00:22:56Z"
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/deploying-to-fermyon.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/deploying-to-fermyon.md"
 
 ---
 - [Deploying Microservices \& Web Apps](#deploying-microservices--web-apps)

--- a/content/spin/v1/distributing-apps.md
+++ b/content/spin/v1/distributing-apps.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/distributing-apps.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/distributing-apps.md"
 
 ---
 - [Logging Into a Registry](#logging-into-a-registry)

--- a/content/spin/v1/dynamic-configuration.md
+++ b/content/spin/v1/dynamic-configuration.md
@@ -2,7 +2,7 @@ title = "Dynamic and Runtime Application Configuration"
 template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/dynamic-configuration.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/dynamic-configuration.md"
 
 ---
 - [Custom Config Variables](#custom-config-variables)

--- a/content/spin/v1/extending-and-embedding.md
+++ b/content/spin/v1/extending-and-embedding.md
@@ -2,7 +2,7 @@ title = "Extending and Embedding Spin"
 template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/extending-and-embedding.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/extending-and-embedding.md"
 
 ---
 - [Other Ways to Extend and Use Spin](#other-ways-to-extend-and-use-spin)

--- a/content/spin/v1/go-components.md
+++ b/content/spin/v1/go-components.md
@@ -2,7 +2,7 @@ title = "Building Spin components in Go"
 template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/go-components.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/go-components.md"
 
 ---
 

--- a/content/spin/v1/http-outbound.md
+++ b/content/spin/v1/http-outbound.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/http-outbound.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/http-outbound.md"
 
 ---
 - [Using HTTP From Applications](#using-http-from-applications)

--- a/content/spin/v1/http-trigger.md
+++ b/content/spin/v1/http-trigger.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/http-trigger.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/http-trigger.md"
 
 ---
 - [Specifying an Application as HTTP](#specifying-an-application-as-http)

--- a/content/spin/v1/index.md
+++ b/content/spin/v1/index.md
@@ -2,7 +2,7 @@ title = "Introducing Spin"
 template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/index.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/index.md"
 
 ---
 

--- a/content/spin/v1/install.md
+++ b/content/spin/v1/install.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/install.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/install.md"
 keywords = "install"
 
 ---

--- a/content/spin/v1/javascript-components.md
+++ b/content/spin/v1/javascript-components.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/javascript-components.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/javascript-components.md"
 
 ---
 - [Installing Templates](#installing-templates)

--- a/content/spin/v1/key-value-store-tutorial.md
+++ b/content/spin/v1/key-value-store-tutorial.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2023-02-21T00:00:00Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/key-value-store-tutorial.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/key-value-store-tutorial.md"
 
 ---
 - [Key Value Store With Spin Applications](#key-value-store-with-spin-applications)

--- a/content/spin/v1/kubernetes.md
+++ b/content/spin/v1/kubernetes.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2023-03-01T00:01:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/kubernetes.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/kubernetes.md"
 
 ---
 - [Why Use Spin With Kubernetes?](#why-use-spin-with-kubernetes)

--- a/content/spin/v1/kv-store-api-guide.md
+++ b/content/spin/v1/kv-store-api-guide.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2023-04-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/kv-store-api-guide.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/kv-store-api-guide.md"
 
 ---
 - [Using Key Value Store From Applications](#using-key-value-store-from-applications)

--- a/content/spin/v1/language-support-overview.md
+++ b/content/spin/v1/language-support-overview.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-01-01T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/language-support-overview.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/language-support-overview.md"
 
 ---
 

--- a/content/spin/v1/managing-plugins.md
+++ b/content/spin/v1/managing-plugins.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/managing-plugins.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/managing-plugins.md"
 
 ---
 - [Installing Plugins](#installing-plugins)

--- a/content/spin/v1/managing-templates.md
+++ b/content/spin/v1/managing-templates.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/managing-templates.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/managing-templates.md"
 
 ---
 - [Installing Templates](#installing-templates)

--- a/content/spin/v1/manifest-reference.md
+++ b/content/spin/v1/manifest-reference.md
@@ -2,7 +2,7 @@ title = "Spin Application Manifest Reference"
 template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/manifest-reference.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/manifest-reference.md"
 
 ---
 - [Format](#format)

--- a/content/spin/v1/other-languages.md
+++ b/content/spin/v1/other-languages.md
@@ -2,7 +2,7 @@ title = "Building Spin components in other languages"
 template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/other-languages.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/other-languages.md"
 
 ---
 - [AssemblyScript](#assemblyscript)

--- a/content/spin/v1/plugin-authoring.md
+++ b/content/spin/v1/plugin-authoring.md
@@ -2,7 +2,7 @@ title = "Creating Spin Plugins"
 template = "spin_main"
 date = "2023-02-1T00:22:56Z"
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/plugin-authoring.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/plugin-authoring.md"
 
 ---
 - [What Are Spin Plugins?](#what-are-spin-plugins)

--- a/content/spin/v1/python-components.md
+++ b/content/spin/v1/python-components.md
@@ -2,7 +2,7 @@ title = "Building Spin Components in Python"
 template = "spin_main"
 date = "2023-02-28T02:00:00Z"
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/python-components.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/python-components.md"
 
 ---
 - [Spin's Python Plugin](#spins-python-plugin)

--- a/content/spin/v1/quickstart.md
+++ b/content/spin/v1/quickstart.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/quickstart.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/quickstart.md"
 keywords = "quickstart"
 
 ---

--- a/content/spin/v1/rdbms-storage.md
+++ b/content/spin/v1/rdbms-storage.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/rdbms-storage.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/rdbms-storage.md"
 
 ---
 - [Using MySQL and PostgreSQL From Applications](#using-mysql-and-postgresql-from-applications)

--- a/content/spin/v1/redis-outbound.md
+++ b/content/spin/v1/redis-outbound.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/redis-outbound.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/redis-outbound.md"
 
 ---
 - [Using Redis From Applications](#using-redis-from-applications)

--- a/content/spin/v1/redis-trigger.md
+++ b/content/spin/v1/redis-trigger.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/redis-trigger.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/redis-trigger.md"
 
 ---
 - [Specifying an Application as Redis](#specifying-an-application-as-redis)

--- a/content/spin/v1/registry-tutorial.md
+++ b/content/spin/v1/registry-tutorial.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2023-02-13T00:00:00Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/registry-tutorial.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/registry-tutorial.md"
 
 ---
 - [Spin Registry Support](#spin-registry-support)

--- a/content/spin/v1/running-apps.md
+++ b/content/spin/v1/running-apps.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/running-apps.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/running-apps.md"
 
 ---
 - [Specifying the Application to Run](#specifying-the-application-to-run)

--- a/content/spin/v1/rust-components.md
+++ b/content/spin/v1/rust-components.md
@@ -2,7 +2,7 @@ title = "Building Spin components in Rust"
 template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/rust-components.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/rust-components.md"
 
 ---
 - [Prerequisites](#prerequisites)

--- a/content/spin/v1/see-what-people-have-built-with-spin.md
+++ b/content/spin/v1/see-what-people-have-built-with-spin.md
@@ -2,7 +2,7 @@ title = "Built With Spin"
 template = "spin_main"
 date = "2023-05-05T00:01:01Z"
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/see-what-people-have-built-with-spin.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/see-what-people-have-built-with-spin.md"
 
 ---
 - [Like Button](#like-button)

--- a/content/spin/v1/serverless-ai-api-guide.md
+++ b/content/spin/v1/serverless-ai-api-guide.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2023-09-05T09:00:00Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/serverless-ai-api-guide.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/serverless-ai-api-guide.md"
 
 ---
 - [Using Serverless AI From Applications](#using-serverless-ai-from-applications)

--- a/content/spin/v1/serverless-ai-hello-world.md
+++ b/content/spin/v1/serverless-ai-hello-world.md
@@ -5,7 +5,7 @@ template = "spin_main"
 tags = ["ai", "serverless", "getting started"]
 enable_shortcodes = true
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/serverless-ai-hello-world.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/serverless-ai-hello-world.md"
 
 ---
 

--- a/content/spin/v1/spin-application-structure.md
+++ b/content/spin/v1/spin-application-structure.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2023-08-20T00:00:00Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/spin-application-structure.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/spin-application-structure.md"
 keywords = "structure"
 
 ---

--- a/content/spin/v1/sqlite-api-guide.md
+++ b/content/spin/v1/sqlite-api-guide.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2023-04-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/sqlite-api-guide.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/sqlite-api-guide.md"
 
 ---
 - [Granting SQLite Database Permissions to Components](#granting-sqlite-database-permissions-to-components)

--- a/content/spin/v1/template-authoring.md
+++ b/content/spin/v1/template-authoring.md
@@ -2,7 +2,7 @@ title = "Creating Spin templates"
 template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/template-authoring.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/template-authoring.md"
 
 ---
 - [Authoring the Content](#authoring-the-content)

--- a/content/spin/v1/troubleshooting-application-dev.md
+++ b/content/spin/v1/troubleshooting-application-dev.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2023-02-13T00:00:00Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/troubleshooting-application-dev.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/troubleshooting-application-dev.md"
 
 ---
 

--- a/content/spin/v1/upgrade.md
+++ b/content/spin/v1/upgrade.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2023-05-01T00:01:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/upgrade.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/upgrade.md"
 
 ---
 - [Are You on the Latest Version?](#are-you-on-the-latest-version)

--- a/content/spin/v1/url-shortener-tutorial.md
+++ b/content/spin/v1/url-shortener-tutorial.md
@@ -2,7 +2,7 @@ title = "Building a URL Shortener With Spin"
 template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/url-shortener-tutorial.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/url-shortener-tutorial.md"
 
 ---
 - [A Simple URL Shortener Built With Spin](#a-simple-url-shortener-built-with-spin)

--- a/content/spin/v1/variables.md
+++ b/content/spin/v1/variables.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-06-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/variables.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/variables.md"
 
 ---
 - [Adding Variables to Your Applications](#adding-variables-to-your-applications)

--- a/content/spin/v1/writing-apps.md
+++ b/content/spin/v1/writing-apps.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/fermyon/developer/blob/main/content/spin/writing-apps.md"
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/writing-apps.md"
 
 ---
 - [Writing an Application Manifest](#writing-an-application-manifest)


### PR DESCRIPTION
Fix the URLs in the `[extra]` frontmatter so that when a user clicks on “Edit this page” it sends the user to the correct GitHub page (where they can edit and contribute).