### PR TITLE
feat(*): add fermyon/wasm-languages submodule

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,13 @@ jobs:
         with:
           node-version: 16
 
+      # spin build will attempt to update the wasm-languages submodule via its ssh url
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.SSH_KEY }}
+          known_hosts: ${{ secrets.KNOWN_HOSTS }}
+
       - name: Setup Spin
         uses: fermyon/actions/spin/setup@v1
         with:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -12,6 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      # spin build will attempt to update the wasm-languages submodule via its ssh url
       - name: Install SSH key
         uses: shimataro/ssh-key-action@v2
         with:
@@ -27,9 +28,6 @@ jobs:
         run: |
           npm ci
           npm ci --prefix ./spin-up-hub
-
-      - name: Update wasm-languages submodule
-        run: npm run update-wasm-lang
 
       - name: Build app
         run: |

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -22,6 +22,9 @@ jobs:
           npm ci
           npm ci --prefix ./spin-up-hub
 
+      - name: Update wasm-languages submodule
+        run: make update-lang
+
       - name: Build app
         run: |
           spin build

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -29,7 +29,7 @@ jobs:
           npm ci --prefix ./spin-up-hub
 
       - name: Update wasm-languages submodule
-        run: make update-lang
+        run: npm run update-wasm-lang
 
       - name: Build app
         run: |

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -12,6 +12,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.SSH_KEY }}
+          known_hosts: ${{ secrets.KNOWN_HOSTS }}
+
       - name: Setup `spin`
         uses: fermyon/actions/spin/setup@v1
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,7 +71,7 @@ jobs:
           npm ci --prefix ./spin-up-hub
 
       - name: Update wasm-languages submodule
-        run: make update-lang
+        run: npm run update-wasm-lang
 
       - name: Build app
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,6 +53,12 @@ jobs:
         with:
           node-version: 16
 
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.SSH_KEY }}
+          known_hosts: ${{ secrets.KNOWN_HOSTS }}
+
       - name: Setup Spin
         uses: fermyon/actions/spin/setup@v1
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,6 +53,7 @@ jobs:
         with:
           node-version: 16
 
+      # spin build will attempt to update the wasm-languages submodule via its ssh url
       - name: Install SSH key
         uses: shimataro/ssh-key-action@v2
         with:
@@ -69,9 +70,6 @@ jobs:
         run: |
           npm ci
           npm ci --prefix ./spin-up-hub
-
-      - name: Update wasm-languages submodule
-        run: npm run update-wasm-lang
 
       - name: Build app
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,6 +64,9 @@ jobs:
           npm ci
           npm ci --prefix ./spin-up-hub
 
+      - name: Update wasm-languages submodule
+        run: make update-lang
+
       - name: Build app
         run: |
           spin build

--- a/.github/workflows/wasm-lang-update.yml
+++ b/.github/workflows/wasm-lang-update.yml
@@ -27,7 +27,7 @@ jobs:
           git_commit_gpgsign: true
 
       - name: Update wasm-languages
-        run: make update-lang
+        run: npm run update-wasm-lang
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/wasm-lang-update.yml
+++ b/.github/workflows/wasm-lang-update.yml
@@ -1,0 +1,46 @@
+name: Update wasm-languages
+
+on:
+  repository_dispatch:
+    types: [wasm-languages-updated]
+
+concurrency: ${{ github.workflow }}
+
+jobs:
+  update-wasm-lang:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.SSH_KEY }}
+          known_hosts: ${{ secrets.KNOWN_HOSTS }}
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v5
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      - name: Update wasm-languages
+        run: make update-lang
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        env:
+          WASM_LANG_COMMIT: ${{ github.event.client_payload.sha }}
+        with:
+          token: ${{ secrets.PAT }}
+          commit-message: "chore(.gitmodules): update wasm-languages submodule commit"
+          title: "chore(.gitmodules): update wasm-languages submodule commit"
+          body: "Update the wasm-languages git submodule to https://github.com/fermyon/wasm-languages/commit/${{ env.WASM_LANG_COMMIT }}"
+          branch: wasm-lang-submodule-update
+          base: main
+          delete-branch: true
+          committer: fermybot <103076628+fermybot@users.noreply.github.com>
+          author: fermybot <103076628+fermybot@users.noreply.github.com>
+          signoff: true

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "content/wasm-languages"]
+	path = content/wasm-languages
+	url = git@github.com:fermyon/wasm-languages.git

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,0 @@
-.PHONY: update-lang
-update-lang:
-	git submodule update --init --recursive --remote

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: update-lang
+update-lang:
+	git submodule update --init --recursive --remote

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "test": "npx markdownlint-cli2 content/**/*.md \"#node_modules\" && npm run check-broken-links",
     "build-index": "node md_parser.mjs --dir=./content/ --out=./static/data.json --ignore=./content/api/**/*",
     "check-broken-links": ".build/check-broken-links.sh",
