### PR TITLE
Update API guides to v2

### DIFF
--- a/content/spin/v2/api-guides-overview.md
+++ b/content/spin/v2/api-guides-overview.md
@@ -8,17 +8,17 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/v2/api-guides
 
 The following table shows the status of the interfaces Spin provides to applications.
 
-| Host Capabilities/Interfaces           | Stability  |    Cloud    |
-|----------------------------------------|----------|-------|
-| [HTTP Trigger](./http-trigger)                          | Stable   | Yes   |
-| [Redis Trigger](./redis-trigger)                         | Stable   | No  |
-| [Outbound HTTP](./http-outbound)                          | Stable   | Yes   |
-| [Outbound Redis](./redis-outbound)                         | Stable  | Yes   |
-| [Configuration Variables](./variables)                      | Stable | Yes |
-| [PostgreSQL](./rdbms-storage)                             | Experimental | Yes |
-| [MySQL](./rdbms-storage)                                  | Experimental | Yes |
-| [Key-value Storage](./kv-store-api-guide)                      | Stabilizing | Yes |
-| [Serverless AI](./serverless-ai-api-guide)                      | Experimental | [Private Beta](/cloud/serverless-ai.md) |
-| [SQLite Storage](./sqlite-api-guide)                      | Experimental | Yes |
+| Host Capabilities/Interfaces                 | Stability    | Cloud   |
+|----------------------------------------------|--------------|---------|
+| [HTTP Trigger](./http-trigger)               | Stable       | Yes |
+| [Redis Trigger](./redis-trigger)             | Stable       | No  |
+| [Outbound HTTP](./http-outbound)             | Stable       | Yes |
+| [Outbound Redis](./redis-outbound)           | Stable       | Yes |
+| [Configuration Variables](./variables)       | Stable       | Yes |
+| [PostgreSQL](./rdbms-storage)                | Experimental | Yes |
+| [MySQL](./rdbms-storage)                     | Experimental | Yes |
+| [Key-value Storage](./kv-store-api-guide)    | Stabilizing  | Yes |
+| [Serverless AI](./serverless-ai-api-guide)   | Experimental | [Private Beta](/cloud/serverless-ai.md) |
+| [SQLite Storage](./sqlite-api-guide)         | Experimental | Yes |
 
 For more information about what is possible in the programming language of your choice, please see our [Language Support Overview](./language-support-overview).

--- a/content/spin/v2/http-outbound.md
+++ b/content/spin/v2/http-outbound.md
@@ -26,7 +26,7 @@ The outbound HTTP interface depends on your language.
 
 To send requests, use the [`spin_sdk::http::send`](https://fermyon.github.io/rust-docs/spin/main/spin_sdk/http/fn.send.html) function. This takes a request argument and returns a response (or error). It is `async`, so within an async inbound handler you can have multiple outbound `send`s running concurrently.
 
-> The Rust SDK includes **experimental** support for streaming request and response bodies. We currently recommend that you stick with the simpler non-streaming interfaces if you don't require streaming.
+> Support for streaming request and response bodies is **experimental**. We currently recommend that you stick with the simpler non-streaming interfaces if you don't require streaming.
 
 `send` is quite flexible in its request and response types. The request may be:
 
@@ -119,7 +119,7 @@ You can find a complete example for using outbound HTTP in the [Python SDK repos
 
 {{ startTab "TinyGo"}}
 
-HTTP functions are available in the `github.com/fermyon/spin/sdk/go/v2/http` package. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2/http). The general function is named `Send`, but the Go SDK also surfaces individual functions, with request-specific parameters, for the `Get` and `Post` operations. For example:
+HTTP functions are available in the `github.com/fermyon/spin/sdk/go/v2/http` package. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2/http) The general function is named `Send`, but the Go SDK also surfaces individual functions, with request-specific parameters, for the `Get` and `Post` operations. For example:
 
 ```go
 import (

--- a/content/spin/v2/kv-store-api-guide.md
+++ b/content/spin/v2/kv-store-api-guide.md
@@ -45,16 +45,17 @@ Key value functions are available in the `spin_sdk::key_value` module. The funct
 ```rust
 use anyhow::Result;
 use spin_sdk::{
-    http::{Request, Response},
+    http::{IntoResponse, Request},
     http_component,
     key_value::{Store},
 };
 #[http_component]
