### PR TITLE
More info about template syntax

### DIFF
--- a/content/spin/v2/template-authoring.md
+++ b/content/spin/v2/template-authoring.md
@@ -6,6 +6,7 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/v2/template-a
 
 ---
 - [Authoring the Content](#authoring-the-content)
+  - [Expression Syntax](#expression-syntax)
 - [Authoring the Manifest](#authoring-the-manifest)
 - [Supporting `spin add`](#supporting-spin-add)
 - [Hosting Templates in Git](#hosting-templates-in-git)
@@ -53,6 +54,12 @@ are supported:
 | `kebab_case`  | Transforms input into kebab case, e.g. `My Application` to `my-application` |
 | `snake_case`  | Transforms input into snake case, e.g. `My Application` to `my_application` |
 | `pascal_case` | Transforms input into Pascal case, e.g. `my application` to `MyApplication` |
+
+### Expression Syntax
+
+Content uses [the Liquid template language](https://shopify.github.io/liquid/). See the Liquid documentation for the available syntax and control tags.
+
+A common pitfall occurs because some entries in `spin.toml`, such as [component variable templates](variables), use the same double-brace syntax as Liquid does. If you want to generate a line such as `my-secret = "{{ secret }}"`, you must escape the double braces, for example using the Liquid [`raw` tag](https://shopify.github.io/liquid/tags/template/). If you don't do this, Liquid will look for a template parameter called `secret` instead!
 
 ## Authoring the Manifest
 


### PR DESCRIPTION
Addresses https://github.com/fermyon/spin/issues/2205.

(The change is true for both Spin 1 and Spin 2, but I added it only to Spin 2 because my understanding is that Spin 1 content is considered archived unless circumstances warrant, and this... didn't seem to warrant.  If we are containuing to maintain Spin 1 copies then I can easily add it there too.)

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
