### PR TITLE
docs(kubernetes.md): shim version bumps/updates

### DIFF
--- a/content/spin/v2/kubernetes.md
+++ b/content/spin/v2/kubernetes.md
@@ -251,7 +251,7 @@ Deis Labs provides a preconfigured K3d environment that can be run using this co
 <!-- @selectiveCpy -->
 
 ```console
-$ k3d cluster create wasm-cluster --image ghcr.io/deislabs/containerd-wasm-shims/examples/k3d:v0.8.0 -p "8081:80@loadbalancer" --agents 2 --registry-create mycluster-registry:12345
+$ k3d cluster create wasm-cluster --image ghcr.io/deislabs/containerd-wasm-shims/examples/k3d:v0.10.0 -p "8081:80@loadbalancer" --agents 2 --registry-create mycluster-registry:12345
 ```
 
 Create a file wasm-runtimeclass.yml and populate with the following information:
@@ -260,7 +260,7 @@ Create a file wasm-runtimeclass.yml and populate with the following information:
 apiVersion: node.k8s.io/v1
 kind: RuntimeClass
 metadata:
-  name: "wasmtime-spin-v1"
+  name: "wasmtime-spin"
 handler: "spin"
 ```
 
@@ -293,8 +293,10 @@ We provide the [spin-containerd-shim-installer](https://github.com/fermyon/spin-
 
 The version of the container image and Helm chart directly correlates to the version of the containerd shim. We recommend selecting the shim version that correlates the version of Spin that you use for your application(s). For simplicity, here is a table depicting the version matrix between Spin and the containerd shim.
 
-| [Spin](https://github.com/fermyon/spin/releases)              | [containerd-shim-spin-v1](https://github.com/deislabs/containerd-wasm-shims/releases) |
+| [Spin](https://github.com/fermyon/spin/releases)              | [containerd-shim-spin](https://github.com/deislabs/containerd-wasm-shims/releases) |
 | ------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| [v2.0.1](https://github.com/fermyon/spin/releases/tag/v2.0.1) | [v0.10.0](https://github.com/deislabs/containerd-wasm-shims/releases/tag/v0.10.0)       |
+| [v1.4.1](https://github.com/fermyon/spin/releases/tag/v1.4.1) | [v0.9.0](https://github.com/deislabs/containerd-wasm-shims/releases/tag/v0.9.0)       |
 | [v1.4.0](https://github.com/fermyon/spin/releases/tag/v1.4.0) | [v0.8.0](https://github.com/deislabs/containerd-wasm-shims/releases/tag/v0.8.0)       |
 | [v1.3.0](https://github.com/fermyon/spin/releases/tag/v1.3.0) | [v0.7.0](https://github.com/deislabs/containerd-wasm-shims/releases/tag/v0.7.0)       |
 | [v1.1.0](https://github.com/fermyon/spin/releases/tag/v1.1.0) | [v0.6.0](https://github.com/deislabs/containerd-wasm-shims/releases/tag/v0.6.0)       |
@@ -393,7 +395,7 @@ COPY ./spin_static_fs.wasm ./spin_static_fs.wasm
 COPY ./static ./static
 ```
 
-The deploy.yaml file defines the deployment to the Kubernetes server. By default the replicas is configured as 3, however this can be edited after the scaffolding stage and before the deployment stage. Additionally, the runtimeClassName is defined as wasmtime-spin-v1. It’s critical that that is the exact name used when setting up the Kubernetes service to support Spin, or that the deployment be edited to the appropriate name.
+The deploy.yaml file defines the deployment to the Kubernetes server. By default the replicas is configured as 3, however this can be edited after the scaffolding stage and before the deployment stage. Additionally, the runtimeClassName is defined as wasmtime-spin. It’s critical that that is the exact name used when setting up the Kubernetes service to support Spin, or that the deployment be edited to the appropriate name.
 
 deploy.yaml
 
@@ -412,7 +414,7 @@ spec:
       labels:
         app: test
     spec:
-      runtimeClassName: wasmtime-spin-v1
+      runtimeClassName: wasmtime-spin
       containers:
         - name: test
           image: chrismatteson/test:0.1.5
@@ -483,7 +485,7 @@ $ spin k8s deploy
 
 #### Spin K8s Getsvc
 
-The following command retrieves information about the service that gets deployed (such as it’s external IP):
+The following command retrieves information about the service that gets deployed (such as its external IP):
 
 <!-- @selectiveCpy -->
 


### PR DESCRIPTION
- Bumps to latest [v0.10.0](https://github.com/deislabs/containerd-wasm-shims/releases/tag/v0.10.0) version of the shim
- Updates RuntimeClassName to `wasmtime-spin` per https://github.com/deislabs/containerd-wasm-shims/blob/main/README.md?plain=1#L89 and https://github.com/chrismatteson/spin-plugin-k8s/blob/main/k8s#L138
- Updates Spin/shim version matrix

Fixes https://github.com/fermyon/developer/issues/1053

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
