### PR TITLE
Advanced section to v2

### DIFF
--- a/content/spin/v2/deploying-to-fermyon.md
+++ b/content/spin/v2/deploying-to-fermyon.md
@@ -5,22 +5,27 @@ date = "2023-11-02T16:00:00Z"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v2/deploying-to-fermyon.md"
 
 ---
-- [Deploying Microservices \& Web Apps](#deploying-microservices--web-apps)
-- [Running on Your Workstation](#running-on-your-workstation)
-- [Running on AWS](#running-on-aws)
+- [Fermyon Cloud](#fermyon-cloud)
+- [Fermyon Platform](#fermyon-platform)
+  - [Running on Your Workstation](#running-on-your-workstation)
+  - [Running on AWS](#running-on-aws)
 
-## Deploying Microservices & Web Apps
+## Fermyon Cloud
 
-[Fermyon](https://www.fermyon.dev/) is the frictionless WebAssembly platform for deploying
-microservices and web apps. With Fermyon, you can deploy your spin applications onto a server in
-moments.
+[Fermyon Cloud](/cloud) is a self-service application platform for WebAssembly-based serverless functions and microservices. It enables you to run Spin applications, at scale, in the cloud, without any infrastructure setup or maintenance required.
 
-## Running on Your Workstation
+## Fermyon Platform
+
+[Fermyon Platform](https://www.fermyon.dev/) is a self-host platform for Spin applications. With Fermyon, you can deploy your spin applications onto a server in moments.
+
+> Fermyon Platform does not currently support Spin 2.
+
+### Running on Your Workstation
 
 For instructions guiding you through running the Fermyon platform on your development workstation,
 follow [this guide](https://www.fermyon.dev/quickstart-local).
 
-## Running on AWS
+### Running on AWS
 
 For instructions guiding you through running the Fermyon platform on AWS, follow
 [this guide](https://www.fermyon.dev/quickstart-aws).

--- a/content/spin/v2/template-authoring.md
+++ b/content/spin/v2/template-authoring.md
@@ -127,7 +127,7 @@ skip_parameters = ["http-base"]
 component = "component.txt"
 ```
 
-> For examples from the Spin project, see `http-rust` (can be used in both`spin new` and `spin add`) and `static-fileserver` (`spin add` only).
+> For examples from the Spin project, see `http-rust` and `static-fileserver`.
 
 ## Hosting Templates in Git
 


### PR DESCRIPTION
There didn't seem to be too many changes here but my brain has turned to mush so 🤷 

This should be it apart from the tutorials and going back over the triggers and API sections for snazzy new features since the original update.

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