-fn handle_request(_req: Request) -> Result<Response> {
+fn handle_request(_req: Request) -> Result<impl IntoResponse> {
     let store = Store::open_default()?;
     store.set("mykey", "myvalue")?;
     let value = store.get("mykey")?;
-    Ok(http::Response::builder().status(200).body(Some(value.into()))?)
+    let response = value.unwrap_or_else(|| "not found".into());
+    Ok(http::Response::builder().status(200).body(response)?)
 }
 ```
 
@@ -136,7 +137,7 @@ def handle_request(request):
 
 {{ startTab "TinyGo"}}
 
-Key value functions are provided by the `github.com/fermyon/spin/sdk/go/v2/kv` module. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2/kv). For example:
+Key value functions are provided by the `github.com/fermyon/spin/sdk/go/v2/kv` module. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2/kv) For example:
 
 ```go
 import "github.com/fermyon/spin/sdk/go/v2/kv"

--- a/content/spin/v2/rdbms-storage.md
+++ b/content/spin/v2/rdbms-storage.md
@@ -7,6 +7,7 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/v2/rdbms-stor
 
 ---
 - [Using MySQL and PostgreSQL From Applications](#using-mysql-and-postgresql-from-applications)
+- [Granting Network Permissions to Components](#granting-network-permissions-to-components)
 
 Spin provides two interfaces for relational (SQL) databases:
 
@@ -21,10 +22,11 @@ This page covers the "bring your own database" scenario.  See [SQLite Storage](.
 
 The Spin SDK surfaces the Spin MySQL and PostgreSQL interfaces to your language. The set of operations is the same across both databases:
 
-| Operation  | Parameters                          | Returns             | Behavior |
-|------------|-------------------------------------|---------------------|----------|
-| `query`    | address, statement, SQL parameters  | database records    | Runs the specified statement against the database, returning the query results as a set of rows. |
-| `execute`  | address, statement, SQL parameters  | integer (not MySQL) | Runs the specified statement against the database, returning the number of rows modified by the statement.  (MySQL does not return the modified row count.) |
+| Operation  | Parameters                 | Returns             | Behavior |
+|------------|----------------------------|---------------------|----------|
+| `open`     | address                    | connection resource | Opens a connection to the specified database. The host must be listed in `allowed_outbound_hosts`. Other operations must be called through a connection. |
+| `query`    | statement, SQL parameters  | database records    | Runs the specified statement against the database, returning the query results as a set of rows. |
+| `execute`  | statement, SQL parameters  | integer (not MySQL) | Runs the specified statement against the database, returning the number of rows modified by the statement.  (MySQL does not return the modified row count.) |
 
 The exact detail of calling these operations from your application depends on your language:
 
@@ -35,10 +37,12 @@ The exact detail of calling these operations from your application depends on yo
 MySQL functions are available in the `spin_sdk::mysql` module, and PostgreSQL functions in the `spin_sdk::pg` module. The function names match the operations above. This example shows MySQL:
 
 ```rust
-use spin_sdk::mysql::{self, Decode, ParameterValue};
+use spin_sdk::mysql::{self, Connection, Decode, ParameterValue};
+
+let connection = Connection::open(&address)?;
 
 let params = vec![ParameterValue::Int32(id)];
-let rowset = mysql::query(&address, "SELECT id, name FROM pets WHERE id = ?", &params)?;
+let rowset = connection.query("SELECT id, name FROM pets WHERE id = ?", &params)?;
 
 match rowset.rows.first() {
     None => /* no rows matched query */,
@@ -58,6 +62,8 @@ match rowset.rows.first() {
 
 You can find complete examples for using relational databases in the Spin repository on GitHub ([MySQL](https://github.com/fermyon/spin/tree/main/examples/rust-outbound-mysql), [PostgreSQL](https://github.com/fermyon/spin/tree/main/examples/rust-outbound-pg)).
 
+For full information about the MySQL and PostgreSQL APIs, see [the Spin SDK reference documentation](https://fermyon.github.io/rust-docs/spin/main/spin_sdk/index.html).
+
 {{ blockEnd }}
 
 {{ startTab "TypeScript"}}
@@ -74,8 +80,76 @@ The Python SDK doesn't currently surface the MySQL or PostgreSQL APIs.
 
 {{ startTab "TinyGo"}}
 
-The Go SDK doesn't currently surface the MySQL or PostgreSQL APIs.
+MySQL functions are available in the `github.com/fermyon/spin/sdk/go/v2/mysql` package, and PostgreSQL in `github.com/fermyon/spin/sdk/go/v2/pg`. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2)
+
+The package follows the usual Go database API. Use `Open` to return a connection to the database of type `*sql.DB` - see the [Go standard library documentation](https://pkg.go.dev/database/sql#DB) for usage information.  For example:
+
+```go
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+
+	spinhttp "github.com/fermyon/spin/sdk/go/v2/http"
+	"github.com/fermyon/spin/sdk/go/v2/pg"
+)
+
+type Pet struct {
+	ID        int64
+	Name      string
+	Prey      *string // nullable field must be a pointer
+	IsFinicky bool
+}
+
+func init() {
+	spinhttp.Handle(func(w http.ResponseWriter, r *http.Request) {
+
+		// addr is the environment variable set in `spin.toml` that points to the
+		// address of the Mysql server.
+		addr := os.Getenv("DB_URL")
+
+		db := pg.Open(addr)
+		defer db.Close()
+
+		_, err := db.Query("INSERT INTO pets VALUES ($1, 'Maya', $2, $3);", int32(4), "bananas", true)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		rows, err := db.Query("SELECT * FROM pets")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		var pets []*Pet
+		for rows.Next() {
+			var pet Pet
+			if err := rows.Scan(&pet.ID, &pet.Name, &pet.Prey, &pet.IsFinicky); err != nil {
+				fmt.Println(err)
+			}
+			pets = append(pets, &pet)
+		}
+		json.NewEncoder(w).Encode(pets)
+	})
+}
+
+func main() {}
+```
 
 {{ blockEnd }}
 
 {{ blockEnd }}
+
+## Granting Network Permissions to Components
+
+By default, Spin components are not allowed to make outgoing network requests, including MySQL or PostgreSQL. This follows the general Wasm rule that modules must be explicitly granted capabilities, which is important to sandboxing. To grant a component permission to make network requests to a particular host, use the `allowed_outbound_hosts` field in the component manifest, specifying the host and allowed port:
+
+```toml
+[component.uses-db]
+allowed_outbound_hosts = ["postgres.example.com:5432"]
+```

--- a/content/spin/v2/serverless-ai-api-guide.md
+++ b/content/spin/v2/serverless-ai-api-guide.md
@@ -17,14 +17,14 @@ The nature of AI and LLM workloads on already trained models lends itself very n
 
 ### Configuration
 
-By default, a given component of a Spin application will not have access to any Serverless AI models. Access must be provided explicitly via the Spin application's manifest (the `spin.toml` file).  For example, an individual component in a Spin application could be given access to the llama2-chat model by adding the following `ai_models` configuration inside the specific `[[component]]` section:
+By default, a given component of a Spin application will not have access to any Serverless AI models. Access must be provided explicitly via the Spin application's manifest (the `spin.toml` file).  For example, an individual component in a Spin application could be given access to the llama2-chat model by adding the following `ai_models` configuration inside the specific `[component.(name)]` section:
 
 <!-- @nocpy -->
 
 ```toml
 // -- snip --
 
-[[component]]
+[component.please-send-the-codes]
 ai_models = ["codellama-instruct"]
 
 // -- snip --

--- a/content/spin/v2/sqlite-api-guide.md
+++ b/content/spin/v2/sqlite-api-guide.md
@@ -21,7 +21,7 @@ Spin provides an interface for you to persist data in an SQLite Database managed
 By default, a given component of an app will not have access to any SQLite Databases. Access must be granted specifically to each component via the component manifest.  For example, a component could be given access to the default store using:
 
 ```toml
-[component]
+[component.example]
 sqlite_databases = ["default"]
 ```
 
@@ -51,18 +51,18 @@ SQLite functions are available in the `spin_sdk::sqlite` module. The function na
 use anyhow::Result;
 use serde::Serialize;
 use spin_sdk::{
-    http::{Request, Response},
+    http::{Request, IntoResponse},
     http_component,
-    sqlite::{Connection, Error, ValueParam},
+    sqlite::{Connection, Value},
 };
 
 #[http_component]
-fn handle_request(req: Request) -> Result<Response> {
+fn handle_request(req: Request) -> Result<impl IntoResponse> {
     let connection = Connection::open_default()?;
 
     let execute_params = [
-        ValueParam::Text("Try out Spin SQLite"),
-        ValueParam::Text("Friday"),
+        Value::Text("Try out Spin SQLite".to_owned()),
+        Value::Text("Friday".to_owned()),
     ];
     connection.execute(
         "INSERT INTO todos (description, due) VALUES (?, ?)",
@@ -97,9 +97,9 @@ struct ToDo {
 
 **General Notes** 
 * All functions are on the `spin_sdk::sqlite::Connection` type.
-* Parameters are instances of the `ValueParam` enum; you must wrap raw values in this type.
+* Parameters are instances of the `Value` enum; you must wrap raw values in this type.
 * The `execute` function returns a `QueryResult`. To iterate over the rows use the `rows()` function. This returns an iterator; use `collect()` if you want to load it all into a collection.
-* The values in rows are instances of the `ValueResult` enum.  However, you can use `row.get(column_name)` to extract a specific column from a row.  `get` casts the database value to the target Rust type. If the compiler can't infer the target type, write `row.get::<&str>(column_name)` (or whatever the desired type is).
+* The values in rows are instances of the `Value` enum.  However, you can use `row.get(column_name)` to extract a specific column from a row.  `get` casts the database value to the target Rust type. If the compiler can't infer the target type, write `row.get::<&str>(column_name)` (or whatever the desired type is).
 * All functions wrap the return in `Result`, with the error type being `spin_sdk::sqlite::Error`.
 
 {{ blockEnd }}


### PR DESCRIPTION
There were a few modifications to samples, and I am a bit at sea with which languages have updated how.  Reasonably confident with the Rust changes but would really appreciate heightened diligence on this one, I am very concerned I have missed something or messed something up but cannot see what

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)

✅ content/spin/v2/api-guides-overview.md
✅ content/spin/v2/http-outbound.md
✅ content/spin/v2/kv-store-api-guide.md
✅ content/spin/v2/rdbms-storage.md
✅ content/spin/v2/redis-outbound.md
✅ content/spin/v2/serverless-ai-api-guide.md
✅ content/spin/v2/sqlite-api-guide.md
✅ content/spin/v2/variables.md

- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors

<img width="284" alt="Screenshot 2023-10-31 at 12 15 44" src="https://github.com/fermyon/developer/assets/9831342/8b26c975-3d97-4bda-932e-13a635d0e6a2">

- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
