### PR TITLE
Mention some of the new outbound HTTP helpers

### DIFF
--- a/content/spin/v2/http-outbound.md
+++ b/content/spin/v2/http-outbound.md
@@ -31,7 +31,8 @@ To send requests, use the [`spin_sdk::http::send`](https://fermyon.github.io/rus
 `send` is quite flexible in its request and response types. The request may be:
 
 * [`http::Request`](https://docs.rs/http/latest/http/request/struct.Request.html) - typically constructed via `http::Request::builder()`
-* [`spin_sdk::http::Request`](https://fermyon.github.io/rust-docs/spin/main/spin_sdk/http/struct.Request.html) - typically constructed via `spin_sdk::http::Request::builder()`
+* [`spin_sdk::http::Request`](https://fermyon.github.io/rust-docs/spin/main/spin_sdk/http/struct.Request.html) - typically constructed via `spin_sdk::http::Request::get()`, `spin_sdk::http::Request::post()`, or `spin_sdk::http::Request::builder()`
+  * You can also use the [builder type](https://fermyon.github.io/rust-docs/spin/main/spin_sdk/http/struct.RequestBuilder.html) directly - `build` will be called automatically for you
 * [`spin_sdk::http::OutgoingRequest`](https://fermyon.github.io/rust-docs/spin/main/spin_sdk/http/struct.OutgoingRequest.html) - constructed via `OutgoingRequest::new()`
 * Any type for which you have implemented the `TryInto<spin_sdk::http::OutgoingRequest>` trait
 
@@ -57,10 +58,9 @@ use spin_sdk::http_component;
 // so we can `await` the outbound send.
 async fn handle_request(_req: Request) -> anyhow::Result<impl IntoResponse> {
 
-    // For this example, use the http::Request type for the outbound request
-    let outbound_req = http::Request::builder()
-        .uri("https://www.fermyon.com/")
-        .body(())?;
+    // For this example, use the spin_sdk::http::RequestBuilder type
+    // for the outbound request.
+    let outbound_req = Request::get("https://www.fermyon.com/");
 
     // Send the outbound request, capturing the response as raw bytes
     let response: http::Response<Vec<u8>> = send(outbound_req).await?;


### PR DESCRIPTION
Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)

✅ content/spin/v2/http-outbound.md

- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors

![Screenshot 2023-10-31 at 14 15 12](https://github.com/fermyon/developer/assets/9831342/98e92473-273b-4afd-ad80-fc15f20aa808)

- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
