### PR TITLE
Fix incorrect underscoring of ai-models directory

### DIFF
--- a/content/spin/v1/serverless-ai-api-guide.md
+++ b/content/spin/v1/serverless-ai-api-guide.md
@@ -35,10 +35,10 @@ ai_models = ["codellama-instruct"]
 
 ### File Structure
 
-By default, the Spin framework will expect any already trained model files (which are configured as per the previous section) to be downloaded by the user and made available inside a `.spin/ai_models/` file path of a given application. For example:
+By default, the Spin framework will expect any already trained model files (which are configured as per the previous section) to be downloaded by the user and made available inside a `.spin/ai-models/` file path of a given application. For example:
 
 ```bash
-code-generator-rs/.spin/ai_models/codellama-instruct
+code-generator-rs/.spin/ai-models/codellama-instruct
 ```
 
 See the [serverless AI Tutorial](./ai-sentiment-analysis-api-tutorial) documentation for more concrete examples of implementing the Fermyon Serverless AI API, in your favorite language.

--- a/content/spin/v2/serverless-ai-api-guide.md
+++ b/content/spin/v2/serverless-ai-api-guide.md
@@ -34,10 +34,10 @@ ai_models = ["codellama-instruct"]
 
 ### File Structure
 
-By default, the Spin framework will expect any already trained model files (which are configured as per the previous section) to be downloaded by the user and made available inside a `.spin/ai_models/` file path of a given application. For example:
+By default, the Spin framework will expect any already trained model files (which are configured as per the previous section) to be downloaded by the user and made available inside a `.spin/ai-models/` file path of a given application. For example:
 
 ```bash
-code-generator-rs/.spin/ai_models/codellama-instruct
+code-generator-rs/.spin/ai-models/codellama-instruct
 ```
 
 See the [serverless AI Tutorial](./ai-sentiment-analysis-api-tutorial) documentation for more concrete examples of implementing the Fermyon Serverless AI API, in your favorite language.


### PR DESCRIPTION
Fixes #1067.

I believe all remaining occurrences of `ai_models` with an underscore are referring to the `spin.toml` entry, where the underscore is correct.

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
