### PR TITLE
Add 11ty-spin template repository to Spin Up Hub

### DIFF
--- a/content/api/hub/sample_11ty.md
+++ b/content/api/hub/sample_11ty.md
@@ -1,0 +1,23 @@
+title = "Spin 11ty"
+template = "render_hub_content_body"
+date = "2023-12-19T04:30:32.000Z"
+content-type = "text/html"
+tags = ["javascript", "11ty", "Fermyon Cloud",]
+
+[extra]
+author = "VamshiReddy02"
+type = "hub_document"
+category = "Sample"
+language = "JS/TS"
+created_at = "2023-12-19T04:30:32.000Z"
+last_updated = "2023-12-19T04:30:32.000Z"
+spin_version = ">v1.3"
+summary =  "A template to use 11ty with Spin"
+url = "https://github.com/VamshiReddy02/spin-11ty"
+keywords = "html, 11ty, javascript, Nunjucks"
+
+---
+  
+This is a template for building and statically exporting your 11ty application and running it on Fermyon Spin.
+
+All you need to do is open the [spin-11ty](https://github.com/VamshiReddy02/spin-11ty) repository and click the "Use this template" button. Once you've created your repository from the template, Run `npm install` and `npx start`, then start editing your application. Alternatively, you can run `spin build` and `spin up` to build and run your application.


### PR DESCRIPTION
This PR adds the [spin-11ty](https://github.com/VamshiReddy02/spin-11ty) template repository to the Spin Up Hub.

Fixes issues: #802 

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors
- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
