### PR TITLE
Created docusaurus-spin template repository to Spin Up Hub

### DIFF
--- a/content/api/hub/template_docusaurus.md
+++ b/content/api/hub/template_docusaurus.md
@@ -1,0 +1,23 @@
+title = "Spin Docusaurus"
+template = "render_hub_content_body"
+date = "2023-12-14T04:30:32.000Z"
+content-type = "text/html"
+tags = ["javascript", "docusaurus", "react",]
+
+[extra]
+author = "VamshiReddy02"
+type = "hub_document"
+category = "Template"
+language = "JS/TS"
+created_at = "2023-12-14T04:30:32.000Z"
+last_updated = "2023-12-14T04:30:32.000Z"
+spin_version = ">v1.3"
+summary =  "A template to use docusaurus with Spin"
+url = "https://github.com/VamshiReddy02/spin-docusaurus"
+keywords = "react, docusaurus, javascript, typescript"
+
+---
+  
+This is a template for building and statically exporting your Docusaurus application and running it on Fermyon Spin.
+
+All you need to do is open the [spin-docusaurus](https://github.com/VamshiReddy02/spin-docusaurus) repository and install the template in your spin CLI. Once you've created your repository from the template, Run `npm install` and `npx start`, then start editing your application. Alternatively, you can run `spin build` and `spin up` to build and run your application.


### PR DESCRIPTION
This PR adds the [spin-docusaurus](https://github.com/VamshiReddy02/spin-docusaurus) template repository to the Spin Up Hub. I'm sorry for closing my Last PR because of some technical issues. All the requested changes have been made. please let me know if there are any further changes to be made. 

Fixes issues: #801 

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)

✅ content/api/hub/template_docusaurus.md

- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)

![Screenshot 2023-12-18 at 11 13 46](https://github.com/fermyon/developer/assets/9831342/4a82ea58-e65b-4706-b9f7-998b444e442f)

- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors
- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
