### PR TITLE
ollama api sample added

### DIFF
--- a/content/api/hub/sample_ollama.md
+++ b/content/api/hub/sample_ollama.md
@@ -1,0 +1,87 @@
+title = "Ollama Using Spin"
+template = "render_hub_content_body"
+date = "2022-10-15T00:22:56Z"
+content-type = "text/html"
+tags = ["rust", "ollama"]
+
+[extra]
+author = "Devashish Lal"
+type = "hub_document"
+category = "Sample"
+language = "Rust"
+created_at = "2023-12-12T02:00:00Z"
+last_updated = "2022-10-15T02:00:0Z"
+spin_version = ">v2.0"
+summary =  "Ollama api implementation using spin"
+url = "https://github.com/BLaZeKiLL/Spin-O-Llama"
+
+---
+
+This sample demonstrates how spin can be used to implement the [Ollama api](https://github.com/jmorganca/ollama/blob/main/docs/api.md), which when deployed can be used as any other Ollama instance. LLM orchestration frameworks like LangChain and semantic kernel can use this instance as a Ollama backend.
+
+## Quick Start
+- [Install spin](https://developer.fermyon.com/spin/v2/install)
+- login to fermeyon cloud
+    ```
+    spin login
+    ```
+- clone this repository
+    ```
+    git clone https://github.com/BLaZeKiLL/Spin-O-Llama.git
+    cd Spin-O-Llama
+    ```
+- build
+    ```
+    spin build
+    ```
+- deploy
+    ```
+    spin deploy
+    ```
+
+Routes implemented
+- POST [/api/generate](https://github.com/jmorganca/ollama/blob/main/docs/api.md#generate-a-completion)
+
+    supported request body
+    ```json
+    {
+        "model": "<supported-model>",
+        "prompt": "<input prompt>",
+        "stream": false // streaming not supported, has no impact
+        "options": { // options are optional
+            "num_predict": 128,
+            "temperature": 0.8,
+            "top_p": 0.9,
+            "repeat_penalty": 1.1
+        } // default values provided above
+    }
+    ```
+
+    response body
+    ```json
+    {
+        "model": "<model-id>",
+        "response": "<output>",
+        "done": true
+    }
+    ```
+- POST [/api/embeddings](https://github.com/jmorganca/ollama/blob/main/docs/api.md#generate-embeddings)
+
+    supported request body
+    ```json
+    {
+        "model": "<model-id>", // doesn't matter for now will always use all-minilm-l6-v2
+        "prompt": "<input>"
+    }
+    ```
+
+    response body
+    ```json
+    {
+        "embedding": [<float array>]
+    }
+    ```
+
+Model compatibility
+- generate - llama2-chat, codellama-instruct
+- embeddings - all-minilm-l6-v2

--- a/content/api/hub/sample_ollama.md
+++ b/content/api/hub/sample_ollama.md
@@ -2,7 +2,7 @@ title = "Ollama Using Spin"
 template = "render_hub_content_body"
 date = "2022-10-15T00:22:56Z"
 content-type = "text/html"
-tags = ["rust", "ollama"]
+tags = ["rust", "ollama", "llm", "ai"]
 
 [extra]
 author = "Devashish Lal"
@@ -14,6 +14,7 @@ last_updated = "2022-10-15T02:00:0Z"
 spin_version = ">v2.0"
 summary =  "Ollama api implementation using spin"
 url = "https://github.com/BLaZeKiLL/Spin-O-Llama"
+keywords = "rust, ollama, llm, ai"
 
 ---
 


### PR DESCRIPTION
This sample showcases Ollama api implementation using spin.

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
![image](https://github.com/fermyon/developer/assets/33104478/289799fd-58bf-4248-a941-e07aac5a0001)
- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
![image](https://github.com/fermyon/developer/assets/33104478/94d2efd7-6d69-4b6c-bcb5-1c64676b4e4f)
- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors
