### PR TITLE
added SUH cards to developer docs

### DIFF
--- a/content/spin/v1/index.md
+++ b/content/spin/v1/index.md
@@ -1,6 +1,7 @@
 title = "Introducing Spin"
 template = "spin_main"
 date = "2022-03-14T00:22:56Z"
+enable_shortcodes = true
 [extra]
 canonical_url = "https://developer.fermyon.com/spin/v2/index"
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/index.md"

--- a/content/spin/v1/index.md
+++ b/content/spin/v1/index.md
@@ -8,6 +8,12 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/index.md"
 
 ---
 
+{{suh_cards}}
+{{card_element "sample" "Checklist Sample App" "A checklist app that persists data in a key value store" "https://developer.fermyon.com/hub/preview/sample_checklist" "Typescript,Http,Kv" }}
+{{card_element "template" "Zola SSG Tempalte" "A template for using Zola framework to create a static webpage" "https://developer.fermyon.com/hub/preview/template_zola_ssg" "rust" }}
+{{card_element "sample" "AI-assisted News Summarizer" "Read an RSS newsfeed and have AI summarize it for you" "https://developer.fermyon.com/hub/preview/sample_newsreader_ai" "Typescript,Javascript,Ai" }}
+{{blockEnd}}
+
 Spin is a framework for building and running event-driven microservice applications with WebAssembly (Wasm) components.
 
 Spin uses Wasm because it is **sandboxed, portable, and fast**.  Millisecond cold start times mean no need to keep applications "warm".

--- a/content/spin/v1/install.md
+++ b/content/spin/v1/install.md
@@ -321,6 +321,7 @@ For more information, please visit the [managing plugins](./managing-plugins) se
 
 ## Next Steps
 
-- [Take Spin for a spin](./quickstart.md)
-- Learn about how to [write a Spin application](writing-apps)
-- Try the [Fermyon Cloud](/cloud/quickstart)
+{{suh_cards}}
+{{card_element "sample" "Checklist Sample App" "A checklist app that persists data in a key value store" "https://developer.fermyon.com/hub/preview/sample_checklist" "Typescript,Http,Kv" }}
+{{card_element "sample" "AI-assisted News Summarizer" "Read an RSS newsfeed and have AI summarize it for you" "https://developer.fermyon.com/hub/preview/sample_newsreader_ai" "Typescript,Javascript,Ai" }}
+{{blockEnd}}

--- a/content/spin/v1/quickstart.md
+++ b/content/spin/v1/quickstart.md
@@ -232,6 +232,10 @@ You'll need the TinyGo compiler, as the standard Go compiler does not yet suppor
 
 ## Create Your First Application
 
+{{suh_cards}}
+{{card_element "template" "Zola SSG Tempalte" "A template for using Zola framework to create a static webpage" "https://developer.fermyon.com/hub/preview/template_zola_ssg" "rust" }}
+{{blockEnd}}
+
 Now you are ready to create your first Spin application:
 
 {{ tabs "sdk-type" }}

--- a/content/spin/v2/index.md
+++ b/content/spin/v2/index.md
@@ -6,6 +6,12 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/v2/index.md"
 
 ---
 
+{{suh_cards}}
+{{card_element "sample" "Checklist Sample App" "A checklist app that persists data in a key value store" "https://developer.fermyon.com/hub/preview/sample_checklist" "Typescript,Http,Kv" }}
+{{card_element "template" "Zola SSG Tempalte" "A template for using Zola framework to create a static webpage" "https://developer.fermyon.com/hub/preview/template_zola_ssg" "rust" }}
+{{card_element "sample" "AI-assisted News Summarizer" "Read an RSS newsfeed and have AI summarize it for you" "https://developer.fermyon.com/hub/preview/sample_newsreader_ai" "Typescript,Javascript,Ai" }}
+{{blockEnd}}
+
 Spin is a framework for building and running event-driven microservice applications with WebAssembly (Wasm) components.
 
 Spin uses Wasm because it is **sandboxed, portable, and fast**.  Millisecond cold start times mean no need to keep applications "warm".

--- a/content/spin/v2/index.md
+++ b/content/spin/v2/index.md
@@ -1,6 +1,7 @@
 title = "Introducing Spin"
 template = "spin_main"
 date = "2023-11-04T00:00:01Z"
+enable_shortcodes = true
 [extra]
 url = "https://github.com/fermyon/developer/blob/main/content/spin/v2/index.md"
 

--- a/content/spin/v2/install.md
+++ b/content/spin/v2/install.md
@@ -320,6 +320,8 @@ For more information, please visit the [managing plugins](./managing-plugins) se
 
 ## Next Steps
 
-- [Take Spin for a spin](./quickstart.md)
-- Learn about how to [write a Spin application](writing-apps)
-- Try the [Fermyon Cloud](/cloud/quickstart)
+{{suh_cards}}
+{{card_element "sample" "Checklist Sample App" "A checklist app that persists data in a key value store" "https://developer.fermyon.com/hub/preview/sample_checklist" "Typescript,Http,Kv" }}
+{{card_element "template" "Zola SSG Tempalte" "A template for using Zola framework to create a static webpage" "https://developer.fermyon.com/hub/preview/template_zola_ssg" "rust" }}
+{{card_element "sample" "AI-assisted News Summarizer" "Read an RSS newsfeed and have AI summarize it for you" "https://developer.fermyon.com/hub/preview/sample_newsreader_ai" "Typescript,Javascript,Ai" }}
+{{blockEnd}}

--- a/content/spin/v2/quickstart.md
+++ b/content/spin/v2/quickstart.md
@@ -237,6 +237,11 @@ You'll need the TinyGo compiler, as the standard Go compiler does not yet suppor
 
 ## Create Your First Application
 
+{{suh_cards}}
+{{card_element "sample" "Checklist Sample App" "A checklist app that persists data in a key value store" "https://developer.fermyon.com/hub/preview/sample_checklist" "Typescript,Http,Kv" }}
+{{card_element "sample" "AI-assisted News Summarizer" "Read an RSS newsfeed and have AI summarize it for you" "https://developer.fermyon.com/hub/preview/sample_newsreader_ai" "Typescript,Javascript,Ai" }}
+{{blockEnd}}
+
 Now you are ready to create your first Spin application:
 
 {{ tabs "sdk-type" }}


### PR DESCRIPTION
Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

<img width="1740" alt="Screenshot 2023-11-06 at 13 24 27" src="https://github.com/fermyon/developer/assets/9831342/2fcf9221-af21-474c-a6b5-d7c7d5f0deb7">

This documentation has been checked to ensure that:

- [x] The `title, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)

✅ content/spin/v1/install.md
✅ content/spin/v1/index.md
✅ content/spin/v1/quickstart.md
✅ content/spin/v2/install.md
✅ content/spin/v2/index.md
✅ content/spin/v2/quickstart.md

- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors
- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
