### PR TITLE
Link SDK reference docs where available

### DIFF
--- a/content/spin/v2/go-components.md
+++ b/content/spin/v2/go-components.md
@@ -26,6 +26,8 @@ Using TinyGo to compile components for Spin is currently required, as the
 
 > All examples from this page can be found in [the Spin repository on GitHub](https://github.com/fermyon/spin/tree/main/examples).
 
+[**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2)
+
 ## Versions
 
 TinyGo `0.29.0` is recommended, which requires Go `v1.18+` or newer.

--- a/content/spin/v2/http-outbound.md
+++ b/content/spin/v2/http-outbound.md
@@ -24,6 +24,8 @@ The outbound HTTP interface depends on your language.
 
 {{ startTab "Rust"}}
 
+> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/rust-docs/spin/main/spin_sdk/http/index.html)
+
 To send requests, use the [`spin_sdk::http::send`](https://fermyon.github.io/rust-docs/spin/main/spin_sdk/http/fn.send.html) function. This takes a request argument and returns a response (or error). It is `async`, so within an async inbound handler you can have multiple outbound `send`s running concurrently.
 
 > Support for streaming request and response bodies is **experimental**. We currently recommend that you stick with the simpler non-streaming interfaces if you don't require streaming.
@@ -118,6 +120,8 @@ You can find a complete example for using outbound HTTP in the [Python SDK repos
 {{ blockEnd }}
 
 {{ startTab "TinyGo"}}
+
+> [**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/http)
 
 HTTP functions are available in the `github.com/fermyon/spin/sdk/go/v2/http` package. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2/http) The general function is named `Send`, but the Go SDK also surfaces individual functions, with request-specific parameters, for the `Get` and `Post` operations. For example:
 

--- a/content/spin/v2/http-trigger.md
+++ b/content/spin/v2/http-trigger.md
@@ -141,6 +141,8 @@ The exact signature of the HTTP handler, and how a function is identified to be 
 
 {{ startTab "Rust"}}
 
+> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/rust-docs/spin/main/spin_sdk/http/index.html)
+
 In Rust, the handler is identified by the [`#[spin_sdk::http_component]`](https://fermyon.github.io/rust-docs/spin/main/spin_sdk/attr.http_component.html) attribute.  The handler function can have one of two forms: _request-response_ or _input-output parameter_.
 
 **Request-Response Handlers**
@@ -288,6 +290,8 @@ def handle_request(request):
 {{ blockEnd }}
 
 {{ startTab "TinyGo"}}
+
+> [**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/http)
 
 In Go, you register the handler as a callback in your program's `init` function.  Call `spinhttp.Handle`, passing your handler as the sole argument.  Your handler takes a `http.Request` record, from the standard `net/http` package, and a `ResponseWriter` to construct the response.
 

--- a/content/spin/v2/kv-store-api-guide.md
+++ b/content/spin/v2/kv-store-api-guide.md
@@ -40,6 +40,8 @@ The exact detail of calling these operations from your application depends on yo
 
 {{ startTab "Rust"}}
 
+> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/rust-docs/spin/main/spin_sdk/key_value/index.html)
+
 Key value functions are available in the `spin_sdk::key_value` module. The function names match the operations above. For example:
 
 ```rust
@@ -136,6 +138,8 @@ def handle_request(request):
 {{ blockEnd }}
 
 {{ startTab "TinyGo"}}
+
+> [**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/kv)
 
 Key value functions are provided by the `github.com/fermyon/spin/sdk/go/v2/kv` module. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2/kv) For example:
 

--- a/content/spin/v2/language-support-overview.md
+++ b/content/spin/v2/language-support-overview.md
@@ -13,6 +13,8 @@ This page contains information about language support for Spin features:
 
 {{ startTab "Rust"}}
 
+[Visit the Spin SDK reference documentation.](https://fermyon.github.io/rust-docs/spin/main/spin_sdk/index.html)
+
 | Feature | SDK Supported? |
 |-----|-----|
 | **Triggers** |
@@ -75,6 +77,8 @@ This page contains information about language support for Spin features:
 {{ blockEnd }}
 
 {{ startTab "TinyGo"}}
+
+[Visit the Spin SDK reference documentation.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2)
 
 | Feature | SDK Supported? |
 |-----|-----|

--- a/content/spin/v2/rdbms-storage.md
+++ b/content/spin/v2/rdbms-storage.md
@@ -34,6 +34,8 @@ The exact detail of calling these operations from your application depends on yo
 
 {{ startTab "Rust"}}
 
+> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/rust-docs/spin/main/spin_sdk/index.html)
+
 MySQL functions are available in the `spin_sdk::mysql` module, and PostgreSQL functions in the `spin_sdk::pg` module. The function names match the operations above. This example shows MySQL:
 
 ```rust
@@ -114,6 +116,8 @@ The Python SDK doesn't currently surface the MySQL or PostgreSQL APIs.
 {{ blockEnd }}
 
 {{ startTab "TinyGo"}}
+
+> [**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2)
 
 MySQL functions are available in the `github.com/fermyon/spin/sdk/go/v2/mysql` package, and PostgreSQL in `github.com/fermyon/spin/sdk/go/v2/pg`. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2)
 

--- a/content/spin/v2/redis-outbound.md
+++ b/content/spin/v2/redis-outbound.md
@@ -40,6 +40,8 @@ The exact detail of calling these operations from your application depends on yo
 
 {{ startTab "Rust"}}
 
+> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/rust-docs/spin/main/spin_sdk/redis/index.html)
+
 Redis functions are available in the `spin_sdk::redis` module.
 
 To access a Redis instance, use the `Connection::open` function.
@@ -133,6 +135,8 @@ You can find a complete Python code example for using outbound Redis from an HTT
 {{ blockEnd }}
 
 {{ startTab "TinyGo"}}
+
+> [**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/redis)
 
 Redis functions are available in the `github.com/fermyon/spin/sdk/go/v2/redis` package. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2/redis) The function names are TitleCased. For example:
 

--- a/content/spin/v2/redis-trigger.md
+++ b/content/spin/v2/redis-trigger.md
@@ -61,6 +61,8 @@ The exact signature of the Redis handler, and how a function is identified to be
 
 {{ startTab "Rust"}}
 
+> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/rust-docs/spin/main/spin_sdk/index.html)
+
 In Rust, the handler is identified by the `#[spin_sdk::redis_component]` attribute.  It takes a `bytes::Bytes`, representing the raw payload of the Redis message, and returns an `anyhow::Result` indicating success or an error with details.  This example just logs the payload as a string:
 
 ```rust
@@ -92,6 +94,8 @@ The Python SDK doesn't currently support Redis components.  Please [let us know]
 {{ blockEnd }}
 
 {{ startTab "TinyGo"}}
+
+> [**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/redis)
 
 In Go, you register the handler as a callback in your program's `init` function.  Call `redis.Handle` (from the Spin SDK `redis` package), passing your handler as the sole argument.  Your handler takes a single byte slice (`[]byte`) argument, and may return an error or `nil`.
 

--- a/content/spin/v2/rust-components.md
+++ b/content/spin/v2/rust-components.md
@@ -33,6 +33,8 @@ official resources for learning Rust](https://www.rust-lang.org/learn).
 
 > All examples from this page can be found in [the Spin repository on GitHub](https://github.com/fermyon/spin/tree/main/examples).
 
+[**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://fermyon.github.io/rust-docs/spin/main/spin_sdk/index.html)
+
 ## Prerequisites
 
 ### Install the Templates

--- a/content/spin/v2/serverless-ai-api-guide.md
+++ b/content/spin/v2/serverless-ai-api-guide.md
@@ -62,6 +62,8 @@ The exact detail of calling these operations from your application depends on yo
 
 {{ startTab "Rust"}}
 
+> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/rust-docs/spin/main/spin_sdk/llm/index.html)
+
 To use Serverless AI functions, the `llm` module from the Spin SDK provides the methods. The following snippet is from the [Rust code generation example](https://github.com/fermyon/ai-examples/tree/main/code-generator-rs):
 
 <!-- @nocpy -->
@@ -168,6 +170,8 @@ def handle_request(request):
 {{ blockEnd }}
 
 {{ startTab "TinyGo"}}
+
+> [**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/llm)
 
 Serverless AI functions are available in the `github.com/fermyon/spin/sdk/go/v2/llm` package. See [Go Packages](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2/llm) for reference documentation. For example:
 

--- a/content/spin/v2/sqlite-api-guide.md
+++ b/content/spin/v2/sqlite-api-guide.md
@@ -45,6 +45,8 @@ The exact detail of calling these operations from your application depends on yo
 
 {{ startTab "Rust"}}
 
+> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/rust-docs/spin/main/spin_sdk/sqlite/index.html)
+
 SQLite functions are available in the `spin_sdk::sqlite` module. The function names match the operations above. For example:
 
 ```rust
@@ -151,6 +153,8 @@ def handle_request(request):
 {{ blockEnd }}
 
 {{ startTab "TinyGo"}}
+
+> [**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/sqlite)
 
 The Go SDK is implemented as a driver for the standard library's [database/sql](https://pkg.go.dev/database/sql) interface.
 

--- a/content/spin/v2/variables.md
+++ b/content/spin/v2/variables.md
@@ -83,6 +83,8 @@ The exact details of calling the config SDK from a Spin application depends on t
 
 {{ startTab "Rust"}}
 
+> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/rust-docs/spin/main/spin_sdk/variables/index.html)
+
 The interface is available in the `spin_sdk::variables` module and is named `get`.
 
 ```rust
@@ -168,6 +170,8 @@ def handle_request(request):
 {{ blockEnd }}
 
 {{ startTab "TinyGo"}}
+
+> [**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/variables)
 
 The function is available in the `github.com/fermyon/spin/sdk/go/v2/variables` package and is named `Get`. See [Go package](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2/variables) for reference documentation.
 


### PR DESCRIPTION
Although we link specific Rust and Go SDK members, there are no prominent links to the published SDK docs as a whole.  This PR adds SDK links (either whole-SDK or the specific subset) at the top of each language tab so that users who just want the reference can dive across, hopefully without it getting too much in the way of readers who want to get a bit more explanation!

Examples of how it looks:

**Language support overview**

![image](https://github.com/fermyon/developer/assets/865538/f8b40100-0f1f-47bf-b563-2ff2ce5421d4)

**Language guide**

![image](https://github.com/fermyon/developer/assets/865538/f4a46bda-93ad-4257-860a-a35dcdd4b06e)

**Trigger docs**

![image](https://github.com/fermyon/developer/assets/865538/63bf0d32-f906-4100-a312-40cf24ca3c03)

**API guides**

![image](https://github.com/fermyon/developer/assets/865538/0bb8dc29-fed5-4d8b-9965-b1c859c0357e)

I've raised issues for JS and Python reference docs and the idea is to link those in a consistent style when we have them.


Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
