### PR TITLE
enable goal metrics in spin up hub

### DIFF
--- a/spin-up-hub/index.html
+++ b/spin-up-hub/index.html
@@ -7,7 +7,7 @@
     <script
       defer
       data-domain="developer.fermyon.com"
-      src="https://plausible.io/js/plausible.js"
+      src="https://plausible.io/js/script.tagged-events.js"
     ></script>
 
     <link rel="icon" type="image/png" href="/static/image/icon/favicon.png" />


### PR DESCRIPTION
Small edit, to enable [Plausible Goal metrics](https://plausible.io/docs/custom-event-goals). We added targeted event classes to see no. of clicks etc, but the JS include needs to be updated to get this working properly.  