### PR TITLE
add empty href tag to fix macos chrome bug

### DIFF
--- a/spin-up-hub/src/components/ContentFilter.vue
+++ b/spin-up-hub/src/components/ContentFilter.vue
@@ -47,14 +47,14 @@ export default {
     <div class="filter-group">
       <div class="filter-category">Resource Types:</div>
       <div v-for="item in contentTypes" class="tag" v-bind:class="isActiveContentType(item)" @click="toggleContentFilter(item)">
-        <a class="plausible-event-name=hub-filter-type">{{ item }}</a>
+        <a href="#" class="plausible-event-name=hub-filter-type">{{ item }}</a>
       </div>
     </div>
 
     <div class="filter-group">
       <div class="filter-category"> Languages:</div>
       <div v-for="item in languages" class="tag" v-bind:class="isActiveLanguage(item)" @click="toggleLanguageFilter(item)">
-        <a class="plausible-event-name=hub-filter-lang">{{ item }}</a>
+        <a href="#" class="plausible-event-name=hub-filter-lang">{{ item }}</a>
       </div>
     </div>
     


### PR DESCRIPTION
fixes #1107 

Weird bug in Chrome on macos where a `<a>` tag without a `href` was causing the page to reload. We should potentially not be using the `a` tag where it is not a link but that involves stylistic changes which can be done in a future PR. 

cc: @flynnduism 