### PR TITLE
Make link to SDK reference more prominent

### DIFF
--- a/content/spin/v2/language-support-overview.md
+++ b/content/spin/v2/language-support-overview.md
@@ -13,7 +13,7 @@ This page contains information about language support for Spin features:
 
 {{ startTab "Rust"}}
 
-**[📄 Visit the Rust Spin SDK reference documentation](https://fermyon.github.io/rust-docs/spin/main/spin_sdk/index.html) to see specific modules, functions, variables and syntax relating to the following Rust features.**
+**[📄 Visit the Rust Spin SDK reference documentation](https://docs.rs/spin-sdk/latest/spin_sdk/) to see specific modules, functions, variables and syntax relating to the following Rust features.**
 
 | Feature | SDK Supported? |
 |-----|-----|

--- a/content/spin/v2/language-support-overview.md
+++ b/content/spin/v2/language-support-overview.md
@@ -13,7 +13,7 @@ This page contains information about language support for Spin features:
 
 {{ startTab "Rust"}}
 
-[Visit the Spin SDK reference documentation.](https://fermyon.github.io/rust-docs/spin/main/spin_sdk/index.html)
+**[📄 Visit the Rust Spin SDK reference documentation](https://fermyon.github.io/rust-docs/spin/main/spin_sdk/index.html) to see specific modules, functions, variables and syntax relating to the following Rust features.**
 
 | Feature | SDK Supported? |
 |-----|-----|
@@ -36,7 +36,7 @@ This page contains information about language support for Spin features:
 
 {{ startTab "TypeScript"}}
 
-[Visit the Spin SDK reference documentation.](https://fermyon.github.io/spin-js-sdk/)
+**[📄 Visit the JS/TS Spin SDK reference documentation](https://fermyon.github.io/spin-js-sdk/) to see specific modules, functions, variables and syntax relating to the following TS/JS features.**
 
 | Feature | SDK Supported? |
 |-----|-----|
@@ -59,7 +59,7 @@ This page contains information about language support for Spin features:
 
 {{ startTab "Python"}}
 
-[Visit the Spin SDK reference documentation.](https://fermyon.github.io/spin-python-sdk/)
+**[📄 Visit the Python Spin SDK reference documentation](https://fermyon.github.io/spin-python-sdk/) to see specific modules, functions, variables and syntax relating to the following Python SDK.**
 
 | Feature | SDK Supported? |
 |-----|-----|
@@ -82,7 +82,7 @@ This page contains information about language support for Spin features:
 
 {{ startTab "TinyGo"}}
 
-[Visit the Spin SDK reference documentation.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2)
+**[📄 Visit the TinyGo Spin SDK reference documentation](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2) to see specific modules, functions, variables and syntax relating to the following TinyGo SDK.**
 
 | Feature | SDK Supported? |
 |-----|-----|


### PR DESCRIPTION
Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)

✅ content/spin/v2/language-support-overview.md

- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)

![Screenshot 2023-12-15 at 09 05 21](https://github.com/fermyon/developer/assets/9831342/20cd422a-53bf-4e01-ac54-3dba915a76eb)

- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors
- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
