### PR TITLE
Fixed "qr code" problem in hub search

### DIFF
--- a/content/api/hub/sample_redirect.md
+++ b/content/api/hub/sample_redirect.md
@@ -14,7 +14,7 @@ last_updated = "2023-08-14T00:00:00Z"
 spin_version = ">v1.0"
 summary =  "A sample of using mulitple components to create an app"
 url = "https://github.com/mikkelhegn/redirect"
-keywords = "rust, static content, components, html"
+keywords = "rust, static content, components, html, qr code"
 
 ---
 


### PR DESCRIPTION
Fixes #1097 

Result:
<img width="1440" alt="Screenshot 2023-12-28 at 2 12 58 PM" src="https://github.com/fermyon/developer/assets/99033623/57c3194b-6c8b-4214-97d1-d4cae4886531">


## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
