### PR TITLE
Fixed the AI bookmarker card title

### DIFF
--- a/content/api/hub/sample_bookmarker.md
+++ b/content/api/hub/sample_bookmarker.md
@@ -1,8 +1,8 @@
-title = "Bookmarker: An AI-powered Bookmarking Web App"
+title = "AI Bookmarker: Smart Bookmarking Web App"
 template = "render_hub_content_body"
 date = "2023-12-08T00:22:56Z"
 content-type = "text/html"
-tags = ["python", "serverless-ai", "web", "key-value"]
+tags = ["python", "serverless-ai", "key-value"]
 
 [extra]
 author = "technosophos"


### PR DESCRIPTION
I renamed the title of "Bookmarker: An AI-powered Bookmarking Web App" to "AI Bookmarker: Smart Bookmarking Web App" because it overlapped with tags that did not look good. It's a temporary fix for now.

Before changes:
<img width="363" alt="Screenshot 2023-12-28 at 1 32 17 PM" src="https://github.com/fermyon/developer/assets/99033623/00637c0a-cd7e-4cf5-85f4-bc73a297d91a">

After changes:
<img width="367" alt="Screenshot 2023-12-28 at 1 31 25 PM" src="https://github.com/fermyon/developer/assets/99033623/5b14bb4d-9c86-426f-ba1c-afcbb120bc2a">



## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
