### PR TITLE
Add Python SDK reference links

### DIFF
--- a/content/spin/v2/http-outbound.md
+++ b/content/spin/v2/http-outbound.md
@@ -99,7 +99,9 @@ You can find a complete example of using outbound HTTP in the JavaScript SDK rep
 
 {{ startTab "Python"}}
 
-HTTP functions and classes are available in the `spin_http` module. The function name is `http_send`. The request type is `Request`, and the response type is `Response`. For example:
+> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-python-sdk/spin_http.html)
+
+HTTP functions and classes are available in the `spin_http` module. The function name is [`http_send`](https://fermyon.github.io/spin-python-sdk/spin_http.html#spin_sdk.spin_http.http_send). The [request type](https://fermyon.github.io/spin-python-sdk/spin_http.html#spin_sdk.spin_http.Request) is `Request`, and the [response type](https://fermyon.github.io/spin-python-sdk/spin_http.html#spin_sdk.spin_http.Response) is `Response`. For example:
 
 ```python
 from spin_http import Request, Response, http_send
@@ -121,7 +123,7 @@ You can find a complete example for using outbound HTTP in the [Python SDK repos
 
 {{ startTab "TinyGo"}}
 
-> [**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/http)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/http)
 
 HTTP functions are available in the `github.com/fermyon/spin/sdk/go/v2/http` package. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2/http) The general function is named `Send`, but the Go SDK also surfaces individual functions, with request-specific parameters, for the `Get` and `Post` operations. For example:
 

--- a/content/spin/v2/http-trigger.md
+++ b/content/spin/v2/http-trigger.md
@@ -244,7 +244,7 @@ For a full Rust SDK reference, see the [Rust Spin SDK documentation](https://fer
 
 {{ startTab "TypeScript"}}
 
-[**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/)
 
 In JavaScript or TypeScript, the handler is identified by name.  It must be called `handleRequest`.  The way you declare it is slightly different between the two languages.
 
@@ -278,6 +278,8 @@ export const handleRequest: HandleRequest = async function(request: HttpRequest)
 
 {{ startTab "Python"}}
 
+> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-python-sdk/)
+
 In Python, the handler is identified by name.  It must be called `handle_request`.  It takes a request object and must return an instance of `Response`, defined in the `spin_http` package:
 
 ```python
@@ -293,7 +295,7 @@ def handle_request(request):
 
 {{ startTab "TinyGo"}}
 
-> [**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/http)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/http)
 
 In Go, you register the handler as a callback in your program's `init` function.  Call `spinhttp.Handle`, passing your handler as the sole argument.  Your handler takes a `http.Request` record, from the standard `net/http` package, and a `ResponseWriter` to construct the response.
 

