### PR TITLE
Add missing code block close

### DIFF
--- a/content/spin/v2/quickstart.md
+++ b/content/spin/v2/quickstart.md
@@ -491,6 +491,8 @@ class IncomingHandler(http.IncomingHandler):
             {"content-type": "text/plain"},
             bytes("Hello from the Python SDK!", "utf-8")
         )
+```
+
 {{ blockEnd }}
 
 {{ startTab "TinyGo"}}


### PR DESCRIPTION
Quickstart page missed a closing code block.