### PR TITLE
Fix response body for outbound Rust HTTP example

### DIFF
--- a/content/spin/v2/rust-components.md
+++ b/content/spin/v2/rust-components.md
@@ -223,7 +223,7 @@ async fn send_outbound(_req: Request) -> Result<impl IntoResponse> {
         .body(())?;
 
     // Send the request and await the response
-    let mut res: http::Response<()> = spin_sdk::http::send(req).await?;
+    let mut res: http::Response<String> = spin_sdk::http::send(req).await?;
 
     // Demonstrate modifying the response before passing it
     // back to the client


### PR DESCRIPTION
The example code does not currently work as expected (i.e., it does not return a response with a body). This fixes that.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title, `template`, and `date` are all set
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
