### PR TITLE
Update KV explorer docs for latest release

### DIFF
--- a/content/api/hub/template_kv_explorer.md
+++ b/content/api/hub/template_kv_explorer.md
@@ -13,12 +13,24 @@ created_at = "2023-10-15T00:22:56Z"
 last_updated = "2023-05-18T00:22:56Z"
 spin_version = ">=v1.0"
 summary =  "A Spin component for exploring the contents of key/value stores."
-url = "https://github.com/radu-matei/spin-kv-explorer"
+url = "https://github.com/fermyon/spin-kv-explorer"
 keywords = "key-value, kv, explorer"
 
 ---
 
-The explorer will use the default store to persist the credentials to access the UI and the API. If no values are set, the first invocation will set a randomly generated pair of username and password under the kv-credentials key, with the value following the user:password format. On the first run, the values will be printed in the logs, and they can be used to log in and change them (creating a new credentials value will override the existing value).
+This template enables managing the key value pairs set in any key value store linked to an application.
 
-*Known limitations* 
-the explorer can only be used with Spin's default key/value store. When this will be configurable, this component will support working with custom stores as well.
+To keep the contents of your key value store secure, the explorer expects the credentials to access the UI and the API to be stored in the configuration store as variables. Values can be set locally using the [variables provider](https://developer.fermyon.com/spin/v2/dynamic-configuration#application-variables-runtime-configuration) or you can skip checking for the credentials on every request by passing the `SPIN_APP_KV_SKIP_AUTH` environment variable. When deploying to cloud, set the `kv_explorer_user` and `kv_explorer_password` variables using the `--variable` flag. These credentials can then be updated at any time using `spin cloud variables set`.
+
+Visit the [GitHub repo](https://github.com/fermyon/spin-kv-explorer) for complete configuration instructions.
+
+## Installation and Use
+
+```sh
+spin templates install --upgrade --git https://github.com/fermyon/spin-kv-explorer
+```
+
+Use the `spin add` command to add the KV explorer to your application, specifying `kv-explorer` as the component name.
+```sh
+spin add kv-explorer -t kv-explorer
+```

--- a/content/spin/v1/ai-sentiment-analysis-api-tutorial.md
+++ b/content/spin/v1/ai-sentiment-analysis-api-tutorial.md
@@ -821,7 +821,7 @@ For this, we install use a pre-made template by pointing to the templates GitHub
 <!-- @selectiveCpy -->
 
 ```bash
-$ spin templates install --git https://github.com/radu-matei/spin-kv-explorer
+$ spin templates install --git https://github.com/fermyon/spin-kv-explorer
 ```
 
 Then, we again use `spin add` to add the new component. We will name the component  `kv-explorer`):
@@ -829,8 +829,7 @@ Then, we again use `spin add` to add the new component. We will name the compone
 <!-- @selectiveCpy -->
 
 ```bash
-$ spin add kv-explorer --accept-defaults
-Enter a name for your new application: kv-explorer
+$ spin add kv-explorer -t kv-explorer
 ```
 
 We create an `assets` directory where we can store files to serve statically (see the `spin.toml` file for more configuration information):
@@ -874,7 +873,7 @@ files = [ { source = "assets", destination = "/" } ]
 route = "/..."
 
 [[component]]
-source = { url = "https://github.com/radu-matei/spin-kv-explorer/releases/download/v0.9.0/spin-kv-explorer.wasm", digest = "sha256:07f5f0b8514c14ae5830af0f21674fd28befee33cd7ca58bc0a68103829f2f9c" }
+source = { url = "https://github.com/fermyon/spin-kv-explorer/releases/download/v0.9.0/spin-kv-explorer.wasm", digest = "sha256:07f5f0b8514c14ae5830af0f21674fd28befee33cd7ca58bc0a68103829f2f9c" }
 id = "kv-explorer"
 # add or remove stores you want to explore here
 key_value_stores = ["default"]

--- a/content/spin/v2/ai-sentiment-analysis-api-tutorial.md
+++ b/content/spin/v2/ai-sentiment-analysis-api-tutorial.md
@@ -977,7 +977,7 @@ For this, we install use a pre-made template by pointing to the templates GitHub
 <!-- @selectiveCpy -->
 
 ```bash
-$ spin templates install --git https://github.com/radu-matei/spin-kv-explorer
+$ spin templates install --git https://github.com/fermyon/spin-kv-explorer
 ```
 
 Then, we again use `spin add` to add the new component. We will name the component  `kv-explorer`):
@@ -985,8 +985,7 @@ Then, we again use `spin add` to add the new component. We will name the compone
 <!-- @selectiveCpy -->
 
 ```bash
-$ spin add -t kv-explorer --accept-defaults
-Enter a name for your new application: kv-explorer
+$ spin add kv-explorer -t kv-explorer
 ```
 
 ### Application Manifest
@@ -1030,7 +1029,7 @@ route = "/internal/kv-explorer/..."
 component = "kvv2"
 
 [component.kv-explorer]
-source = { url = "https://github.com/radu-matei/spin-kv-explorer/releases/download/v0.6.0/spin-kv-explorer.wasm", digest = "sha256:38110bc277a393cdfb1a885a0fd56923d47314b2086399d1e3bbcb6daa1f04ad" }
+source = { url = "https://github.com/fermyon/spin-kv-explorer/releases/download/v0.6.0/spin-kv-explorer.wasm", digest = "sha256:38110bc277a393cdfb1a885a0fd56923d47314b2086399d1e3bbcb6daa1f04ad" }
 # add or remove stores you want to explore here
 key_value_stores = ["default"]
 ```


### PR DESCRIPTION
Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title`, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result)
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)

✅ content/api/hub/template_kv_explorer.md
✅ content/spin/v1/ai-sentiment-analysis-api-tutorial.md
✅ content/spin/v2/ai-sentiment-analysis-api-tutorial.md

- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)

![Screenshot 2024-01-29 at 16 25 50](https://github.com/fermyon/developer/assets/9831342/05f8e7f3-1cfc-4b59-bb4d-ac658c1147ea)

- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors
- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
