### PR TITLE
ref(deploy): update to publish to ECR; simplify deployment logic

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - 'main'
+      # remove after testing
+      - 'vdice/ref/oci-deploy'
 
   workflow_dispatch:
     inputs:
@@ -12,12 +14,6 @@ on:
         default: 'refs/heads/main'
       commit:
         description: 'Commit SHA to deploy from (optional)'
-      environment:
-        type: choice
-        description: 'Environment to deploy to (Default: canary)'
-        options:
-          - canary
-          - prod
 
 # Construct a concurrency group to be shared across workflow runs.
 # The default behavior ensures that only one is running at a time, with
@@ -28,10 +24,6 @@ permissions:
   contents: read
   id-token: write # Allow the workflow to create a JWT for AWS auth
 
-env:
-  OCI_REGISTRY: index.docker.io
-  OCI_IMAGE_NAME: fermyon/developer
-
 jobs:
   echo-inputs:
     runs-on: ubuntu-latest
@@ -41,71 +33,71 @@ jobs:
         run: |
           echo ref: ${{ inputs.ref }}
           echo commit: ${{ inputs.commit }}
-          echo environment: ${{ inputs.environment }}
-
-  publish:
-      runs-on: ubuntu-latest
-      if: ${{ github.repository_owner == 'fermyon' }}
-      outputs:
-        oci_ref: ${{ env.OCI_REGISTRY }}/${{ env.OCI_IMAGE_NAME }}@${{ steps.push.outputs.digest }}
-      steps:
-        - uses: actions/checkout@v3
-
-        - name: Check out specific ref
-          if: ${{ github.event_name == 'workflow_dispatch' }} && ${{ inputs.ref != ''}}
-          run: git checkout ${{ inputs.ref }}
-
-        - name: Check out specific commit
-          if: ${{ github.event_name == 'workflow_dispatch' }} && ${{ inputs.commit != ''}}
-          run: git checkout ${{ inputs.commit }}
-
-        - name: Setup Node
-          uses: actions/setup-node@v3
-          with:
-            node-version: 16
-
-        - name: Setup Spin
-          uses: fermyon/actions/spin/setup@v1
-          with:
-            github_token: ${{ secrets.GITHUB_TOKEN }}
-            version: v2.0.0
-
-        - name: Install npm packages
-          run: |
-            npm ci
-            npm ci --prefix ./spin-up-hub
-
-        - name: Build app
-          run: |
-            spin build
-
-        - name: Construct OCI image tag
-          shell: bash
-          run: |
-            [[ "${{ github.event_name }}" == "push" ]] && \
-              echo "IMAGE_TAG=latest" >> $GITHUB_ENV || \
-              echo "IMAGE_TAG=canary" >> $GITHUB_ENV
-
-        - name: Login and Publish Spin app
-          id: push
-          uses: fermyon/actions/spin/push@v1
-          with:
-            registry: ${{ env.OCI_REGISTRY }}
-            registry_username: fermyon
-            registry_password: ${{ secrets.DOCKERHUB_PAT }}
-            registry_reference: ${{ env.OCI_REGISTRY }}/${{ env.OCI_IMAGE_NAME }}:${{ env.IMAGE_TAG }}
-
-        - name: Cleanup login
-          if: ${{ always() }}
-          run: |
-            rm -rf /home/runner/fermyon
 
   deploy:
     runs-on: ubuntu-latest
-    needs: publish
     if: ${{ github.repository_owner == 'fermyon' }}
+    env:
+      OCI_IMAGE_NAME: developer
     steps:
       - uses: actions/checkout@v3
