### PR TITLE
All Structural Changes (and some content) For Spin 2 Documentation Release - approved and ready

### DIFF
--- a/config/site.toml
+++ b/config/site.toml
@@ -2,6 +2,7 @@ title = "Fermyon Developer"
 base_url = ""
 about = "Fermyon Developer — the home for you as a developer using Fermyon projects and products."
 index_site_pages = ["sitemap", "home", "changelog", "hub_list_api"]
+prepend_route_info = true
 
 [extra]
 copyright = "Fermyon"

--- a/content/spin/v1/ai-sentiment-analysis-api-tutorial.md
+++ b/content/spin/v1/ai-sentiment-analysis-api-tutorial.md
@@ -3,6 +3,7 @@ template = "spin_main"
 date = "2023-09-05T09:00:00Z"
 enable_shortcodes = true
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/ai-sentiment-analysis-api-tutorial"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/ai-sentiment-analysis-api-tutorial.md"
 
 ---

--- a/content/spin/v1/ai-sentiment-analysis-api-tutorial.md
+++ b/content/spin/v1/ai-sentiment-analysis-api-tutorial.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2023-09-05T09:00:00Z"
 enable_shortcodes = true
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/ai-sentiment-analysis-api-tutorial"
+canonical_url = "https://developer.fermyon.com/spin/v2/ai-sentiment-analysis-api-tutorial"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/ai-sentiment-analysis-api-tutorial.md"
 
 ---

--- a/content/spin/v1/api-guides-overview.md
+++ b/content/spin/v1/api-guides-overview.md
@@ -2,6 +2,7 @@ title = "API Support Overview"
 template = "spin_main"
 date = "2023-03-03T03:03:03Z"
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/api-guides-overview"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/api-guides-overview.md"
 
 ---

--- a/content/spin/v1/api-guides-overview.md
+++ b/content/spin/v1/api-guides-overview.md
@@ -2,7 +2,7 @@ title = "API Support Overview"
 template = "spin_main"
 date = "2023-03-03T03:03:03Z"
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/api-guides-overview"
+canonical_url = "https://developer.fermyon.com/spin/v2/api-guides-overview"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/api-guides-overview.md"
 
 ---

--- a/content/spin/v1/build.md
+++ b/content/spin/v1/build.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/build"
+canonical_url = "https://developer.fermyon.com/spin/v2/build"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/build.md"
 
 ---

--- a/content/spin/v1/build.md
+++ b/content/spin/v1/build.md
@@ -3,6 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/build"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/build.md"
 
 ---

--- a/content/spin/v1/cache.md
+++ b/content/spin/v1/cache.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/cache"
+canonical_url = "https://developer.fermyon.com/spin/v2/cache"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/cache.md"
 
 ---

--- a/content/spin/v1/cache.md
+++ b/content/spin/v1/cache.md
@@ -3,6 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/cache"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/cache.md"
 
 ---

--- a/content/spin/v1/cli-reference.md
+++ b/content/spin/v1/cli-reference.md
@@ -3,6 +3,7 @@ template = "spin_main"
 date = "2022-01-01T00:00:01Z"
 enable_shortcodes = true
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/cli-reference"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/cli-reference.md"
 
 ---

--- a/content/spin/v1/cli-reference.md
+++ b/content/spin/v1/cli-reference.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-01-01T00:00:01Z"
 enable_shortcodes = true
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/cli-reference"
+canonical_url = "https://developer.fermyon.com/spin/v2/cli-reference"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/cli-reference.md"
 
 ---

--- a/content/spin/v1/contributing-docs.md
+++ b/content/spin/v1/contributing-docs.md
@@ -2,7 +2,7 @@ title = "Contributing to Docs"
 template = "spin_main"
 date = "2022-01-01T00:00:01Z"
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/contributing-docs"
+canonical_url = "https://developer.fermyon.com/spin/v2/contributing-docs"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/contributing-docs.md"
 keywords = "contribute contributing"
 

--- a/content/spin/v1/contributing-docs.md
+++ b/content/spin/v1/contributing-docs.md
@@ -2,6 +2,7 @@ title = "Contributing to Docs"
 template = "spin_main"
 date = "2022-01-01T00:00:01Z"
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/contributing-docs"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/contributing-docs.md"
 keywords = "contribute contributing"
 

--- a/content/spin/v1/contributing-spin.md
+++ b/content/spin/v1/contributing-spin.md
@@ -2,7 +2,7 @@ title = "Contributing to Spin"
 template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/contributing-spin"
+canonical_url = "https://developer.fermyon.com/spin/v2/contributing-spin"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/contributing-spin.md"
 
 ---

--- a/content/spin/v1/contributing-spin.md
+++ b/content/spin/v1/contributing-spin.md
@@ -2,6 +2,7 @@ title = "Contributing to Spin"
 template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/contributing-spin"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/contributing-spin.md"
 
 ---

--- a/content/spin/v1/deploying-to-fermyon.md
+++ b/content/spin/v1/deploying-to-fermyon.md
@@ -2,7 +2,7 @@ title = "Deploying Spin Applications to Fermyon"
 template = "spin_main"
 date = "2022-05-20T00:22:56Z"
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/deploying-to-fermyon"
+canonical_url = "https://developer.fermyon.com/spin/v2/deploying-to-fermyon"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/deploying-to-fermyon.md"
 
 ---

--- a/content/spin/v1/deploying-to-fermyon.md
+++ b/content/spin/v1/deploying-to-fermyon.md
@@ -2,6 +2,7 @@ title = "Deploying Spin Applications to Fermyon"
 template = "spin_main"
 date = "2022-05-20T00:22:56Z"
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/deploying-to-fermyon"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/deploying-to-fermyon.md"
 
 ---

