### PR TITLE
increase font weight on links

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -4070,6 +4070,7 @@ html.dark-theme body main .feedback-wrapper .feedback-modal a {
   border-radius: 1px;
   margin: 0;
   padding: .25rem 0 .25rem .5rem;
+  font-weight: 400;
   line-height: 1.5;
   transition: all .3s ease-in-out;
   display: inline-block;
@@ -4295,6 +4296,10 @@ html.dark-theme body main .feedback-wrapper .feedback-modal a {
 
 .documentation h1:hover > a.anchor-link, .documentation h2:hover > a.anchor-link, .documentation h3:hover > a.anchor-link, .documentation h4:hover > a.anchor-link {
   opacity: 1;
+}
+
+.documentation a {
+  font-weight: 600;
 }
 
 .documentation a.anchor-link:after {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -131,6 +131,7 @@ Importing color and theme updates for the brand 1.5 refresh
 						line-height: 1.5;
 						display: inline-block;
 						color: darken($bluedark, 7.5%);
+						font-weight: 400;
 						@include transition;
 
 						&:hover {
@@ -407,6 +408,10 @@ Importing color and theme updates for the brand 1.5 refresh
 				opacity: 1;
 			}
 		}
+	}
+
+	a {
+		font-weight: 600;
 	}
 
 	a.anchor-link {


### PR DESCRIPTION
fix #1122 

This PR increases the font weight of the links in the content to make them a bit more bold and distinguishable.

![image](https://github.com/fermyon/developer/assets/25023490/ce525a88-3449-44c2-9256-aa6e644eadaa)
![image](https://github.com/fermyon/developer/assets/25023490/222e306d-a8f4-4607-95ed-4aeec1fc8fb0)
