### PR TITLE
Remove links to Rust target spec docs

### DIFF
--- a/content/bartholomew/contributing-bartholomew.md
+++ b/content/bartholomew/contributing-bartholomew.md
@@ -75,7 +75,7 @@ Installing Rust via the<a href="https://www.rust-lang.org/tools/install" target=
 
 **wasm32-wasi**
 
-Installing the <a href="https://doc.rust-lang.org/stable/nightly-rustc/rustc_target/spec/wasm32_wasi/index.html" target="_blank">wasm32-wasi</a> target is done using the following commands:
+To install the `wasm32-wasi` target, run the following commands:
 
 <!-- @selectiveCpy -->
 

--- a/content/spin/v1/rust-components.md
+++ b/content/spin/v1/rust-components.md
@@ -443,8 +443,7 @@ Spin provides clients for MySQL and PostgreSQL. For information about using them
 ## Using External Crates in Rust Components
 
 In Rust, Spin components are regular libraries that contain a function
-annotated using the `http_component` macro, compiled to the
-[`wasm32-wasi` target](https://doc.rust-lang.org/stable/nightly-rustc/rustc_target/spec/wasm32_wasi/index.html).
+annotated using the `http_component` macro, compiled to the `wasm32-wasi` target.
 This means that any [crate](https://crates.io) that compiles to `wasm32-wasi` can
 be used when implementing the component.
 

--- a/content/spin/v2/rust-components.md
+++ b/content/spin/v2/rust-components.md
@@ -500,8 +500,7 @@ Spin provides clients for MySQL and PostgreSQL. For information about using them
 ## Using External Crates in Rust Components
 
 In Rust, Spin components are regular libraries that contain a function
-annotated using the `http_component` macro, compiled to the
-[`wasm32-wasi` target](https://doc.rust-lang.org/stable/nightly-rustc/rustc_target/spec/wasm32_wasi/index.html).
+annotated using the `http_component` macro, compiled to the `wasm32-wasi` target.
 This means that any [crate](https://crates.io) that compiles to `wasm32-wasi` can
 be used when implementing the component.
 


### PR DESCRIPTION
Fixes #1114.

In this PR I've opted to remove the broken links altogether, because the moved pages seemed more scary than helpful to someone just wanting to install or use the target.  If other folks think the links did add value, I can restore them to the new location.

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