--- a/content/spin/v1/distributing-apps.md
+++ b/content/spin/v1/distributing-apps.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/distributing-apps"
+canonical_url = "https://developer.fermyon.com/spin/v2/distributing-apps"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/distributing-apps.md"
 
 ---

--- a/content/spin/v1/distributing-apps.md
+++ b/content/spin/v1/distributing-apps.md
@@ -3,6 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/distributing-apps"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/distributing-apps.md"
 
 ---

--- a/content/spin/v1/dynamic-configuration.md
+++ b/content/spin/v1/dynamic-configuration.md
@@ -2,6 +2,7 @@ title = "Dynamic and Runtime Application Configuration"
 template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/dynamic-configuration"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/dynamic-configuration.md"
 
 ---

--- a/content/spin/v1/dynamic-configuration.md
+++ b/content/spin/v1/dynamic-configuration.md
@@ -2,7 +2,7 @@ title = "Dynamic and Runtime Application Configuration"
 template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/dynamic-configuration"
+canonical_url = "https://developer.fermyon.com/spin/v2/dynamic-configuration"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/dynamic-configuration.md"
 
 ---

--- a/content/spin/v1/extending-and-embedding.md
+++ b/content/spin/v1/extending-and-embedding.md
@@ -2,7 +2,7 @@ title = "Extending and Embedding Spin"
 template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/extending-and-embedding"
+canonical_url = "https://developer.fermyon.com/spin/v2/extending-and-embedding"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/extending-and-embedding.md"
 
 ---

--- a/content/spin/v1/extending-and-embedding.md
+++ b/content/spin/v1/extending-and-embedding.md
@@ -2,6 +2,7 @@ title = "Extending and Embedding Spin"
 template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/extending-and-embedding"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/extending-and-embedding.md"
 
 ---

--- a/content/spin/v1/go-components.md
+++ b/content/spin/v1/go-components.md
@@ -2,6 +2,7 @@ title = "Building Spin components in Go"
 template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/go-components"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/go-components.md"
 
 ---

--- a/content/spin/v1/go-components.md
+++ b/content/spin/v1/go-components.md
@@ -2,7 +2,7 @@ title = "Building Spin components in Go"
 template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/go-components"
+canonical_url = "https://developer.fermyon.com/spin/v2/go-components"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/go-components.md"
 
 ---

--- a/content/spin/v1/http-outbound.md
+++ b/content/spin/v1/http-outbound.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/http-outbound"
+canonical_url = "https://developer.fermyon.com/spin/v2/http-outbound"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/http-outbound.md"
 
 ---

--- a/content/spin/v1/http-outbound.md
+++ b/content/spin/v1/http-outbound.md
@@ -3,6 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/http-outbound"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/http-outbound.md"
 
 ---

--- a/content/spin/v1/http-trigger.md
+++ b/content/spin/v1/http-trigger.md
@@ -3,6 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/http-trigger"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/http-trigger.md"
 
 ---

--- a/content/spin/v1/http-trigger.md
+++ b/content/spin/v1/http-trigger.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/http-trigger"
+canonical_url = "https://developer.fermyon.com/spin/v2/http-trigger"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/http-trigger.md"
 
 ---

--- a/content/spin/v1/index.md
+++ b/content/spin/v1/index.md
@@ -3,6 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 [extra]
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/index.md"
+canonical_url = "https://developer.fermyon.com/spin"
 
 ---
 

--- a/content/spin/v1/index.md
+++ b/content/spin/v1/index.md
@@ -2,9 +2,9 @@ title = "Introducing Spin"
 template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/index"
+canonical_url = "https://developer.fermyon.com/spin/v2/index"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/index.md"
-canonical_url = "https://developer.fermyon.com/spin"
+
 
 ---
 

--- a/content/spin/v1/index.md
+++ b/content/spin/v1/index.md
@@ -2,6 +2,7 @@ title = "Introducing Spin"
 template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/index"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/index.md"
 canonical_url = "https://developer.fermyon.com/spin"
 

--- a/content/spin/v1/install.md
+++ b/content/spin/v1/install.md
@@ -3,6 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/install"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/install.md"
 keywords = "install"
 

--- a/content/spin/v1/install.md
+++ b/content/spin/v1/install.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/install"
+canonical_url = "https://developer.fermyon.com/spin/v2/install"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/install.md"
 keywords = "install"
 

--- a/content/spin/v1/javascript-components.md
+++ b/content/spin/v1/javascript-components.md
@@ -3,6 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/javascript-components"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/javascript-components.md"
 
 ---

--- a/content/spin/v1/javascript-components.md
+++ b/content/spin/v1/javascript-components.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/javascript-components"
+canonical_url = "https://developer.fermyon.com/spin/v2/javascript-components"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/javascript-components.md"
 
 ---

--- a/content/spin/v1/key-value-store-tutorial.md
+++ b/content/spin/v1/key-value-store-tutorial.md
@@ -3,6 +3,7 @@ template = "spin_main"
 date = "2023-02-21T00:00:00Z"
 enable_shortcodes = true
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/key-value-store-tutorial"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/key-value-store-tutorial.md"
 
 ---

--- a/content/spin/v1/key-value-store-tutorial.md
+++ b/content/spin/v1/key-value-store-tutorial.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2023-02-21T00:00:00Z"
 enable_shortcodes = true
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/key-value-store-tutorial"
+canonical_url = "https://developer.fermyon.com/spin/v2/key-value-store-tutorial"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/key-value-store-tutorial.md"
 
 ---