--- a/content/spin/v2/kv-store-api-guide.md
+++ b/content/spin/v2/kv-store-api-guide.md
@@ -79,7 +79,7 @@ fn handle_request(_req: Request) -> Result<impl IntoResponse> {
 
 {{ startTab "Typescript"}}
 
-[**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/)
 
 With Typescript, the key value functions can be accessed after opening a store using either [the `Kv.open` or the `Kv.openDefault` methods](https://fermyon.github.io/spin-js-sdk/variables/Kv.html) which returns a [handle to the store](https://fermyon.github.io/spin-js-sdk/interfaces/_internal_.KvStore.html). For example:
 
@@ -115,6 +115,8 @@ export const handleRequest: HandleRequest = async function (request: HttpRequest
 
 {{ startTab "Python"}}
 
+> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-python-sdk/spin_key_value.html)
+
 The key value functions are provided through the `spin_key_value` module in the Python SDK. For example:
 
 ```python
@@ -134,7 +136,7 @@ def handle_request(request):
 
 **General Notes**
 
-`get` **Operation**
+[`get` **Operation**](https://fermyon.github.io/spin-python-sdk/spin_key_value.html#spin_sdk.spin_key_value.Store.get)
 - If a key does not exist, it returns `None`
 
 {{ blockEnd }}

--- a/content/spin/v2/language-support-overview.md
+++ b/content/spin/v2/language-support-overview.md
@@ -59,6 +59,8 @@ This page contains information about language support for Spin features:
 
 {{ startTab "Python"}}
 
+[Visit the Spin SDK reference documentation.](https://fermyon.github.io/spin-python-sdk/)
+
 | Feature | SDK Supported? |
 |-----|-----|
 | **Triggers** |

--- a/content/spin/v2/python-components.md
+++ b/content/spin/v2/python-components.md
@@ -26,6 +26,8 @@ With <a href="https://www.python.org/" target="_blank">Python</a> being a very p
 
 > This guide assumes you are familiar with the Python programming language, but if you are just getting started, be sure to check out <a href="https://docs.python.org/3/" target="_blank">the official Python documentation</a> and comprehensive <a href="https://docs.python.org/3/reference/" target="_blank">language reference</a>.
 
+[**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://fermyon.github.io/spin-python-sdk/)
+
 **Please note:** There is a blog article [introducing the release of this Spin Python SDK](https://www.fermyon.com/blog/spin-python-sdk) if you are interested in some further reading; in addition to this technical documentation.
 
 ## Spin's Python Plugin

--- a/content/spin/v2/rdbms-storage.md
+++ b/content/spin/v2/rdbms-storage.md
@@ -70,7 +70,7 @@ For full information about the MySQL and PostgreSQL APIs, see [the Spin SDK refe
 
 {{ startTab "TypeScript"}}
 
-[**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/)
 
 The code below is an [Outbound MySQL example](https://github.com/fermyon/spin-js-sdk/tree/main/examples/typescript/outbound_mysql). There is also an outbound [PostgreSQL example](https://github.com/fermyon/spin-js-sdk/tree/main/examples/typescript/outbound_pg) available.
 
@@ -119,7 +119,7 @@ The Python SDK doesn't currently surface the MySQL or PostgreSQL APIs.
 
 {{ startTab "TinyGo"}}
 
-> [**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2)
 
 MySQL functions are available in the `github.com/fermyon/spin/sdk/go/v2/mysql` package, and PostgreSQL in `github.com/fermyon/spin/sdk/go/v2/pg`. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2)
 

--- a/content/spin/v2/redis-outbound.md
+++ b/content/spin/v2/redis-outbound.md
@@ -88,7 +88,7 @@ You can find a complete Rust code example for using outbound Redis from an HTTP 
 
 {{ startTab "TypeScript"}}
 
-[**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/)
 
 Redis functions are available on [the `Redis` object](https://fermyon.github.io/spin-js-sdk/variables/Redis.html). The function names match the operations above, but you must pass the Redis instance address to _each_ operation as its first parameter. For example:
 
@@ -116,7 +116,9 @@ You can find a complete TypeScript example for using outbound Redis from an HTTP
 
 {{ startTab "Python"}}
 
-Redis functions are available in the `spin_redis` module. The function names are prefixed `redis_`. You must pass the Redis instance address to _each_ operation as its first parameter. For example:
+> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-python-sdk/spin_redis.html)
+
+Redis functions are available in [the `spin_redis` module](https://fermyon.github.io/spin-python-sdk/spin_redis.html). The function names are prefixed `redis_`. You must pass the Redis instance address to _each_ operation as its first parameter. For example:
 
 ```python
 from spin_redis import redis_get
@@ -138,7 +140,7 @@ You can find a complete Python code example for using outbound Redis from an HTT
 
 {{ startTab "TinyGo"}}
 
-> [**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/redis)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/redis)
 
 Redis functions are available in the `github.com/fermyon/spin/sdk/go/v2/redis` package. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2/redis) The function names are TitleCased. For example:
 

--- a/content/spin/v2/redis-trigger.md
+++ b/content/spin/v2/redis-trigger.md
@@ -95,7 +95,7 @@ The Python SDK doesn't currently support Redis components.  Please [let us know]
 
 {{ startTab "TinyGo"}}
 
-> [**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/redis)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/redis)
 
 In Go, you register the handler as a callback in your program's `init` function.  Call `redis.Handle` (from the Spin SDK `redis` package), passing your handler as the sole argument.  Your handler takes a single byte slice (`[]byte`) argument, and may return an error or `nil`.
 

--- a/content/spin/v2/serverless-ai-api-guide.md
+++ b/content/spin/v2/serverless-ai-api-guide.md
@@ -110,7 +110,7 @@ The `infer_with_options` examples, operation:
 
 {{ startTab "Typescript"}}
 
