### PR TITLE
Fixing the hover effect issue on footer links on the spin-up hub page

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1518,6 +1518,16 @@ html.dark-theme body.documentation footer.footer-links {
   border-top: 1px solid #e7d3f220 !important;
 }
 
+html.dark-theme body.documentation footer.footer-links .level a {
+  color: #ccb2f0 !important;
+}
+
+html.dark-theme body.documentation footer.footer-links .level a:hover {
+  border-radius: 25px;
+  color: #fff !important;
+  background: #7c6db980 !important;
+}
+
 html.dark-theme body.documentation .content a {
   color: #ccb2f0;
 }

--- a/static/sass/developer-color-dark.scss
+++ b/static/sass/developer-color-dark.scss
@@ -190,6 +190,14 @@ html.dark-theme {
 
         footer.footer-links {
             border-top: 1px solid rgba($lavenderlight, 0.125) !important;
+            .level a {
+                color: #ccb2f0 !important;
+                &:hover {
+                    background: rgba(124, 109, 185, 0.5) !important;
+                    color: #fff !important;
+                    border-radius: 25px;
+                }
+            }
         }
 
         .content {


### PR DESCRIPTION
Fixes: #1131 
<img width="635" alt="Screenshot 2024-01-11 at 12 29 50 AM" src="https://github.com/fermyon/developer/assets/99033623/eb80669f-ad98-4df4-87ba-adb4c6200077">

I made some changes, please once check and let me know if any further changes need to be made

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title`, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result)
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
