### PR TITLE
Update dynamic-configuration.md

### DIFF
--- a/content/spin/v2/dynamic-configuration.md
+++ b/content/spin/v2/dynamic-configuration.md
@@ -51,7 +51,7 @@ to environment variables by upper-casing and prepending with `SPIN_VARIABLE_`:
 <!-- @selectiveCpy -->
 
 ```bash
-$ export SPIN_VARIABLE_API_KEY = "1234"  # Sets the `api_key` value.
+$ export SPIN_VARIABLE_API_KEY="1234"  # Sets the `api_key` value.
 $ spin up
 ```
 


### PR DESCRIPTION
Signed-off-by: tpmccallum tim.mccallum@fermyon.com

macOS does not allow spaces between the `=`

With spaces:
```
$ export SPIN_VARIABLE_API_KEY = "1234" 
zsh: bad assignment
```

Without spaces:
```
$ export SPIN_VARIABLE_API_KEY="1234"   
tpmccallum@192-168-1-14 test_var % echo $SPIN_VARIABLE_API_KEY
1234
```