--- a/content/spin/v1/kubernetes.md
+++ b/content/spin/v1/kubernetes.md
@@ -3,6 +3,7 @@ template = "spin_main"
 date = "2023-03-01T00:01:01Z"
 enable_shortcodes = true
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/kubernetes"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/kubernetes.md"
 
 ---

--- a/content/spin/v1/kubernetes.md
+++ b/content/spin/v1/kubernetes.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2023-03-01T00:01:01Z"
 enable_shortcodes = true
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/kubernetes"
+canonical_url = "https://developer.fermyon.com/spin/v2/kubernetes"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/kubernetes.md"
 
 ---

--- a/content/spin/v1/kv-store-api-guide.md
+++ b/content/spin/v1/kv-store-api-guide.md
@@ -3,6 +3,7 @@ template = "spin_main"
 date = "2023-04-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/kv-store-api-guide"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/kv-store-api-guide.md"
 
 ---

--- a/content/spin/v1/kv-store-api-guide.md
+++ b/content/spin/v1/kv-store-api-guide.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2023-04-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/kv-store-api-guide"
+canonical_url = "https://developer.fermyon.com/spin/v2/kv-store-api-guide"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/kv-store-api-guide.md"
 
 ---

--- a/content/spin/v1/language-support-overview.md
+++ b/content/spin/v1/language-support-overview.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-01-01T00:00:01Z"
 enable_shortcodes = true
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/language-support-overview"
+canonical_url = "https://developer.fermyon.com/spin/v2/language-support-overview"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/language-support-overview.md"
 
 ---

--- a/content/spin/v1/language-support-overview.md
+++ b/content/spin/v1/language-support-overview.md
@@ -3,6 +3,7 @@ template = "spin_main"
 date = "2022-01-01T00:00:01Z"
 enable_shortcodes = true
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/language-support-overview"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/language-support-overview.md"
 
 ---

--- a/content/spin/v1/managing-plugins.md
+++ b/content/spin/v1/managing-plugins.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/managing-plugins"
+canonical_url = "https://developer.fermyon.com/spin/v2/managing-plugins"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/managing-plugins.md"
 
 ---

--- a/content/spin/v1/managing-plugins.md
+++ b/content/spin/v1/managing-plugins.md
@@ -3,6 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/managing-plugins"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/managing-plugins.md"
 
 ---

--- a/content/spin/v1/managing-templates.md
+++ b/content/spin/v1/managing-templates.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/managing-templates"
+canonical_url = "https://developer.fermyon.com/spin/v2/managing-templates"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/managing-templates.md"
 
 ---

--- a/content/spin/v1/managing-templates.md
+++ b/content/spin/v1/managing-templates.md
@@ -3,6 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/managing-templates"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/managing-templates.md"
 
 ---

--- a/content/spin/v1/manifest-reference.md
+++ b/content/spin/v1/manifest-reference.md
@@ -2,7 +2,7 @@ title = "Spin Application Manifest Reference"
 template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/manifest-reference"
+canonical_url = "https://developer.fermyon.com/spin/v2/manifest-reference"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/manifest-reference.md"
 
 ---

--- a/content/spin/v1/manifest-reference.md
+++ b/content/spin/v1/manifest-reference.md
@@ -2,6 +2,7 @@ title = "Spin Application Manifest Reference"
 template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/manifest-reference"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/manifest-reference.md"
 
 ---

--- a/content/spin/v1/other-languages.md
+++ b/content/spin/v1/other-languages.md
@@ -2,6 +2,7 @@ title = "Building Spin components in other languages"
 template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/other-languages"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/other-languages.md"
 
 ---

--- a/content/spin/v1/other-languages.md
+++ b/content/spin/v1/other-languages.md
@@ -2,7 +2,7 @@ title = "Building Spin components in other languages"
 template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/other-languages"
+canonical_url = "https://developer.fermyon.com/spin/v2/other-languages"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/other-languages.md"
 
 ---

--- a/content/spin/v1/plugin-authoring.md
+++ b/content/spin/v1/plugin-authoring.md
@@ -2,6 +2,7 @@ title = "Creating Spin Plugins"
 template = "spin_main"
 date = "2023-02-1T00:22:56Z"
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/plugin-authoring"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/plugin-authoring.md"
 
 ---

--- a/content/spin/v1/plugin-authoring.md
+++ b/content/spin/v1/plugin-authoring.md
@@ -2,7 +2,7 @@ title = "Creating Spin Plugins"
 template = "spin_main"
 date = "2023-02-1T00:22:56Z"
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/plugin-authoring"
+canonical_url = "https://developer.fermyon.com/spin/v2/plugin-authoring"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/plugin-authoring.md"
 
 ---

--- a/content/spin/v1/python-components.md
+++ b/content/spin/v1/python-components.md
@@ -2,6 +2,7 @@ title = "Building Spin Components in Python"
 template = "spin_main"
 date = "2023-02-28T02:00:00Z"
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/python-components"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/python-components.md"
 
 ---

--- a/content/spin/v1/python-components.md
+++ b/content/spin/v1/python-components.md
@@ -2,7 +2,7 @@ title = "Building Spin Components in Python"
 template = "spin_main"
 date = "2023-02-28T02:00:00Z"
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/python-components"
+canonical_url = "https://developer.fermyon.com/spin/v2/python-components"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/python-components.md"
 
 ---

--- a/content/spin/v1/quickstart.md
+++ b/content/spin/v1/quickstart.md
@@ -3,6 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/quickstart"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/quickstart.md"
 keywords = "quickstart"
 