-[**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/variables/Llm.html)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/variables/Llm.html)
 
 To use Serverless AI functions, [the `Llm` module](https://fermyon.github.io/spin-js-sdk/variables/Llm.html) from the Spin SDK provides two methods: `infer` and `generateEmbeddings`. For example: 
 
@@ -148,6 +148,8 @@ export const handleRequest: HandleRequest = async function (request: HttpRequest
 
 {{ startTab "Python"}}
 
+> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-python-sdk/spin_llm.html)
+
 ```python
 from spin_http import Response
 from spin_llm import llm_infer
@@ -163,17 +165,17 @@ def handle_request(request):
 
 **General Notes**
 
-`llm_infer` operation:
+[`llm_infer` operation](https://fermyon.github.io/spin-python-sdk/spin_llm.html#spin_sdk.spin_llm.llm_infer):
 
-- It takes in the following arguments - model name and `prompt`. 
+- It takes in a model name, prompt text, and optionally a [parameter object](https://fermyon.github.io/spin-python-sdk/spin_llm.html#spin_sdk.spin_llm.LLMInferencingParams) to control the inferencing. 
 - The model name is passed in as a string (as shown above; `"llama2-chat"`).
-- The return value is a `string`.
+- The return value is am [`InferencingResult` object](https://fermyon.github.io/spin-python-sdk/spin_llm.html#spin_sdk.spin_llm.LLMInferencingResult) - use the `text` attribute to get the inferred response.
 
 {{ blockEnd }}
 
 {{ startTab "TinyGo"}}
 
-> [**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/llm)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/llm)
 
 Serverless AI functions are available in the `github.com/fermyon/spin/sdk/go/v2/llm` package. See [Go Packages](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2/llm) for reference documentation. For example:
 

--- a/content/spin/v2/sqlite-api-guide.md
+++ b/content/spin/v2/sqlite-api-guide.md
@@ -108,7 +108,7 @@ struct ToDo {
 
 {{ startTab "Typescript"}}
 
-[**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/variables/Sqlite.html)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/variables/Sqlite.html)
 
 To use SQLite functions, use [the `Sqlite.open` or `Sqlite.openDefault` function](https://fermyon.github.io/spin-js-sdk/variables/Sqlite.html) to obtain [a `SqliteStore` object](https://fermyon.github.io/spin-js-sdk/interfaces/_internal_.SqliteStore.html). `SqliteStore` provides the `execute` method as described above. For example:
 
@@ -131,7 +131,9 @@ const json = JSON.stringify(result.rows);
 
 {{ startTab "Python"}}
 
-To use SQLite functions, use the `spin_sqlite` module in the Python SDK. The `sqlite_open` and `sqlite_open_default` functions return a connection object. The connection object provides the `execute` method as described above. For example:
+> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-python-sdk/spin_sqlite.html)
+
+To use SQLite functions, use the `spin_sqlite` module in the Python SDK. The [`sqlite_open`](https://fermyon.github.io/spin-python-sdk/spin_sqlite.html#spin_sdk.spin_sqlite.sqlite_open) and [`sqlite_open_default`](https://fermyon.github.io/spin-python-sdk/spin_sqlite.html#spin_sdk.spin_sqlite.sqlite_open_default) functions return a [connection object](https://fermyon.github.io/spin-python-sdk/spin_sqlite.html#spin_sdk.spin_sqlite.SqliteConnection). The connection object provides the [`execute` method](https://fermyon.github.io/spin-python-sdk/spin_sqlite.html#spin_sdk.spin_sqlite.SqliteConnection.execute) as described above. For example:
 
 ```python
 from spin_http import Response
@@ -148,7 +150,7 @@ def handle_request(request):
 
 **General Notes**
 * Parameters are Python values (numbers, strings, and lists). Spin infers the underlying SQL type.
-* The `execute` method returns an object with `rows` and `columns` methods. `columns` returns a list of strings representing column names. `rows` is an array of rows, each of which is an array of Python values (as above) in the same order as `columns`.
+* The `execute` method returns [a `QueryResult` object](https://fermyon.github.io/spin-python-sdk/spin_sqlite.html#spin_sdk.spin_sqlite.QueryResult) with `rows` and `columns` methods. `columns` returns a list of strings representing column names. `rows` is an array of rows, each of which is an array of Python values (as above) in the same order as `columns`.
 * The connection object doesn't surface the `close` function.
 * Errors are surfaced as exceptions.
 
@@ -156,7 +158,7 @@ def handle_request(request):
 
 {{ startTab "TinyGo"}}
 
-> [**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/sqlite)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/sqlite)
 
 The Go SDK is implemented as a driver for the standard library's [database/sql](https://pkg.go.dev/database/sql) interface.
 

--- a/content/spin/v2/variables.md
+++ b/content/spin/v2/variables.md
@@ -116,7 +116,7 @@ fn handle_spin_example(req: Request) -> Result<impl IntoResponse> {
 
 {{ startTab "TypeScript"}}
 
-[**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/variables/Config.html)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/variables/Config.html)
 
 The function is available on [the `Config` object](https://fermyon.github.io/spin-js-sdk/variables/Config.html) and is named [`get`](https://fermyon.github.io/spin-js-sdk/interfaces/_internal_.SpinConfig.html#get).
 
@@ -149,7 +149,9 @@ export const handleRequest: HandleRequest = async function (request: HttpRequest
 
 {{ startTab "Python"}}
 
-The config function is available in the `spin_config` package and is named `config_get`.
+> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-python-sdk/spin_config.html)
+
+The config function is available in the `spin_config` package and is named [`config_get`](https://fermyon.github.io/spin-python-sdk/spin_config.html#spin_sdk.spin_config.config_get).
 
 > Note that the prefix/suffix is `config` rather than `variables`.
 
@@ -173,7 +175,7 @@ def handle_request(request):
 
 {{ startTab "TinyGo"}}
 
-> [**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/variables)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/variables)
 
 The function is available in the `github.com/fermyon/spin/sdk/go/v2/variables` package and is named `Get`. See [Go package](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2/variables) for reference documentation.
 


### PR DESCRIPTION
Also makes SDK reference links more consistent.

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