+
+      - name: Check out specific ref
+        if: ${{ github.event_name == 'workflow_dispatch' }} && ${{ inputs.ref != ''}}
+        run: git checkout ${{ inputs.ref }}
+
+      - name: Check out specific commit
+        if: ${{ github.event_name == 'workflow_dispatch' }} && ${{ inputs.commit != ''}}
+        run: git checkout ${{ inputs.commit }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Setup Spin
+        uses: fermyon/actions/spin/setup@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          version: v2.0.1
+
+      - name: Install npm packages
+        run: |
+          npm ci
+          npm ci --prefix ./spin-up-hub
+
+      - name: Build app
+        run: |
+          spin build
+
+      - name: Construct OCI image tag
+        shell: bash
+        run: |
+          [[ "${{ github.event_name }}" == "push" ]] && \
+            echo "IMAGE_TAG=latest" >> $GITHUB_ENV || \
+            echo "IMAGE_TAG=canary" >> $GITHUB_ENV
+
+      - name: Configure AWS Credentials for publishing
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_IAM_ROLE }}
+          role-session-name: ${{ env.OCI_IMAGE_NAME }}
+          aws-region: ${{ secrets.AWS_REGION_WEBSITES }}
+
+      - name: Log in to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Publish Spin app
+        id: push
+        uses: fermyon/actions/spin/push@v1
+        with:
+          registry_reference: ${{ steps.login-ecr.outputs.registry }}/${{ env.OCI_IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+
+      - name: Cleanup login
+        if: ${{ always() }}
+        run: |
+          rm -rf /home/runner/fermyon
 
       - name: Install Nomad
         env:
@@ -115,61 +107,21 @@ jobs:
           unzip nomad_${NOMAD_VERSION}_linux_$(dpkg --print-architecture).zip -d /usr/local/bin
           chmod +x /usr/local/bin/nomad
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+      - name: Tailscale
+        uses: tailscale/github-action@v2
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.INFRA_NAMESPACE }}-${{ secrets.AWS_REGION }}-gha-certs
-          role-session-name: fermyon-developer-deploy
-          aws-region: ${{ secrets.AWS_REGION }}
-
-      - name: Fetch Nomad Certs from S3
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          for cert in infra_ca \
-            api_client_cert_private_key \
-            api_client_cert_public_key; do
-
-            aws s3api get-object \
-              --bucket "infra-certs-${{ secrets.INFRA_NAMESPACE }}-${{ secrets.AWS_REGION }}" \
-              --key "${cert}" \
-              "/tmp/${cert}"
-          done
-
-      - name: Configure Nomad
-        shell: bash
-        run: |
-          echo "NOMAD_CACERT=/tmp/infra_ca" >> $GITHUB_ENV
-          echo "NOMAD_CLIENT_CERT=/tmp/api_client_cert_public_key" >> $GITHUB_ENV
-          echo "NOMAD_CLIENT_KEY=/tmp/api_client_cert_private_key" >> $GITHUB_ENV
-          echo "NOMAD_ADDR=https://nomad.${{ secrets.INFRA_NAMESPACE }}.${{ secrets.AWS_REGION }}.fermyon.link:4646" >> $GITHUB_ENV
-
-      - name: Configure manual deploy
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        shell: bash
-        run: |
-          if [[ "${{ inputs.environment }}" == "prod" ]]; then
-            echo "PRODUCTION=true" >> $GITHUB_ENV
-            echo "NOMAD_NAMESPACE=prod" >> $GITHUB_ENV
-          else
-            echo "PRODUCTION=false" >> $GITHUB_ENV
-            echo "NOMAD_NAMESPACE=staging" >> $GITHUB_ENV
-          fi
-
-      - name: Configure auto-deploy
-        if: ${{ github.event_name == 'push' }}
-        shell: bash
-        run: |
-          echo "PRODUCTION=true" >> $GITHUB_ENV
-          echo "NOMAD_NAMESPACE=prod" >> $GITHUB_ENV
+          oauth-client-id: ${{ secrets.TS_CI_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_CI_OAUTH_SECRET }}
+          tags: tag:ci
 
       - name: Deploy
         shell: bash
         run: |
+          export NOMAD_ADDR="${{ secrets.NOMAD_ADDR }}"
+          export NOMAD_NAMESPACE=websites
+
           nomad run \
-            -var "region=${{ secrets.AWS_REGION }}" \
-            -var "production=${{ env.PRODUCTION }}" \
+            -var "region=${{ secrets.AWS_REGION_WEBSITES }}" \
             -var "commit_sha=$(git rev-parse HEAD)" \
-            -var "oci_ref=${{ needs.publish.outputs.oci_ref }}" \
+            -var "ecr_ref=${{ steps.login-ecr.outputs.registry }}/${{ env.OCI_IMAGE_NAME }}@${{ steps.push.outputs.digest }}" \
             deploy/fermyon-developer.nomad

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -2,12 +2,6 @@
 
 The [Developer](https://developer.fermyon.com) website is deployed via the [deploy.yml](../.github/workflows/deploy.yml) GitHub workflow.
 
-## Publishing
-
-In advance of deployment, the Spin app for this website is published to an OCI registry.
-
-In the case of publishing from the `main` branch, both a mutable tag and an immutable tag is pushed: `latest` and `main-<commit sha>` respectively.
-
 ## Auto Deploys
 
 The production version of the website is deployed whenever commits are pushed to the `main` branch.
@@ -15,7 +9,7 @@ The production version of the website is deployed whenever commits are pushed to
 ## Manual Deploys
 
 Deployments may also be [triggered manually](https://github.com/fermyon/developer/actions/workflows/deploy.yml), providing a choice of git
-`ref`, `commit` and `environment` (eg canary or prod).
+`ref` and `commit`.
 
 ## Nomad job
 


### PR DESCRIPTION
- Updates the deployment mechanism of this website (GH workflow and nomad job) to use ECR as its registry, consistent with the other Fermyon websites
  - See also:
    - https://github.com/fermyon/spin/pull/2129
    - https://github.com/fermyon/bartholomew/pull/185
    - https://github.com/fermyon/installer/pull/135
- Simplifies deployment logic/Nomad job

Deployed successfully in https://github.com/fermyon/developer/actions/runs/7040103996/job/19160417298

TODO:
- [ ] remove the testing config from deploy.yaml after LGTM(s).
- [ ] Update DNS to point to new deployment prior to merge