--- a/content/spin/v1/quickstart.md
+++ b/content/spin/v1/quickstart.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/quickstart"
+canonical_url = "https://developer.fermyon.com/spin/v2/quickstart"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/quickstart.md"
 keywords = "quickstart"
 

--- a/content/spin/v1/rdbms-storage.md
+++ b/content/spin/v1/rdbms-storage.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/rdbms-storage"
+canonical_url = "https://developer.fermyon.com/spin/v2/rdbms-storage"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/rdbms-storage.md"
 
 ---

--- a/content/spin/v1/rdbms-storage.md
+++ b/content/spin/v1/rdbms-storage.md
@@ -3,6 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/rdbms-storage"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/rdbms-storage.md"
 
 ---

--- a/content/spin/v1/redis-outbound.md
+++ b/content/spin/v1/redis-outbound.md
@@ -3,6 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/redis-outbound"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/redis-outbound.md"
 
 ---

--- a/content/spin/v1/redis-outbound.md
+++ b/content/spin/v1/redis-outbound.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/redis-outbound"
+canonical_url = "https://developer.fermyon.com/spin/v2/redis-outbound"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/redis-outbound.md"
 
 ---

--- a/content/spin/v1/redis-trigger.md
+++ b/content/spin/v1/redis-trigger.md
@@ -3,6 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/redis-trigger"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/redis-trigger.md"
 
 ---

--- a/content/spin/v1/redis-trigger.md
+++ b/content/spin/v1/redis-trigger.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/redis-trigger"
+canonical_url = "https://developer.fermyon.com/spin/v2/redis-trigger"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/redis-trigger.md"
 
 ---

--- a/content/spin/v1/registry-tutorial.md
+++ b/content/spin/v1/registry-tutorial.md
@@ -3,6 +3,7 @@ template = "spin_main"
 date = "2023-02-13T00:00:00Z"
 enable_shortcodes = true
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/registry-tutorial"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/registry-tutorial.md"
 
 ---

--- a/content/spin/v1/registry-tutorial.md
+++ b/content/spin/v1/registry-tutorial.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2023-02-13T00:00:00Z"
 enable_shortcodes = true
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/registry-tutorial"
+canonical_url = "https://developer.fermyon.com/spin/v2/registry-tutorial"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/registry-tutorial.md"
 
 ---

--- a/content/spin/v1/running-apps.md
+++ b/content/spin/v1/running-apps.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/running-apps"
+canonical_url = "https://developer.fermyon.com/spin/v2/running-apps"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/running-apps.md"
 
 ---

--- a/content/spin/v1/running-apps.md
+++ b/content/spin/v1/running-apps.md
@@ -3,6 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/running-apps"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/running-apps.md"
 
 ---

--- a/content/spin/v1/rust-components.md
+++ b/content/spin/v1/rust-components.md
@@ -2,6 +2,7 @@ title = "Building Spin components in Rust"
 template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/rust-components"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/rust-components.md"
 
 ---

--- a/content/spin/v1/rust-components.md
+++ b/content/spin/v1/rust-components.md
@@ -2,7 +2,7 @@ title = "Building Spin components in Rust"
 template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/rust-components"
+canonical_url = "https://developer.fermyon.com/spin/v2/rust-components"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/rust-components.md"
 
 ---

--- a/content/spin/v1/see-what-people-have-built-with-spin.md
+++ b/content/spin/v1/see-what-people-have-built-with-spin.md
@@ -2,6 +2,7 @@ title = "Built With Spin"
 template = "spin_main"
 date = "2023-05-05T00:01:01Z"
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/see-what-people-have-built-with-spin"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/see-what-people-have-built-with-spin.md"
 
 ---

--- a/content/spin/v1/see-what-people-have-built-with-spin.md
+++ b/content/spin/v1/see-what-people-have-built-with-spin.md
@@ -2,7 +2,7 @@ title = "Built With Spin"
 template = "spin_main"
 date = "2023-05-05T00:01:01Z"
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/see-what-people-have-built-with-spin"
+canonical_url = "https://developer.fermyon.com/spin/v2/see-what-people-have-built-with-spin"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/see-what-people-have-built-with-spin.md"
 
 ---

--- a/content/spin/v1/serverless-ai-api-guide.md
+++ b/content/spin/v1/serverless-ai-api-guide.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2023-09-05T09:00:00Z"
 enable_shortcodes = true
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/serverless-ai-api-guide"
+canonical_url = "https://developer.fermyon.com/spin/v2/serverless-ai-api-guide"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/serverless-ai-api-guide.md"
 
 ---

--- a/content/spin/v1/serverless-ai-api-guide.md
+++ b/content/spin/v1/serverless-ai-api-guide.md
@@ -3,6 +3,7 @@ template = "spin_main"
 date = "2023-09-05T09:00:00Z"
 enable_shortcodes = true
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/serverless-ai-api-guide"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/serverless-ai-api-guide.md"
 
 ---

--- a/content/spin/v1/serverless-ai-hello-world.md
+++ b/content/spin/v1/serverless-ai-hello-world.md
@@ -5,7 +5,7 @@ template = "spin_main"
 tags = ["ai", "serverless", "getting started"]
 enable_shortcodes = true
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/serverless-ai-hello-world"
+canonical_url = "https://developer.fermyon.com/spin/v2/serverless-ai-hello-world"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/serverless-ai-hello-world.md"
 
 ---

--- a/content/spin/v1/serverless-ai-hello-world.md
+++ b/content/spin/v1/serverless-ai-hello-world.md
@@ -5,6 +5,7 @@ template = "spin_main"
 tags = ["ai", "serverless", "getting started"]
 enable_shortcodes = true
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/serverless-ai-hello-world"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/serverless-ai-hello-world.md"
 
 ---

