### PR TITLE
Add --all option to plugins docs and also explain downgrading with an example

### DIFF
--- a/content/spin/v2/managing-plugins.md
+++ b/content/spin/v2/managing-plugins.md
@@ -179,7 +179,7 @@ js2wasm 0.6.0 [installed]
 js2wasm 0.6.1
 ```
 
-After downgrading, that the `[installed]` indicator is aligned with the `0.6.0` version of `js2wasm`, as intended in the example.
+After downgrading, the `[installed]` indicator is aligned with the `0.6.0` version of `js2wasm`, as intended in the example.
 
 ## Next Steps
 

--- a/content/spin/v2/managing-plugins.md
+++ b/content/spin/v2/managing-plugins.md
@@ -146,7 +146,7 @@ The following example shows how to upgrade all installed plugins at once:
 
 ```bash
 $ spin plugins update
-$ spin plugins --all
+$ spin plugins upgrade --all
 ```
 
 The following example shows additional upgrade options. Specifically, how to upgrade using the path to a remote plugin manifest and how to upgrade using the path to a local plugin manifest:

--- a/content/spin/v2/managing-plugins.md
+++ b/content/spin/v2/managing-plugins.md
@@ -187,7 +187,7 @@ js2wasm 0.6.0 [installed]
 js2wasm 0.6.1
 ```
 
-After the success of the downgrade process, we can see that the `[installed]` indicator is now aligned with the `0.6.0` version of `js2wasm`, as intended in the example.
+After downgrading, that the `[installed]` indicator is aligned with the `0.6.0` version of `js2wasm`, as intended in the example.
 
 ## Next Steps
 

--- a/content/spin/v2/managing-plugins.md
+++ b/content/spin/v2/managing-plugins.md
@@ -149,6 +149,8 @@ $ spin plugins update
 $ spin plugins upgrade --all
 ```
 
+> Note: The above example only installs plugins from the catalogue
+
 The following example shows additional upgrade options. Specifically, how to upgrade using the path to a remote plugin manifest and how to upgrade using the path to a local plugin manifest:
 
 <!-- @selectiveCpy -->
@@ -167,22 +169,12 @@ By default, Spin will only _upgrade_ plugins. Pass the `--downgrade` flag and sp
 ```bash
 $ spin plugins update
 $ spin plugins list
-js2wasm 0.1.0
-js2wasm 0.2.0
-js2wasm 0.3.0
-js2wasm 0.4.0
-js2wasm 0.5.0
-js2wasm 0.5.1
+// --snip--
 js2wasm 0.6.0
 js2wasm 0.6.1 [installed]
 $ spin plugins upgrade js2wasm --downgrade --version 0.6.0
 $ spin plugins list
-js2wasm 0.1.0
-js2wasm 0.2.0
-js2wasm 0.3.0
-js2wasm 0.4.0
-js2wasm 0.5.0
-js2wasm 0.5.1
+// --snip--
 js2wasm 0.6.0 [installed]
 js2wasm 0.6.1
 ```

--- a/content/spin/v2/managing-plugins.md
+++ b/content/spin/v2/managing-plugins.md
@@ -125,7 +125,7 @@ To update your local cache of the catalogue, run `spin plugins update`.
 
 ## Upgrading Plugins
 
-To upgrade a plugin to the latest version, first run `spin plugins upgrade` (to refresh the catalogue). 
+To upgrade a plugin to the latest version, first run `spin plugins update` (to refresh the catalogue). 
 
 The `spin plugins upgrade` command has the same options as the `spin plugins install` command (according to whether the plugin comes from the catalogue, a URL, or a file). For more information, see the plugins section of the [Spin CLI Reference documentation](cli-reference#spin-plugins). 
 

--- a/content/spin/v2/managing-plugins.md
+++ b/content/spin/v2/managing-plugins.md
@@ -187,7 +187,7 @@ js2wasm 0.6.0 [installed]
 js2wasm 0.6.1
 ```
 
-After the success of the downgrade process, we can see that the `[installed]` indicator is now aligned with the `0.6.0` version of 'js2wasm`, as intended in the example.
+After the success of the downgrade process, we can see that the `[installed]` indicator is now aligned with the `0.6.0` version of `js2wasm`, as intended in the example.
 
 ## Next Steps
 

--- a/content/spin/v2/managing-plugins.md
+++ b/content/spin/v2/managing-plugins.md
@@ -125,7 +125,7 @@ To update your local cache of the catalogue, run `spin plugins update`.
 
 ## Upgrading Plugins
 
