### PR TITLE
Created Nuxtjs-spin template repository to Spin Up Hub

### DIFF
--- a/content/api/hub/template_nuxt.md
+++ b/content/api/hub/template_nuxt.md
@@ -1,0 +1,36 @@
+title = "NuxtJS SSG Template"
+template = "render_hub_content_body"
+date = "2023-12-31T00:22:56Z"
+content-type = "text/html"
+tags = ["javascript", "Nuxt", "Vue"]
+
+[extra]
+author = "VamshiReddy02"
+type = "hub_document"
+category = "Template"
+language = "JS/TS"
+created_at = "2024-01-01T00:22:56Z"
+last_updated = "2024-01-01T00:22:56Z"
+spin_version = ">v1.3"
+summary =  "A template to use NuxtJS with Spin"
+url = "https://github.com/VamshiReddy02/spin-nuxt"
+keywords = "vue, nuxt, js, javascript"
+
+---
+
+This is a template for using [NuxtJS](https://nuxt.com/docs/getting-started/introduction) to create a static webpage.
+
+
+Install the template
+```bash
+$ spin templates install --upgrade --git https://github.com/VamshiReddy02/spin-nuxt
+```
+
+## Creating and Running
+You can create a new Spin app with `spin new` or add to an existing Spin app with `spin add` 
+
+```bash
+$ spin new my-nuxt -t Nuxt
+$ cd my-nuxt-app
+$ spin build 
+```

--- a/content/api/hub/template_nuxt.md
+++ b/content/api/hub/template_nuxt.md
@@ -20,7 +20,6 @@ keywords = "vue, nuxt, js, javascript"
 
 This is a template for using [NuxtJS](https://nuxt.com/docs/getting-started/introduction) to create a static webpage.
 
-
 Install the template
 ```bash
 $ spin templates install --upgrade --git https://github.com/VamshiReddy02/spin-nuxt


### PR DESCRIPTION
This PR adds the [spin-nuxtjs](https://github.com/VamshiReddy02/spin-nuxt) template repository to the Spin Up Hub. Please let me know if there are any further changes to be made. 

Fixes issue: #800 

And also Happy New Year to the Fermyon team and its community.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