--- a/content/spin/v1/spin-application-structure.md
+++ b/content/spin/v1/spin-application-structure.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2023-08-20T00:00:00Z"
 enable_shortcodes = true
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/spin-application-structure"
+canonical_url = "https://developer.fermyon.com/spin/v2/spin-application-structure"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/spin-application-structure.md"
 keywords = "structure"
 

--- a/content/spin/v1/spin-application-structure.md
+++ b/content/spin/v1/spin-application-structure.md
@@ -3,6 +3,7 @@ template = "spin_main"
 date = "2023-08-20T00:00:00Z"
 enable_shortcodes = true
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/spin-application-structure"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/spin-application-structure.md"
 keywords = "structure"
 

--- a/content/spin/v1/sqlite-api-guide.md
+++ b/content/spin/v1/sqlite-api-guide.md
@@ -3,6 +3,7 @@ template = "spin_main"
 date = "2023-04-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/sqlite-api-guide"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/sqlite-api-guide.md"
 
 ---

--- a/content/spin/v1/sqlite-api-guide.md
+++ b/content/spin/v1/sqlite-api-guide.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2023-04-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/sqlite-api-guide"
+canonical_url = "https://developer.fermyon.com/spin/v2/sqlite-api-guide"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/sqlite-api-guide.md"
 
 ---

--- a/content/spin/v1/template-authoring.md
+++ b/content/spin/v1/template-authoring.md
@@ -2,6 +2,7 @@ title = "Creating Spin templates"
 template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/template-authoring"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/template-authoring.md"
 
 ---

--- a/content/spin/v1/template-authoring.md
+++ b/content/spin/v1/template-authoring.md
@@ -2,7 +2,7 @@ title = "Creating Spin templates"
 template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/template-authoring"
+canonical_url = "https://developer.fermyon.com/spin/v2/template-authoring"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/template-authoring.md"
 
 ---

--- a/content/spin/v1/troubleshooting-application-dev.md
+++ b/content/spin/v1/troubleshooting-application-dev.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2023-02-13T00:00:00Z"
 enable_shortcodes = true
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/troubleshooting-application-dev"
+canonical_url = "https://developer.fermyon.com/spin/v2/troubleshooting-application-dev"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/troubleshooting-application-dev.md"
 
 ---

--- a/content/spin/v1/troubleshooting-application-dev.md
+++ b/content/spin/v1/troubleshooting-application-dev.md
@@ -3,6 +3,7 @@ template = "spin_main"
 date = "2023-02-13T00:00:00Z"
 enable_shortcodes = true
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/troubleshooting-application-dev"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/troubleshooting-application-dev.md"
 
 ---

--- a/content/spin/v1/upgrade.md
+++ b/content/spin/v1/upgrade.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2023-05-01T00:01:01Z"
 enable_shortcodes = true
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/upgrade"
+canonical_url = "https://developer.fermyon.com/spin/v2/upgrade"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/upgrade.md"
 
 ---

--- a/content/spin/v1/upgrade.md
+++ b/content/spin/v1/upgrade.md
@@ -3,6 +3,7 @@ template = "spin_main"
 date = "2023-05-01T00:01:01Z"
 enable_shortcodes = true
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/upgrade"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/upgrade.md"
 
 ---

--- a/content/spin/v1/url-shortener-tutorial.md
+++ b/content/spin/v1/url-shortener-tutorial.md
@@ -2,7 +2,7 @@ title = "Building a URL Shortener With Spin"
 template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/url-shortener-tutorial"
+canonical_url = "https://developer.fermyon.com/spin/v2/url-shortener-tutorial"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/url-shortener-tutorial.md"
 
 ---

--- a/content/spin/v1/url-shortener-tutorial.md
+++ b/content/spin/v1/url-shortener-tutorial.md
@@ -2,6 +2,7 @@ title = "Building a URL Shortener With Spin"
 template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/url-shortener-tutorial"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/url-shortener-tutorial.md"
 
 ---

--- a/content/spin/v1/variables.md
+++ b/content/spin/v1/variables.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-06-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/variables"
+canonical_url = "https://developer.fermyon.com/spin/v2/variables"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/variables.md"
 
 ---

--- a/content/spin/v1/variables.md
+++ b/content/spin/v1/variables.md
@@ -3,6 +3,7 @@ template = "spin_main"
 date = "2022-06-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/variables"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/variables.md"
 
 ---

--- a/content/spin/v1/writing-apps.md
+++ b/content/spin/v1/writing-apps.md
@@ -3,6 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
+canonical = "https://developer.fermyon.com/spin/v2/writing-apps"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/writing-apps.md"
 
 ---

--- a/content/spin/v1/writing-apps.md
+++ b/content/spin/v1/writing-apps.md
@@ -3,7 +3,7 @@ template = "spin_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
-canonical = "https://developer.fermyon.com/spin/v2/writing-apps"
+canonical_url = "https://developer.fermyon.com/spin/v2/writing-apps"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/writing-apps.md"
 
 ---

--- a/spin.toml
+++ b/spin.toml
@@ -6,6 +6,7 @@ authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 trigger = { type = "http", base = "/" }
 
 [[component]]
+# Using build from bartholomew main
 source = "modules/bartholomew.wasm"
 id = "bartholomew"
 environment = { PREVIEW_MODE = "0" }
@@ -239,7 +240,7 @@ allowed_http_hosts = ["self"]
 exclude_files = ["**/node_modules"]
 files = ["spin-redirect.json"]
 [component.config]
-latest_spin_version = "v1"
+latest_spin_version = "v2"
 [component.trigger]
 route = "/spin/..."
 # Need to modify action to get the js2wasm plugin