-To upgrade a plugin to the latest version, first run `spin plugins update` (to refresh the catalogue). 
+To upgrade a plugin to the latest version, first run `spin plugins update` (to refresh the catalogue), then `spin plugins upgrade`. 
 
 The `spin plugins upgrade` command has the same options as the `spin plugins install` command (according to whether the plugin comes from the catalogue, a URL, or a file). For more information, see the plugins section of the [Spin CLI Reference documentation](cli-reference#spin-plugins). 
 

--- a/content/spin/v2/managing-plugins.md
+++ b/content/spin/v2/managing-plugins.md
@@ -15,8 +15,9 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/v2/managing-p
 - [Viewing Available Plugins](#viewing-available-plugins)
   - [Viewing Installed Plugins](#viewing-installed-plugins)
 - [Uninstalling Plugins](#uninstalling-plugins)
-- [Upgrading Plugins](#upgrading-plugins)
 - [Refreshing the Catalogue](#refreshing-the-catalogue)
+- [Upgrading Plugins](#upgrading-plugins)
+- [Downgrading Plugins](#downgrading-plugins)
 - [Next Steps](#next-steps)
 
 Plugins are a way to extend the functionality of Spin. Spin provides commands for installing and removing them, so you don't need to use separate installation tools. When you have installed a plugin into Spin, you can call it as if it were a Spin subcommand. For example, the JavaScript SDK uses a tool called `js2wasm` to package JavaScript code into a Wasm module, and JavaScript applications run it via the `spin js2wasm` command.
@@ -116,27 +117,77 @@ You can uninstall plugins using `spin plugins uninstall` with the plugin name:
 $ spin plugins uninstall befunge2wasm
 ```
 
-## Upgrading Plugins
-
-To upgrade a plugin to the latest version, run `spin plugins upgrade`. This has the same options as `spin plugins install`, according to whether the plugin comes from the catalogue, a URL, or a file:
-
-<!-- @selectiveCpy -->
-
-```bash
-$ spin plugins upgrade js2wasm
-$ spin plugins upgrade --url https://github.com/fermyon/spin-befunge-sdk/releases/download/v1.7.0/befunge2wasm.json
-$ spin plugins upgrade --file ~/dev/spin-befunge-sdk/befunge2wasm.json
-```
-
-> When upgrading from the catalogue, the `upgrade` command uses your local cache of the catalogue. This might not include recently added plugins or versions. Run `spin plugins update` to refresh your local cache of the catalogue.
-
-By default, Spin will only _upgrade_ plugins. If you want to allow Spin to roll back to an earlier version, pass the `--downgrade` flag.
-
 ## Refreshing the Catalogue
 
 The first time you install a plugin from the catalogue, Spin creates a local cache of the catalogue. It continues to use this local cache for future install, list and upgrade commands; this is similar to OS package managers such as `apt`, and avoids rate limiting on the catalogue. However, this means that in order to see new catalogue entries - new plugins or new versions - you must first update the cache. 
 
 To update your local cache of the catalogue, run `spin plugins update`.
+
+## Upgrading Plugins
+
+To upgrade a plugin to the latest version, first run `spin plugins upgrade` (to refresh the catalogue). 
+
+The `spin plugins upgrade` command has the same options as the `spin plugins install` command (according to whether the plugin comes from the catalogue, a URL, or a file). For more information, see the plugins section of the [Spin CLI Reference documentation](cli-reference#spin-plugins). 
+
+> The `upgrade` command uses your local cache of the catalogue. This might not include recently added plugins or versions. So always remember to run `spin plugins update` to refresh your local cache of the catalogue before performing the `spin plugins upgrade` command.
+
+The following example shows how to upgrade one plugin at a time (i.e. the `js2wasm` plugin):
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin plugins update
+$ spin plugins upgrade js2wasm
+```
+
+The following example shows how to upgrade all installed plugins at once:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin plugins update
+$ spin plugins --all
+```
+
+The following example shows additional upgrade options. Specifically, how to upgrade using the path to a remote plugin manifest and how to upgrade using the path to a local plugin manifest:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin plugins upgrade --url https://github.com/fermyon/spin-befunge-sdk/releases/download/v1.7.0/befunge2wasm.json
+$ spin plugins upgrade --file ~/dev/spin-befunge-sdk/befunge2wasm.json
+```
+
+## Downgrading Plugins
+
+By default, Spin will only _upgrade_ plugins. Pass the `--downgrade` flag and specify the `--version` if you want Spin to roll back to an earlier version. The following abridged example (which doesn't list the full console output for simplicity) lists the versions of plugins, downgrades the `js2wasm` to an older version (`0.6.0`) and then lists the versions again to show the results:
+
+<!-- @nocpy -->
+
+```bash
+$ spin plugins update
+$ spin plugins list
+js2wasm 0.1.0
+js2wasm 0.2.0
+js2wasm 0.3.0
+js2wasm 0.4.0
+js2wasm 0.5.0
+js2wasm 0.5.1
+js2wasm 0.6.0
+js2wasm 0.6.1 [installed]
+$ spin plugins upgrade js2wasm --downgrade --version 0.6.0
+$ spin plugins list
+js2wasm 0.1.0
+js2wasm 0.2.0
+js2wasm 0.3.0
+js2wasm 0.4.0
+js2wasm 0.5.0
+js2wasm 0.5.1
+js2wasm 0.6.0 [installed]
+js2wasm 0.6.1
+```
+
+After the success of the downgrade process, we can see that the `[installed]` indicator is now aligned with the `0.6.0` version of 'js2wasm`, as intended in the example.
 
 ## Next Steps
 


### PR DESCRIPTION
Signed-off-by: tpmccallum tim.mccallum@fermyon.com

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title`, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result)
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)

tpmccallum@tpmccallum:~/developer$ bart check content/spin/v2/managing-plugins.md 
✅ content/spin/v2/managing-plugins.md

- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors
- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
