### PR TITLE
Some manifest fields can now include variables

### DIFF
--- a/content/spin/v2/http-outbound.md
+++ b/content/spin/v2/http-outbound.md
@@ -8,6 +8,7 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/v2/http-outbo
 ---
 - [Using HTTP From Applications](#using-http-from-applications)
 - [Granting HTTP Permissions to Components](#granting-http-permissions-to-components)
+  - [Configuration-Based Permissions](#configuration-based-permissions)
 - [Making HTTP Requests Within an Application](#making-http-requests-within-an-application)
   - [Local Service Chaining](#local-service-chaining)
   - [Intra-Application HTTP Requests by Route](#intra-application-http-requests-by-route)
@@ -178,6 +179,10 @@ allowed_outbound_hosts = [ "https://*.example.com" ]
 ```
 
 For development-time convenience, you can also pass the string `"https://*:*"` in the `allowed_outbound_hosts` collection. This allows the Wasm module to make HTTP requests to _any_ host and on any port. However, once you've determined which hosts your code needs, you should remove this string and list the hosts instead.  Other Spin implementations may restrict host access and disallow components that ask to connect to anything and everything!
+
+### Configuration-Based Permissions
+
+You can use [application variables](./variables.md#adding-variables-to-your-applications) in the `allowed_outbound_hosts` field. However, this feature is not yet available on Fermyon Cloud.
 
 ## Making HTTP Requests Within an Application
 

--- a/content/spin/v2/manifest-reference.md
+++ b/content/spin/v2/manifest-reference.md
@@ -6,6 +6,7 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/v2/manifest-r
 
 ---
 - [Manifest Format](#manifest-format)
+- [Using Variables in the Manifest](#using-variables-in-the-manifest)
 - [Manifest Fields](#manifest-fields)
 - [The `application` Table](#the-application-table)
 - [The `application.trigger` Table](#the-applicationtrigger-table)
@@ -48,6 +49,20 @@ allowed_outbound_hosts = []
 command = "cargo build --target wasm32-wasi --release"
 watch = ["src/**/*.rs", "Cargo.toml"]
 ```
+
+## Using Variables in the Manifest
+
+The following fields allow you to use [expressions](./variables.md#adding-variables-to-your-applications) in their values:
+
+* `application.trigger.redis.address`
+* `trigger.redis.channel`
+* `component.*.allowed_outbound_hosts`
+
+Spin resolves manifest expressions at application load time. Subsequent changes to variables do not update expression-based values.
+
+The only variables permitted in manifest expressions are application variables.
+
+> Manifest expressions are not yet supported on Fermyon Cloud.
 
 ## Manifest Fields
 

--- a/content/spin/v2/rdbms-storage.md
+++ b/content/spin/v2/rdbms-storage.md
@@ -213,3 +213,7 @@ By default, Spin components are not allowed to make outgoing network requests, i
 [component.uses-db]
 allowed_outbound_hosts = ["postgres://postgres.example.com:5432"]
 ```
+
+### Configuration-Based Permissions
+
+You can use [application variables](./variables.md#adding-variables-to-your-applications) in the `allowed_outbound_hosts` field. However, this feature is not yet available on Fermyon Cloud.

--- a/content/spin/v2/redis-outbound.md
+++ b/content/spin/v2/redis-outbound.md
@@ -179,3 +179,7 @@ By default, Spin components are not allowed to make outgoing network requests, i
 [component.uses-redis]
 allowed_outbound_hosts = ["redis://redis.example.com:6379"]
 ```
+
+### Configuration-Based Permissions
+
+You can use [application variables](./variables.md#adding-variables-to-your-applications) in the `allowed_outbound_hosts` field. However, this feature is not yet available on Fermyon Cloud.

--- a/content/spin/v2/redis-trigger.md
+++ b/content/spin/v2/redis-trigger.md
@@ -9,7 +9,7 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/v2/redis-trig
 - [Specifying a Redis Trigger](#specifying-a-redis-trigger)
 - [Redis Trigger Application Settings](#redis-trigger-application-settings)
 - [Redis Components](#redis-components)
-	- [The Message Handler](#the-message-handler)
+  - [The Message Handler](#the-message-handler)
 - [Inside Redis Components](#inside-redis-components)
 
 Pub-sub (publish-subscribe) messaging is a popular architecture for asynchronous message processing. Spin has built-in support to creating and running applications in response to messages on [pub-sub Redis channels](https://redis.io/topics/pubsub).
@@ -32,6 +32,8 @@ Such a trigger says that Redis messages on the specified _channel_ should be han
 
 > Spin subscribes only to the channels that are mapped to components. Other channels are ignored. If multiple components subscribe to the same channel, a message on that channel will activate all of the components.
 
+You can use [application variables](./variables.md#adding-variables-to-your-applications) in the `channel` field. However, this feature is not yet available on Fermyon Cloud.
+
 ## Redis Trigger Application Settings
 
 Applications containing Redis triggers must specify the address of the Redis server to subscribe to. This is done via the `[application.trigger.redis]` section of manifest:
@@ -48,6 +50,8 @@ By default, Spin does not authenticate to Redis. You can work around this by pro
 > Do not use passwords in code committed to version control systems.
 
 > We plan to offer secrets-based authentication in future versions of Spin.
+
+You can use [application variables](./variables.md#adding-variables-to-your-applications) in the `address` field. This can be particularly useful for credentials, allowing you to pass credentials in via [variables providers](./dynamic-configuration.md#application-variables-runtime-configuration) rather than including them in `spin.toml`. However, this feature is not yet available on Fermyon Cloud.
 
 ## Redis Components
 


### PR DESCRIPTION
**This is for Spin 2.4.**

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title`, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result)
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
