### PR TITLE
Adding http-auth-middleware to SUH

### DIFF
--- a/content/api/hub/sample_http_auth_middleware.md
+++ b/content/api/hub/sample_http_auth_middleware.md
@@ -23,6 +23,7 @@ This sample shows how to compose a middleware component with a business logic co
 ## Instructions
 
 ### Install Prerequisites
+
 * Install [`cargo component`](https://github.com/bytecodealliance/cargo-component):
 
 ```bash

--- a/content/api/hub/sample_http_auth_middleware.md
+++ b/content/api/hub/sample_http_auth_middleware.md
@@ -45,7 +45,6 @@ cargo install --git https://github.com/dicej/wasm-tools --branch wasm-compose-re
 ### Build And Run The Spin App
 
 ```bash
-
 # Build the middleware
 cargo component build --manifest-path github-oauth/Cargo.toml --release
 

--- a/content/api/hub/sample_http_auth_middleware.md
+++ b/content/api/hub/sample_http_auth_middleware.md
@@ -29,13 +29,13 @@ This sample shows how to compose a middleware component with a business logic co
 cargo install --git https://github.com/bytecodealliance/cargo-component cargo-component
 ```
 
-* Install a fork of [wasm-tools]():
+* Install a fork of [wasm-tools](https://github.com/dicej/wasm-tools/tree/wasm-compose-resource-imports):
 
 ```bash
 cargo install --git https://github.com/dicej/wasm-tools --branch wasm-compose-resource-imports wasm-tools --locked
 ```
 
-* Install latest [Spin](https://github.com/fermyon/spin)
+* Install latest [Spin](https://developer.fermyon.com/spin/v2/install)
 * Create an OAuth App in your [GitHub Developer Settings](https://github.com/settings/developers). 
   * Set the callback URL to `http://127.0.0.1:3000/login/callback`. 
   * Accept defaults and input dummy values for the rest of the fields.

--- a/content/api/hub/sample_http_auth_middleware.md
+++ b/content/api/hub/sample_http_auth_middleware.md
@@ -23,7 +23,7 @@ This sample shows how to compose a middleware component with a business logic co
 ## Instructions
 
 ### Install Prerequisites
-* Install the [cargo component](https://github.com/bytecodealliance/cargo-component):
+* Install [`cargo component`](https://github.com/bytecodealliance/cargo-component):
 
 ```bash
 cargo install --git https://github.com/bytecodealliance/cargo-component cargo-component

--- a/content/api/hub/sample_http_auth_middleware.md
+++ b/content/api/hub/sample_http_auth_middleware.md
@@ -10,7 +10,7 @@ type = "hub_document"
 category = "Sample"
 language = "rust"
 created_at = "2023-11-03T00:00:00Z"
-last_updated = "2023-11-073T00:00:00Z"
+last_updated = "2023-11-07T00:00:00Z"
 spin_version = ">=v2.0"
 summary =  "Example of how to compose a middleware component with a business logic component"
 url = "https://github.com/fermyon/http-auth-middleware"
@@ -22,7 +22,7 @@ This sample shows how to compose a middleware component with a business logic co
 
 ## Instructions
 
-### Install prerequities
+### Install Prerequisites
 * Install the [cargo component](https://github.com/bytecodealliance/cargo-component):
 
 ```bash
@@ -42,7 +42,7 @@ cargo install --git https://github.com/dicej/wasm-tools --branch wasm-compose-re
   * Save the Client ID
   * Generate a new Client Secret and save that as well
 
-### Build the components and run the Spin App
+### Build And Run The Spin App
 
 ```bash
 

--- a/content/api/hub/sample_http_auth_middleware.md
+++ b/content/api/hub/sample_http_auth_middleware.md
@@ -1,0 +1,63 @@
+title = "HTTP Auth Middleware"
+template = "render_hub_content_body"
+date = "2023-11-03T00:00:00Z"
+content-type = "text/html"
+tags = ["rust", "authentication", "http"]
+
+[extra]
+author = "fermyon"
+type = "hub_document"
+category = "Sample"
+language = "rust"
+created_at = "2023-11-03T00:00:00Z"
+last_updated = "2023-11-073T00:00:00Z"
+spin_version = ">=v2.0"
+summary =  "Example of how to compose a middleware component with a business logic component"
+url = "https://github.com/fermyon/http-auth-middleware"
+keywords = "rust, http, auth"
+
+---
+
+This sample shows how to compose a middleware component with a business logic component using Spin 2.0 and the Component Model. 
+
+## Instructions
+
+### Install prerequities
+* Install the [cargo component](https://github.com/bytecodealliance/cargo-component):
+
+```bash
+cargo install --git https://github.com/bytecodealliance/cargo-component cargo-component
+```
+
+* Install a fork of [wasm-tools]():
+
+```bash
+cargo install --git https://github.com/dicej/wasm-tools --branch wasm-compose-resource-imports wasm-tools --locked
+```
+
+* Install latest [Spin](https://github.com/fermyon/spin)
+* Create an OAuth App in your [GitHub Developer Settings](https://github.com/settings/developers). 
+  * Set the callback URL to `http://127.0.0.1:3000/login/callback`. 
+  * Accept defaults and input dummy values for the rest of the fields.
+  * Save the Client ID
+  * Generate a new Client Secret and save that as well
+
+### Build the components and run the Spin App
+
+```bash
+
+# Build the middleware
+cargo component build --manifest-path github-oauth/Cargo.toml --release
+
+# Build and run the example
+spin up --build -f example -e CLIENT_ID=<YOUR_GITHUB_APP_CLIENT_ID> -e CLIENT_SECRET=<YOUR_GITHUB_APP_CLIENT_SECRET>
+
+# Open http://127.0.0.1:3000/login in a browser
+
+# Deploy to Fermyon Cloud
+spin cloud deploy
+```
+
+## Running with Wasmtime
+
+Please visit the [G]itHub repository](https://github.com/fermyon/http-auth-middleware#running-with-wasmtime) for detailed instructions on how to run with Wasmtime. 

--- a/content/api/hub/sample_http_auth_middleware.md
+++ b/content/api/hub/sample_http_auth_middleware.md
@@ -18,7 +18,7 @@ keywords = "rust, http, auth"
 
 ---
 
-This sample shows how to compose a middleware component with a business logic component using Spin 2.0 and the Component Model. 
+This sample shows how to compose a middleware component with a business logic component using [Spin 2.0](https://www.fermyon.com/blog/introducing-spin-v2) and the Component Model. 
 
 ## Instructions
 

--- a/content/api/hub/sample_http_auth_middleware.md
+++ b/content/api/hub/sample_http_auth_middleware.md
@@ -8,7 +8,7 @@ tags = ["rust", "authentication", "http"]
 author = "fermyon"
 type = "hub_document"
 category = "Sample"
-language = "rust"
+language = “Rust"
 created_at = "2023-11-03T00:00:00Z"
 last_updated = "2023-11-07T00:00:00Z"
 spin_version = ">=v2.0"


### PR DESCRIPTION
Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors
- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
