### PR TITLE
Updated v1 links removed from main ages back

### DIFF
--- a/content/spin/v1/http-trigger.md
+++ b/content/spin/v1/http-trigger.md
@@ -286,9 +286,9 @@ For the most part, you'll build HTTP component modules using a language SDK (see
 
 > The WebAssembly component model is in its early stages, and over time the triggers and application entry points will undergo changes, both in the definitions of functions and types, and in the binary representations of those definitions and of primitive types (the so-called Application Binary Interface or ABI).  However, Spin ensures binary compatibility over the course of any given major release.  For example, a component built using the Spin 1.0 SDK will work on any version of Spin in the 1.x range.
 
-The HTTP component interface is defined using a WebAssembly Interface (WIT) file.  ([Learn more about the evolving WIT standard here.](https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md)).  You can find the latest WITs for Spin HTTP components at [https://github.com/fermyon/spin/blob/main/wit/ephemeral](https://github.com/fermyon/spin/blob/main/wit/ephemeral).
+The HTTP component interface is defined using a WebAssembly Interface (WIT) file.  ([Learn more about the evolving WIT standard here.](https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md)).  You can find the latest WITs for Spin HTTP components at [https://github.com/fermyon/spin/tree/v1.6/wit/ephemeral](https://github.com/fermyon/spin/tree/v1.6/wit/ephemeral).
 
-The core HTTP types are defined in [https://github.com/fermyon/spin/blob/main/wit/ephemeral/http-types.wit](https://github.com/fermyon/spin/blob/main/wit/ephemeral/http-types.wit):
+The core HTTP types are defined in [https://github.com/fermyon/spin/blob/v1.6/wit/ephemeral/http-types.wit](https://github.com/fermyon/spin/blob/v1.6/wit/ephemeral/http-types.wit):
 
 <!-- @nocpy -->
 
@@ -329,7 +329,7 @@ record response {
 
 > The same HTTP types are also used to model the API for sending outbound HTTP requests.
 
-The entry point for Spin HTTP components is then defined in [https://github.com/fermyon/spin/blob/main/wit/ephemeral/spin-http.wit](https://github.com/fermyon/spin/blob/main/wit/ephemeral/spin-http.wit):
+The entry point for Spin HTTP components is then defined in [https://github.com/fermyon/spin/blob/v1.6/wit/ephemeral/spin-http.wit](https://github.com/fermyon/spin/blob/v1.6/wit/ephemeral/spin-http.wit):
 
 <!-- @nocpy -->
 

--- a/content/spin/v1/redis-trigger.md
+++ b/content/spin/v1/redis-trigger.md
@@ -135,9 +135,9 @@ For the most part, you'll build Redis component modules using a language SDK (se
 
 > The WebAssembly component model is in its early stages, and over time the triggers and application entry points will undergo changes, both in the definitions of functions and types, and in the binary representations of those definitions and of primitive types (the so-called Application Binary Interface or ABI).  However, Spin ensures binary compatibility over the course of any given major release.  For example, a component built using the Spin 1.0 SDK will work on any version of Spin in the 1.x range.
 
-The Redis component interface is defined using a WebAssembly Interface (WIT) file.  ([Learn more about the evolving WIT standard here.](https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md)).  You can find the latest WITs for Spin Redis components at [https://github.com/fermyon/spin/blob/main/wit/ephemeral](https://github.com/fermyon/spin/blob/main/wit/ephemeral).
+The Redis component interface is defined using a WebAssembly Interface (WIT) file.  ([Learn more about the evolving WIT standard here.](https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md)).  You can find the latest WITs for Spin Redis components at [https://github.com/fermyon/spin/tree/v1.6/wit/ephemeral](https://github.com/fermyon/spin/tree/v1.6/wit/ephemeral).
 
-The core Redis types are defined in [https://github.com/fermyon/spin/blob/main/wit/ephemeral/redis-types.wit](https://github.com/fermyon/spin/blob/main/wit/ephemeral/redis-types.wit), though note that not all of these are used in the pub-sub Redis trigger:
+The core Redis types are defined in [https://github.com/fermyon/spin/blob/v1.6/wit/ephemeral/redis-types.wit](https://github.com/fermyon/spin/blob/v1.6/wit/ephemeral/redis-types.wit), though note that not all of these are used in the pub-sub Redis trigger:
 
 <!-- @nocpy -->
 
@@ -156,7 +156,7 @@ type payload = list<u8>
 
 > The same Redis types are also used to model the API for sending outbound Redis requests.
 
-The entry point for Spin Redis components is then defined in [https://github.com/fermyon/spin/blob/main/wit/ephemeral/spin-redis.wit](https://github.com/fermyon/spin/blob/main/wit/ephemeral/spin-redis.wit):
+The entry point for Spin Redis components is then defined in [https://github.com/fermyon/spin/blob/v1.6/wit/ephemeral/spin-redis.wit](https://github.com/fermyon/spin/blob/v1.6/wit/ephemeral/spin-redis.wit):
 
 <!-- @nocpy -->
 

--- a/content/spin/v1/variables.md
+++ b/content/spin/v1/variables.md
@@ -71,7 +71,7 @@ api_host = "https://my-api.com"
 
 ## Using Variables From Applications
 
-The Spin SDK surfaces the Spin configuration interface to your language. The [interface](https://github.com/fermyon/spin/blob/main/wit/ephemeral/spin-config.wit) consists of one operation:
+The Spin SDK surfaces the Spin configuration interface to your language. The [interface](https://github.com/fermyon/spin/blob/v1.6/wit/ephemeral/spin-config.wit) consists of one operation:
 
 | Operation  | Parameters                          | Returns             | Behavior |
 |------------|-------------------------------------|---------------------|----------|


### PR DESCRIPTION
These files were removed from Spin `main` in November of last year.  No idea how the links only failed today.

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
