### PR TITLE
Fix error on Rust example and test

### DIFF
--- a/content/spin/v2/http-outbound.md
+++ b/content/spin/v2/http-outbound.md
@@ -95,7 +95,7 @@ We can now build and run the application:
 <!-- @selectiveCpy -->
 
 ```bash
-spin build --up
+$ spin build --up
 Building component example with `cargo build --target wasm32-wasi --release`
 Serving http://127.0.0.1:3000
 Available Routes:

--- a/content/spin/v2/http-outbound.md
+++ b/content/spin/v2/http-outbound.md
@@ -83,33 +83,6 @@ async fn handle_request(_req: Request) -> anyhow::Result<impl IntoResponse> {
 }
 ```
 
-The outbound request will only work if we [grant network permissions to the component](https://developer.fermyon.com/spin/v2/redis-outbound#granting-network-permissions-to-components). Please update the `spin.toml` file at the component level as follows:
-
-```toml
-[component.example]
-allowed_outbound_hosts = ["https://www.fermyon.com:443"]
-```
-
-We can now build and run the application:
-
-<!-- @selectiveCpy -->
-
-```bash
-$ spin build --up
-Building component example with `cargo build --target wasm32-wasi --release`
-Serving http://127.0.0.1:3000
-Available Routes:
-  example: http://127.0.0.1:3000 (wildcard)
-```
-We can test this out by making a request to the application's endpoint:
-
-<!-- @selectiveCpy -->
-
-```bash
-$ curl localhost:3000
-The test page was 48203 bytes
-```
-
 For an example of receiving the response in a streaming style, [see this example in the Spin repository](https://github.com/fermyon/spin/blob/main/examples/wasi-http-rust-streaming-outgoing-body/src/lib.rs).
 
 {{ blockEnd }}


### PR DESCRIPTION
Signed-off-by: tpmccallum tim.mccallum@fermyon.com

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title`, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result)
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors
- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