-    "build-hub-index": "node hub_index_generator.mjs --dir=./content/api/hub/ --out=./static/hub-index-data.json --ignore=./content/api/hub/get_list.md,"
+    "build-hub-index": "node hub_index_generator.mjs --dir=./content/api/hub/ --out=./static/hub-index-data.json --ignore=./content/api/hub/get_list.md,",
+    "update-wasm-lang": "git submodule update --init --recursive --remote"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "yaml-front-matter": "^4.1.1"
   },
   "scripts": {
-    "spin": "nodemon --watch content --watch static --watch templates --watch spin-up-hub --ext html,md,rhai,hbs,css,js --verbose --legacy-watch --signal SIGINT --exec 'npm run build-index && npm run build-hub-index && spin up --file spin.toml --quiet --env PREVIEW_MODE=$PREVIEW_MODE'",
+    "spin": "nodemon --watch content --watch static --watch templates --watch spin-up-hub --ext html,md,rhai,hbs,css,js --verbose --legacy-watch --signal SIGINT --exec 'npm run build-index && npm run build-hub-index && npm run update-wasm-lang && spin up --file spin.toml --quiet --env PREVIEW_MODE=$PREVIEW_MODE'",
     "bundle-scripts": "parcel watch static/js/src/main.js --dist-dir static/js --no-source-maps",
     "styles": "parcel watch static/sass/styles.scss --dist-dir static/css",
     "test": "npx markdownlint-cli2 content/**/*.md \"#node_modules\" && npm run check-broken-links",

--- a/spin.toml
+++ b/spin.toml
@@ -154,6 +154,11 @@ id = "trigger-bartholomew-spin-v2"
 component = "bartholomew-spin-v2"
 route = "/spin/v2/..."
 
+[[trigger.http]]
+id = "trigger-redirect-wasm-langs-root"
+component = "redirect-wasm-langs-root"
+route = "/wasm-languages/"
+
 [component.bartholomew]
 # Using build from bartholomew main
 source = "modules/bartholomew.wasm"
@@ -290,6 +295,11 @@ environment = { DESTINATION = "https://developer.fermyon.com/spin/ai-sentiment-a
 [component.serverless-ai]
 source = "modules/redirect.wasm"
 environment = { DESTINATION = "https://developer.fermyon.com/spin/serverless-ai-hello-world.md" }
+
+# Redirect /wasm-languages to /wasm-languages/webassembly-language-support
+[component.redirect-wasm-langs-root]
+source = "modules/redirect.wasm"
+environment = { DESTINATION = "/wasm-languages/webassembly-language-support" }
 
 # Component to give us clean versioned URLs for spin from the root
 [component.spin-version-proxy]

--- a/spin.toml
+++ b/spin.toml
@@ -161,7 +161,7 @@ environment = { PREVIEW_MODE = "0" }
 files = ["content/**/*", "templates/*", "scripts/*", "config/*", "shortcodes/*"]
 
 [component.bartholomew.build]
-command = "npm run build-index && npm run build-hub-index"
+command = "npm run build-index && npm run build-hub-index && npm run update-wasm-lang"
 watch = ["content/**/*", "templates/*"]
 
 [component.fileserver-static]

--- a/templates/page.hbs
+++ b/templates/page.hbs
@@ -1,0 +1,24 @@
+{{! This adds the HTML head section and the beginning of the body. See content_top.hbs. }}
+{{> content_top }}
+
+<div class="container page-wrap">
+    <div class="columns">
+
+        <div class="column">
+            <article class="page content">
+                <h1>{{{page.title}}}</h1>
+                {{! Since this is HTML, we use the triple-curly }}
+                {{{page.body}}}
+                {{! Remove the `!` on the line below to see how to call a Rhai script }}
+                {{! echo "world" }}
+            </article>
+        </div><!-- end col -->
+    
+    </div>
+</div>
+
+{{! This closes the body. See content_bottom.hbs. }}
+
+{{> content_cta }}
+
+{{> content_bottom }}

--- a/templates/page_lang.hbs
+++ b/templates/page_lang.hbs
@@ -1,0 +1,25 @@
+{{! This adds the HTML head section and the beginning of the body. See content_top.hbs. }}
+{{> content_top }}
+
+<div class="container page-wrap">
+    <div class="columns">
+
+        <div class="column">
+            <article class="page page-lang content">
+                <h1>{{{page.title}}}</h1>
+                <p class="subtitle is-size-6 backlink"><a href="{{site.info.base_url}}/wasm-languages/webassembly-language-support"> &larr; Back to Language Index</a></p>
+                {{! Since this is HTML, we use the triple-curly }}
+                {{{page.body}}}
+                {{! Remove the `!` on the line below to see how to call a Rhai script }}
+                {{! echo "world" }}
+            </article>
+        </div><!-- end col -->
+    
+    </div>
+</div>
+
+{{! This closes the body. See content_bottom.hbs. }}
+
+{{> content_cta }}
+
+{{> content_bottom }}


### PR DESCRIPTION
Adds a git submodule for the https://github.com/fermyon/wasm-languages repo at `content/wasm-languages`, so that contents are rendered at eg `developer.fermyon.com/wasm-languages/webassembly-language-support`.  (Or, using this PR preview: https://fermyon-developer-pr-1176-9pebe6w5.fermyon.app/wasm-languages/webassembly-language-support)

Note: I copied the stock `page.hbs` and `page_lang.hbs` templates that are referenced by the markdown files in fermyon/wasm-languages.  (See https://github.com/fermyon/wasm-languages/blob/main/webassembly-language-support.md and https://github.com/fermyon/wasm-languages/blob/main/c-lang.md for example.)  These templates haven't been updated or modified to suit custom layout/rendering needs in these Developer docs.  Looking to @tpmccallum to advise here...  Perhaps a follow-up PR to customize the templates as well as add links to these new wasm-languages pages?

Also adds some CI/CD-related updates, including a workflow that will [watch for changes in the fermyon/wasm-languages repo](https://github.com/fermyon/wasm-languages/blob/main/.github/workflows/dispatch.yml) and then will automatically create an update PR here (note: will require a change in the upstream repo, once we are ready.)