@@ -248,12 +249,11 @@ route = "/spin/..."
 # command = "npm install && npm run build"
 
 [[component]]
+# Using build from bartholomew main
 source = "modules/bartholomew.wasm"
 id = "bartholomew-spin-v1"
 environment = { PREVIEW_MODE = "0" }
 files = ["content/**/*", "templates/*", "scripts/*", "config/*", "shortcodes/*"]
-[component.config]
-optional_path_prefix = "/spin/v1/"
 [component.trigger]
 route = "/spin/v1/..."
 [component.build]
@@ -261,12 +261,11 @@ command = "npm run build-index && npm run build-hub-index"
 watch = ["content/**/*", "templates/*"]
 
 [[component]]
+# Using build from bartholomew main
 source = "modules/bartholomew.wasm"
 id = "bartholomew-spin-v2"
 environment = { PREVIEW_MODE = "0" }
 files = ["content/**/*", "templates/*", "scripts/*", "config/*", "shortcodes/*"]
-[component.config]
-optional_path_prefix = "/spin/v2/"
 [component.trigger]
 route = "/spin/v2/..."
 [component.build]

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -3755,6 +3755,15 @@ html.dark-theme body main .feedback-wrapper .feedback-modal a {
   margin-bottom: 0 !important;
 }
 
+.documentation .content .archived-notice {
+  width: 100%;
+  background-color: #e7d3f2;
+  border-radius: .667rem;
+  margin-bottom: 4rem;
+  padding: 1rem;
+  font-size: 1rem;
+}
+
 .documentation .content h4 {
   margin: 1.3333em 0 .6666em;
 }
@@ -4572,6 +4581,10 @@ html.dark-theme body main .feedback-wrapper .feedback-modal a {
 .changelog .back-arrow {
   margin-bottom: 1.333rem;
   font-size: .825rem;
+}
+
+html.dark-theme .documentation .content .archived-notice {
+  background-color: #345995;
 }
 
 html.dark-theme .changelog section {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -142,10 +142,10 @@
       this[globalName] = mainExports;
     }
   }
-})({"03a13":[function(require,module,exports) {
+})({"bZYIQ":[function(require,module,exports) {
 var global = arguments[3];
 var HMR_HOST = null;
-var HMR_PORT = 58523;
+var HMR_PORT = 1234;
 var HMR_SECURE = false;
 var HMR_ENV_HASH = "42036d7a98ade5a7";
 module.bundle.HMR_BUNDLE_ID = "2a29ff2311f401cb";
@@ -643,6 +643,7 @@ const projectList = [
     "Cloud",
     "Bartholomew"
 ];
+const versionPattern = /^v\d+$/;
 let idx;
 let documents;
 async function getSearchIndex() {
@@ -655,6 +656,16 @@ async function getSearchIndex() {
 }
 async function setupSearch() {
     documents = await getSearchIndex();
+    let currentPath = window.location.pathname;
+    let splitPath = currentPath.split("/");
+    let version = splitPath[2];
+    if (version == "v1") documents = documents.filter((k)=>{
+        if (k.project != "spin") return true;
+        return k.url.includes("spin/v1/");
+    });
+    else documents = documents.filter((k)=>{
+        return k.project != "spin" || !k.url.includes("spin/v1/");
+    });
     idx = lunr(function() {
         this.field("title");
         this.field("subheading");
@@ -1452,5 +1463,5 @@ function createFeedbackElement(handle) {
     mount(handle, feedback);
 }
 
-},{"@parcel/transformer-js/src/esmodule-helpers.js":"j7FRh"}]},["03a13","e9rxa"], "e9rxa", "parcelRequire252c")
+},{"@parcel/transformer-js/src/esmodule-helpers.js":"j7FRh"}]},["bZYIQ","e9rxa"], "e9rxa", "parcelRequire252c")
 

--- a/static/js/src/modules/search.js
+++ b/static/js/src/modules/search.js
@@ -1,22 +1,38 @@
 const { el, mount, text, list, setChildren, setStyle, setAttr } = redom
 
 const projectList = ["Spin", "Cloud", "Bartholomew"]
-
+const versionPattern = /^v\d+$/;
 let idx
 let documents
 
 async function getSearchIndex() {
-  try {
-    let res = await fetch('/static/data.json')
-    return await res.json()
-  }
-  catch (err) {
-    console.log("cannot load search module")
-  }
+    try {
+        let res = await fetch('/static/data.json')
+        return await res.json()
+    }
+    catch (err) {
+        console.log("cannot load search module")
+    }
 }
 
 async function setupSearch() {
     documents = await getSearchIndex()
+    let currentPath = window.location.pathname
+    let splitPath = currentPath.split("/")
+    let version = splitPath[2]
+    if (version == "v1") {
+        documents = documents.filter(k => {
+            if (k.project != "spin") {
+                return true
+            }
+            return k.url.includes("spin/v1/")
+        })
+    } else {
+        documents = documents.filter(k => {
+            return k.project != "spin" || !k.url.includes("spin/v1/")
+        })
+    }
+
     idx = lunr(function () {
         this.field('title')
         this.field('subheading')
@@ -51,14 +67,14 @@ class SearchResultSubHeading {
         this.el = el("a.result-subitem", { onclick: function (e) { searchModal.close() } }, [this.itemIcon, this.link])
     }
     update(data) {
-            this.link.textContent = data.subheading
-            this.el.href = data.url
-            // Hide listing where the subheading is empty
-            if(data.subheading == ""){
-                setStyle(this.el, {display: "none"})
-            } else {
-                setStyle(this.el, {display: "flex"})
-            }
+        this.link.textContent = data.subheading
+        this.el.href = data.url
+        // Hide listing where the subheading is empty
+        if (data.subheading == "") {
+            setStyle(this.el, { display: "none" })
+        } else {
+            setStyle(this.el, { display: "flex" })
+        }
     }
 }
 
@@ -276,4 +292,4 @@ class SearchModal {
 let searchModal = new SearchModal()
 let searchButton = new SearchButton(searchModal)
 
-export {setupSearch, searchButton, searchModal}
+export { setupSearch, searchButton, searchModal }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -71,6 +71,16 @@ Importing color and theme updates for the brand 1.5 refresh
 		position: relative;
 		z-index: 555;
 
+		.archived-notice {
+			width: 100%;
+			background-color: red;
+			border-radius: 0.667rem;
+			padding: 1rem;
+			font-size: 1rem;
+			background-color: $thistle;
+			margin-bottom: 4rem;
+		}
+
 		h4 {
 			margin: 1.3333em 0 0.6666em 0;
 		}
@@ -232,6 +242,7 @@ Importing color and theme updates for the brand 1.5 refresh
 		h5,
 		h6 {
 			font-family: $spaceGro;
+
 			code {
 				font-size: 0.95em !important;
 				font-weight: 600;
@@ -1027,6 +1038,14 @@ screen and (max-width:736px) and (orientation:landscape) {
 }
 
 html.dark-theme {
+	.documentation {
+		.content {
+			.archived-notice {
+				background-color: $midblue;
+			}
+		}
+	}
+
 	.changelog {
 
 		section {

--- a/templates/content_top.hbs
+++ b/templates/content_top.hbs
@@ -10,7 +10,8 @@
     {{! Use the formatter.title and formatter.description in the head }}
     <title>{{page.head.title}} | {{site.info.title}}</title>
 
-    <meta name="keywords" content="{{#if (lt 0 (len page.head.tags))}}{{#each page.head.tags}}{{this}}, {{/each}}{{else}}{{site.info.extra.keywords}}{{/if}}">
+    <meta name="keywords"
+        content="{{#if (lt 0 (len page.head.tags))}}{{#each page.head.tags}}{{this}}, {{/each}}{{else}}{{site.info.extra.keywords}}{{/if}}">
 
     <meta name="title" property="og:title" content="{{page.head.title}}">
     <meta property="og:type" content="article">
@@ -19,22 +20,23 @@
     <meta property="og:site_name" content="{{site.info.title}}">
     <meta property="article:section" content="blog">
 
-    <meta property="article:published_time" content="{{date_format "%Y-%m-%dT%H:%M:%SZ" page.head.date}}">
+    <meta property="article:published_time" content="{{date_format " %Y-%m-%dT%H:%M:%SZ" page.head.date}}">
     {{#if page.head.extra.last_modified}}
-    <meta property="article:modified_time" content="{{date_format "%Y-%m-%dT%H:%M:%SZ" page.head.extra.last_modified}}">
+    <meta property="article:modified_time" content="{{date_format " %Y-%m-%dT%H:%M:%SZ"
+        page.head.extra.last_modified}}">
     {{else}}
-    <meta property="article:modified_time" content="{{date_format "%Y-%m-%dT%H:%M:%SZ" page.head.date}}">
+    <meta property="article:modified_time" content="{{date_format " %Y-%m-%dT%H:%M:%SZ" page.head.date}}">
     {{/if}}
 
     <meta name="twitter:title" content="{{page.head.title}}">
     {{#if page.head.extra.image}}
-        <meta name="twitter:card" content="{{page.head.extra.twitter_card_type}}">
-        <meta name="twitter:image" content="{{site.info.base_url}}{{page.head.extra.image}}">
-        <meta name="image" property="og:image" content="{{site.info.base_url}}{{page.head.extra.image}}">
+    <meta name="twitter:card" content="{{page.head.extra.twitter_card_type}}">
+    <meta name="twitter:image" content="{{site.info.base_url}}{{page.head.extra.image}}">
+    <meta name="image" property="og:image" content="{{site.info.base_url}}{{page.head.extra.image}}">
     {{else}}
-        <meta name="twitter:card" content="summary">
-        <meta name="twitter:image" content="{{site.info.base_url}}{{site.info.extra.twitter_card}}">
-        <meta name="image" property="og:image" content="{{site.info.base_url}}{{site.info.extra.twitter_card}}">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:image" content="{{site.info.base_url}}{{site.info.extra.twitter_card}}">
+    <meta name="image" property="og:image" content="{{site.info.base_url}}{{site.info.extra.twitter_card}}">
     {{/if}}
 
     {{#if page.head.description}}
@@ -57,20 +59,26 @@
     <meta name="msapplication-TileColor" content="#0d203f">
 
     <link rel="alternate" type="application/rss+xml" title="{{site.info.title}}" href="{{site.info.base_url}}/atom.xml">
-    <link rel="canonical" href="{{site.info.base_url}}{{env.PATH_INFO}}">
+    {{#if page.head.extra.canonical_url}}
+        <link rel="canonical" href="{{page.head.extra.canonical_url}}" />
+    {{/if}}
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.9.3/css/bulma.min.css"
-        integrity="sha512-IgmDkwzs96t4SrChW29No3NXBIBv8baW490zk5aXvhCD8vuZM3yUSkbyTBcXohkySecyzIrUwiF/qV0cuPcL3Q==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+        integrity="sha512-IgmDkwzs96t4SrChW29No3NXBIBv8baW490zk5aXvhCD8vuZM3yUSkbyTBcXohkySecyzIrUwiF/qV0cuPcL3Q=="
+        crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link href="https://fonts.googleapis.com/css2?family=Sen:wght@400;700&amp;display=swap" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{site.info.base_url}}/static/css/styles.css" />
 
     <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-T28H3XL');</script>
+    <script>(function (w, d, s, l, i) {
+            w[l] = w[l] || []; w[l].push({
+                'gtm.start':
+                    new Date().getTime(), event: 'gtm.js'
+            }); var f = d.getElementsByTagName(s)[0],
+                j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
+                    'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
+        })(window, document, 'script', 'dataLayer', 'GTM-T28H3XL');</script>
     <!-- End Google Tag Manager -->
 
     <script>
@@ -128,14 +136,15 @@
     </script>
 
     <script type="text/javascript" defer>
-    window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var r=document.createElement("script");r.type="text/javascript",r.async=!0,r.src="https://cdn.heapanalytics.com/js/heap-"+e+".js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(r,a);for(var n=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["addEventProperties","addUserProperties","clearEventProperties","identify","resetIdentity","removeEventProperty","setEventProperties","track","unsetEventProperty"],o=0;o<p.length;o++)heap[p[o]]=n(p[o])};
-  heap.load("3221611804");
+        window.heap = window.heap || [], heap.load = function (e, t) { window.heap.appid = e, window.heap.config = t = t || {}; var r = document.createElement("script"); r.type = "text/javascript", r.async = !0, r.src = "https://cdn.heapanalytics.com/js/heap-" + e + ".js"; var a = document.getElementsByTagName("script")[0]; a.parentNode.insertBefore(r, a); for (var n = function (e) { return function () { heap.push([e].concat(Array.prototype.slice.call(arguments, 0))) } }, p = ["addEventProperties", "addUserProperties", "clearEventProperties", "identify", "resetIdentity", "removeEventProperty", "setEventProperties", "track", "unsetEventProperty"], o = 0; o < p.length; o++)heap[p[o]] = n(p[o]) };
+        heap.load("3221611804");
     </script>
-
 </head>
+
 <body class="documentation">
-   <!-- Google Tag Manager (noscript) -->
-   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T28H3XL" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-   <!-- End Google Tag Manager (noscript) -->
-   
-   {{> content_navbar }}
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T28H3XL" height="0" width="0"
+            style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+
+    {{> content_navbar }}

--- a/templates/sitemap.hbs
+++ b/templates/sitemap.hbs
@@ -10,12 +10,16 @@ For date/time format, see https://www.w3.org/TR/NOTE-datetime
         <priority>0.8</priority>
     </url>
     {{#each (sitemap site.pages) }}
-
     <url>
         <loc>https://developer.fermyon.com{{uri}}</loc>
         {{#if page.head.date }}<lastmod>{{date_format "%Y-%m-%dT%H:%M:%SZ" page.head.date}}</lastmod>{{/if}}
-        <changefreq>{{frequency}}</changefreq>
-        <priority>{{priority}}</priority>
+        {{#if (active_project uri "/spin/v1" )}}
+        <changefreq>weekly</changefreq>
+        <priority>0.5</priority>
+        {{else}}
+        <changefreq>daily</changefreq>
+        <priority>1</priority>
+        {{/if}}
     </url>
     {{/each}}
 </urlset>

--- a/templates/spin_main.hbs
+++ b/templates/spin_main.hbs
@@ -8,12 +8,12 @@
         <div class="menu-wrap is-narrow is-fixed-desktop" id="docsMenu">
             <aside class="menu">
                 {{! This adds the version selector - uncomment after v2 launch }}
-                {{!-- <select class="version-dropdown"
+                <select class="version-dropdown"
                     onchange="this.options[this.selectedIndex].value && (window.location = this.options[this.selectedIndex].value);">
                     <option value="/spin/v2/index">Spin v2.x</option>
                     <option value="/spin/v1/index" {{#if (active_project request.spin-full-url "/spin/v1/" )}} selected
                         {{/if}}>Spin v1.x</option>
-                </select> --}}
+                </select>
                 {{#if (active_project request.spin-full-url "/spin/v2/" )}}
                 {{> spin_sidebar_v2 }}
                 {{else}}
@@ -25,10 +25,10 @@
         <article class="column content content-docs content-docs-wide">
             <section id="type">
                 {{! This adds an archival notice - needs to styled }}
-                {{!-- {{#if (active_project request.spin-full-url "/spin/v1" )}}
+                {{#if (active_project request.spin-full-url "/spin/v1" )}}
                 <span style="color:red">This is archived content, find docs for <a href="/spin">the latest
                         version</a></span>
-                {{/if}} --}}
+                {{/if}}
                 <h1 class="blog-post-title border-bottom">{{page.head.title}}</h1>
 
                 {{{page.body}}}

--- a/templates/spin_main.hbs
+++ b/templates/spin_main.hbs
@@ -26,8 +26,8 @@
             <section id="type">
                 {{! This adds an archival notice - needs to styled }}
                 {{#if (active_project request.spin-full-url "/spin/v1" )}}
-                <span style="color:red">This is archived content, find docs for <a href="/spin">the latest
-                        version</a></span>
+                <div class="archived-notice"> This page refers to an older version of Spin. <a href="/spin">Go to the
+                        latest version.</a></div>
                 {{/if}}
                 <h1 class="blog-post-title border-bottom">{{page.head.title}}</h1>
 


### PR DESCRIPTION
I have created a new commit to your v2 update that adds a canonical URL entry into the [extra] section of every v1 .md file that has a canonical v2 equivalent.
https://github.com/fermyon/developer/pull/993/commits/8e3cd25baaff7678b8ec878cf7578639029375f0