### PR TITLE
Create new 2.4 tabs to populate

### DIFF
--- a/content/spin/v2/cli-reference.md
+++ b/content/spin/v2/cli-reference.md
@@ -164,6 +164,43 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v2.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin add --help
+spin-add 
+Scaffold a new component into an existing application
+
+USAGE:
+    spin add [OPTIONS] [NAME]
+
+ARGS:
+    <NAME>    The name of the new application or component
+
+OPTIONS:
+    -a, --accept-defaults              An optional argument that allows to skip prompts for the
+                                       manifest file by accepting the defaults if available on the
+                                       template
+    -f, --file <APP_MANIFEST_FILE>     Path to spin.toml
+    -h, --help                         Print help information
+        --init                         Create the new application or component in the current
+                                       directory
+    -o, --output <OUTPUT_PATH>         The directory in which to create the new application or
+                                       component. The default is the name argument
+    -t, --template <TEMPLATE_ID>       The template from which to create the new application or
+                                       component. Run `spin templates list` to see available options
+        --tag <TAGS>                   Filter templates to select by tags
+    -v, --value <VALUES>               Parameter values to be passed to the template (in name=value
+                                       format)
+        --values-file <VALUES_FILE>    A TOML file which contains parameter values in name = "value"
+                                       format. Parameters passed as CLI option overwrite parameters
+                                       specified in the file
+```
+
+
+
 
 {{ blockEnd }}
 
@@ -271,6 +308,39 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v2.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin build --help
+spin-build 
+Build the Spin application
+
+USAGE:
+    spin build [OPTIONS] [--] [UP_ARGS]...
+
+ARGS:
+    <UP_ARGS>...    
+
+OPTIONS:
+    -c, --component-id <COMPONENT_ID>...
+            Component ID to build. This can be specified multiple times. The default is all
+            components
+
+    -f, --from <APP_MANIFEST_FILE>
+            The application to build. This may be a manifest (spin.toml) file, or a directory
+            containing a spin.toml file. If omitted, it defaults to "spin.toml" [default: spin.toml]
+
+    -h, --help
+            Print help information
+
+    -u, --up
+            Run the application after building
+```
+
+
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -295,6 +365,12 @@ The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](/cloud/clo
 The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference).
 
 {{ blockEnd }}
+
+{{ startTab "v2.4"}}
+
+The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference).
+
+
 
 {{ blockEnd }}
 
@@ -321,6 +397,12 @@ The `spin cloud apps` command is implemented by the [Fermyon Cloud Plugin](/clou
 
 {{ blockEnd }}
 
+{{ startTab "v2.4"}}
+
+The `spin cloud apps` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-apps).
+
+
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -345,6 +427,12 @@ The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](/cl
 The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-deploy).
 
 {{ blockEnd }}
+
+{{ startTab "v2.4"}}
+
+The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-deploy).
+
+
 
 {{ blockEnd }}
 
@@ -371,6 +459,12 @@ The `spin cloud link` command is implemented by the [Fermyon Cloud Plugin](/clou
 
 {{ blockEnd }}
 
+{{ startTab "v2.4"}}
+
+The `spin cloud link` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-link).
+
+
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -395,6 +489,12 @@ The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](/clo
 The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-login).
 
 {{ blockEnd }}
+
+{{ startTab "v2.4"}}
+
+The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-login).
+
+
 
 {{ blockEnd }}
 
@@ -421,6 +521,12 @@ The `spin cloud sqlite` command is implemented by the [Fermyon Cloud Plugin](/cl
 
 {{ blockEnd }}
 
+{{ startTab "v2.4"}}
+
+The `spin cloud sqlite` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-sqlite).
+
+
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -446,6 +552,12 @@ The `spin cloud unlink` command is implemented by the [Fermyon Cloud Plugin](/cl
 
 {{ blockEnd }}
 
+{{ startTab "v2.4"}}
+
+The `spin cloud unlink` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-unlink).
+
+
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -470,6 +582,12 @@ The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](
 The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-variables).
 
 {{ blockEnd }}
+
+{{ startTab "v2.4"}}
+
+The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-variables).
+
+
 
 {{ blockEnd }}
 
@@ -549,6 +667,28 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v2.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin doctor --help
+
+spin-doctor 
+Detect and fix problems with Spin applications
+
+USAGE:
+    spin doctor [OPTIONS]
+
+OPTIONS:
+    -f, --from <APP_MANIFEST_FILE>    The application to check. This may be a manifest (spin.toml)
+                                      file, or a directory containing a spin.toml file. If omitted,
+                                      it defaults to "spin.toml" [default: spin.toml]
+    -h, --help                        Print help information
+```
+
+
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -573,6 +713,12 @@ OPTIONS:
 > Please note: Spin `help` is a convenient way to access help using a subcommand, instead of using the `--help` option. For example, `spin help cloud` will give you the same output as `spin cloud --help`. Similarly, `spin help build` will give you the same output as `spin build --help` and so forth.
 
 {{ blockEnd }}
+
+{{ startTab "v2.4"}}
+
+> Please note: Spin `help` is a convenient way to access help using a subcommand, instead of using the `--help` option. For example, `spin help cloud` will give you the same output as `spin cloud --help`. Similarly, `spin help build` will give you the same output as `spin build --help` and so forth.
+
+
 
 {{ blockEnd }}
 
@@ -697,6 +843,43 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v2.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin new --help  
+
+spin-new 
+Scaffold a new application based on a template
+
+USAGE:
+    spin new [OPTIONS] [NAME]
+
+ARGS:
+    <NAME>    The name of the new application or component
+
+OPTIONS:
+    -a, --accept-defaults              An optional argument that allows to skip prompts for the
+                                       manifest file by accepting the defaults if available on the
+                                       template
+    -h, --help                         Print help information
+        --init                         Create the new application or component in the current
+                                       directory
+    -o, --output <OUTPUT_PATH>         The directory in which to create the new application or
+                                       component. The default is the name argument
+    -t, --template <TEMPLATE_ID>       The template from which to create the new application or
+                                       component. Run `spin templates list` to see available options
+        --tag <TAGS>                   Filter templates to select by tags
+    -v, --value <VALUES>               Parameter values to be passed to the template (in name=value
+                                       format)
+        --values-file <VALUES_FILE>    A TOML file which contains parameter values in name = "value"
+                                       format. Parameters passed as CLI option overwrite parameters
+                                       specified in the file
+```
+
+
+
 {{ blockEnd }}
 
 **Please note: `spin new` vs `spin add`**.  These commands are similar except that:
@@ -792,6 +975,34 @@ SUBCOMMANDS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins --help
+
+spin-plugins 
+Install/uninstall Spin plugins
+
+USAGE:
+    spin plugins <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    help         Print this message or the help of the given subcommand(s)
+    install      Install plugin from a manifest
+    list         List available or installed plugins
+    search       Search for plugins by name
+    uninstall    Remove a plugin from your installation
+    update       Fetch the latest Spin plugins from the spin-plugins repository
+    upgrade      Upgrade one or all plugins
+```
+
+
 
 {{ blockEnd }}
 
@@ -923,6 +1134,47 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v2.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins install --help
+
+spin-plugins-install 
+Install plugin from a manifest.
+
+The binary file and manifest of the plugin is copied to the local Spin plugins directory.
+
+USAGE:
+    spin plugins install [OPTIONS] [PLUGIN_NAME]
+
+ARGS:
+    <PLUGIN_NAME>
+            Name of Spin plugin
+
+OPTIONS:
+    -f, --file <LOCAL_PLUGIN_MANIFEST>
+            Path to local plugin manifest
+
+    -h, --help
+            Print help information
+
+        --override-compatibility-check
+            Overrides a failed compatibility check of the plugin with the current version of Spin
+
+    -u, --url <REMOTE_PLUGIN_MANIFEST>
+            URL of remote plugin manifest to install
+
+    -v, --version <VERSION>
+            Specific version of a plugin to be install from the centralized plugins repository
+
+    -y, --yes
+            Skips prompt to accept the installation of the plugin
+```
+
+
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -993,6 +1245,27 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v2.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins list --help   
+
+spin-plugins-list 
+List available or installed plugins
+
+USAGE:
+    spin plugins list [OPTIONS]
+
+OPTIONS:
+        --filter <FILTER>    Filter the list to plugins containing this string
+    -h, --help               Print help information
+        --installed          List only installed plugins
+```
+
+
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -1062,6 +1335,27 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins search --help
+spin-plugins-search 
+Search for plugins by name
+
+USAGE:
+    spin plugins search [FILTER]
+
+ARGS:
+    <FILTER>    The text to search for. If omitted, all plugins are returned
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+
 
 {{ blockEnd }}
 
@@ -1136,6 +1430,28 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v2.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins uninstall --help
+
+spin-plugins-uninstall 
+Remove a plugin from your installation
+
+USAGE:
+    spin plugins uninstall <NAME>
+
+ARGS:
+    <NAME>    Name of Spin plugin
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -1199,6 +1515,25 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins update --help
+
+spin-plugins-update 
+Fetch the latest Spin plugins from the spin-plugins repository
+
+USAGE:
+    spin plugins update
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+
 
 {{ blockEnd }}
 
@@ -1339,6 +1674,50 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v2.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins upgrade --help
+
+spin-plugins-upgrade 
+Upgrade one or all plugins
+
+USAGE:
+    spin plugins upgrade [OPTIONS] [PLUGIN_NAME]
+
+ARGS:
+    <PLUGIN_NAME>    Name of Spin plugin to upgrade
+
+OPTIONS:
+    -a, --all
+            Upgrade all plugins
+
+    -d, --downgrade
+            Allow downgrading a plugin's version
+
+    -f, --file <LOCAL_PLUGIN_MANIFEST>
+            Path to local plugin manifest
+
+    -h, --help
+            Print help information
+
+        --override-compatibility-check
+            Overrides a failed compatibility check of the plugin with the current version of Spin
+
+    -u, --url <REMOTE_PLUGIN_MANIFEST>
+            Path to remote plugin manifest
+
+    -v, --version <VERSION>
+            Specific version of a plugin to be install from the centralized plugins repository
+
+    -y, --yes
+            Skips prompt to accept the installation of the plugin[s]
+```
+
+
+
 {{ blockEnd }}
 
 **Note:** For additional information, please see the [Managing Plugins](/spin/managing-plugins) and/or [Creating Plugins](/spin/plugin-authoring) sections of the documentation.
@@ -1419,6 +1798,30 @@ SUBCOMMANDS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry --help
+spin-registry 
+Commands for working with OCI registries to distribute applications
+
+USAGE:
+    spin registry <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    help     Print this message or the help of the given subcommand(s)
+    login    Log in to a registry
+    pull     Pull a Spin application from a registry
+    push     Push a Spin application to a registry
+```
+
+
 
 {{ blockEnd }}
 
@@ -1502,6 +1905,31 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v2.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry login --help
+
+spin-registry-login 
+Log in to a registry
+
+USAGE:
+    spin registry login [OPTIONS] <SERVER>
+
+ARGS:
+    <SERVER>    OCI registry server (e.g. ghcr.io)
+
+OPTIONS:
+    -h, --help                   Print help information
+    -p, --password <PASSWORD>    Password for the registry
+        --password-stdin         Take the password from stdin
+    -u, --username <USERNAME>    Username for the registry
+```
+
+
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -1583,6 +2011,32 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry pull --help
+
+spin-registry-pull 
+Pull a Spin application from a registry
+
+USAGE:
+    spin registry pull [OPTIONS] <REFERENCE>
+
+ARGS:
+    <REFERENCE>    Reference in the registry of the published Spin application. This is a string
+                   whose format is defined by the registry standard, and generally consists of
+                   <registry>/<username>/<application-name>:<version>. E.g.
+                   ghcr.io/ogghead/spin-test-app:0.1.0
+
+OPTIONS:
+    -h, --help        Print help information
+    -k, --insecure    Ignore server certificate errors
+```
+
+
 
 {{ blockEnd }}
 
@@ -1680,6 +2134,37 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry push --help 
+
+spin-registry-push 
+Push a Spin application to a registry
+
+USAGE:
+    spin registry push [OPTIONS] <REFERENCE>
+
+ARGS:
+    <REFERENCE>    Reference in the registry of the Spin application. This is a string whose
+                   format is defined by the registry standard, and generally consists of
+                   <registry>/<username>/<application-name>:<version>. E.g.
+                   ghcr.io/ogghead/spin-test-app:0.1.0
+
+OPTIONS:
+        --build                       Specifies to perform `spin build` before pushing the
+                                      application [env: SPIN_ALWAYS_BUILD=]
+    -f, --from <APP_MANIFEST_FILE>    The application to push. This may be a manifest (spin.toml)
+                                      file, or a directory containing a spin.toml file. If omitted,
+                                      it defaults to "spin.toml" [default: spin.toml]
+    -h, --help                        Print help information
+    -k, --insecure                    Ignore server certificate errors
+```
+
+
 
 {{ blockEnd }}
 
@@ -1855,6 +2340,42 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v2.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates install --help
+
+spin-templates-install 
+Install templates from a Git repository or local directory.
+
+The files of the templates are copied to the local template store: a directory in your data or home
+directory.
+
+USAGE:
+    spin templates install [OPTIONS]
+
+OPTIONS:
+        --branch <BRANCH>
+            The optional branch of the git repository
+
+        --dir <FROM_DIR>
+            Local directory containing the template(s) to install
+
+        --git <FROM_GIT>
+            The URL of the templates git repository. The templates must be in a git repository in a
+            "templates" directory
+
+    -h, --help
+            Print help information
+
+        --upgrade
+            If present, updates existing templates instead of skipping
+```
+
+
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -1924,6 +2445,27 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates list --help   
+
+spin-templates-list 
+List the installed templates
+
+USAGE:
+    spin templates list [OPTIONS]
+
+OPTIONS:
+    -h, --help          Print help information
+        --tag <TAGS>    Filter templates matching all provided tags
+        --verbose       Whether to show additional template details in the list
+```
+
+
 
 {{ blockEnd }}
 
@@ -1999,6 +2541,28 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates uninstall --help
+
+spin-templates-uninstall 
+Remove a template from your installation
+
+USAGE:
+    spin templates uninstall <TEMPLATE_ID>
+
+ARGS:
+    <TEMPLATE_ID>    The template to uninstall
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+
 
 {{ blockEnd }}
 
@@ -2108,6 +2672,40 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates upgrade --help
+spin-templates-upgrade 
+Upgrade templates to match your current version of Spin.
+
+The files of the templates are copied to the local template store: a directory in your data or home
+directory.
+
+USAGE:
+    spin templates upgrade [OPTIONS]
+
+OPTIONS:
+        --all
+            By default, Spin displays the list of installed repositories and prompts you to choose
+            which to upgrade.  Pass this flag to upgrade all repositories without prompting
+
+        --branch <BRANCH>
+            The optional branch of the git repository, if a specific repository is given
+
+    -h, --help
+            Print help information
+
+        --repo <GIT_URL>
+            By default, Spin displays the list of installed repositories and prompts you to choose
+            which to upgrade.  Pass this flag to upgrade only the specified repository without
+            prompting
+```
+
+
 
 {{ blockEnd }}
 
@@ -2353,6 +2951,85 @@ HTTP TRIGGER OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v2.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin up --help
+
+spin-up 
+Start the Spin application
+
+USAGE:
+    spin up [OPTIONS]
+
+OPTIONS:
+        --build                 For local apps, specifies to perform `spin build` before running the
+                                application [env: SPIN_ALWAYS_BUILD=]
+        --direct-mounts         For local apps with directory mounts and no excluded files, mount
+                                them directly instead of using a temporary directory
+    -e, --env <ENV>             Pass an environment variable (key=value) to all components of the
+                                application
+    -f, --from <APPLICATION>    The application to run. This may be a manifest (spin.toml) file, a
+                                directory containing a spin.toml file, or a remote registry
+                                reference. If omitted, it defaults to "spin.toml"
+    -h, --help                  
+    -k, --insecure              Ignore server certificate errors from a registry
+        --temp <TMP>            Temporary directory for the static assets of the components
+
+HTTP TRIGGER OPTIONS:
+        --allow-transient-write
+            Set the static assets of the components in the temporary directory as writable
+
+        --cache <WASMTIME_CACHE_FILE>
+            Wasmtime cache configuration file
+            
+            [env: WASMTIME_CACHE_FILE=]
+
+        --disable-cache
+            Disable Wasmtime cache
+            
+            [env: DISABLE_WASMTIME_CACHE=]
+
+        --disable-pooling
+            Disable Wasmtime's pooling instance allocator
+
+        --follow <FOLLOW_ID>
+            Print output to stdout/stderr only for given component(s)
+
+        --key-value <KEY_VALUES>
+            Set a key/value pair (key=value) in the application's default store. Any existing value
+            will be overwritten. Can be used multiple times
+
+    -L, --log-dir <APP_LOG_DIR>
+            Log directory for the stdout and stderr of components. Setting to the empty string
+            disables logging to disk
+            
+            [env: SPIN_LOG_DIR=]
+
+    -q, --quiet
+            Silence all component output to stdout/stderr
+
+        --runtime-config-file <RUNTIME_CONFIG_FILE>
+            Configuration file for config providers and wasmtime config
+            
+            [env: RUNTIME_CONFIG_FILE=]
+
+        --sqlite <SQLITE_STATEMENTS>
+            Run a SQLite statement such as a migration against the default database. To run from a
+            file, prefix the filename with @ e.g. spin up --sqlite @migration.sql
+
+        --state-dir <STATE_DIR>
+            Set the application state directory path. This is used in the default locations for
+            logs, key value stores, etc.
+            
+            For local apps, this defaults to `.spin/` relative to the `spin.toml` file. For remote
+            apps, this has no default (unset). Passing an empty value forces the value to be unset.
+```
+
+
+
 {{ blockEnd }}
 
 > **Please note:** If the `-f` or `--from` options do not accurately infer the intended registry or `.toml` file for your application, then you can explicitly specify either the `--from-registry` or  `--from-file` options to clarify this.
@@ -2438,6 +3115,31 @@ The following additional trigger options are available for the [spin up](#spin-u
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+--listen <ADDRESS>
+    IP address and port to listen on
+    
+    [default: 127.0.0.1:3000]
+
+--tls-cert <TLS_CERT>
+    The path to the certificate to use for https, if this is not set, normal http will be
+    used. The cert should be in PEM format
+    
+    [env: SPIN_TLS_CERT=]
+
+--tls-key <TLS_KEY>
+    The path to the certificate key to use for https, if this is not set, normal http will
+    be used. The key should be in PKCS#8 format
+    
+    [env: SPIN_TLS_KEY=]
+```
+
+
 
 {{ blockEnd }}
 
@@ -2533,6 +3235,35 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v2.4"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin watch --help
+spin-watch 
+Build and run the Spin application, rebuilding and restarting it when files change
+
+USAGE:
+    spin watch [OPTIONS] [UP_ARGS]...
+
+ARGS:
+    <UP_ARGS>...    Arguments to be passed through to spin up
+
+OPTIONS:
+    -c, --clear                       Clear the screen before each run
+    -d, --debounce <DEBOUNCE>         Set the timeout between detected change and re-execution, in
+                                      milliseconds [default: 100]
+    -f, --from <APP_MANIFEST_FILE>    The application to watch. This may be a manifest (spin.toml)
+                                      file, or a directory containing a spin.toml file. If omitted,
+                                      it defaults to "spin.toml" [default: spin.toml]
+    -h, --help                        Print help information
+        --skip-build                  Only run the Spin application, restarting it when build
+                                      artifacts change
+```
+
+
+
 {{ blockEnd }}
 
 ## Stability Table
@@ -2596,5 +3327,22 @@ CLI commands have four phases that indicate levels of stability:
 | <code>spin watch</code>                                                               | Experimental |
 
 {{ blockEnd }}
+
+{{ startTab "v2.4"}}
+
+| Command                                                                               | Stability    |
+| ------------------------------------------------------------------------------------- | ------------ |
+| <code>spin add</code>                                                                 | Stable       |
+| <code>spin build</code>                                                               | Stable       |
+| <code>spin new</code>                                                                 | Stable       |
+| <code>spin plugins</code>                                                             | Stable       |
+| <code>spin templates</code>                                                           | Stable       |
+| <code>spin up</code>                                                                  | Stable       |
+| <code>spin cloud</code>                                                               | Stabilizing  |
+| <code>spin registry</code>                                                            | Stabilizing  |
+| <code>spin doctor</code>                                                              | Experimental |
+| <code>spin watch</code>                                                               | Experimental |
+
+
 
 {{ blockEnd }}

--- a/content/spin/v2/cli-reference.md
+++ b/content/spin/v2/cli-reference.md
@@ -200,6 +200,7 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+{{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin build
@@ -337,6 +338,7 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+{{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin cloud
@@ -365,6 +367,7 @@ The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](/cloud/clo
 
 The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference).
 
+{{ blockEnd }}
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -395,6 +398,7 @@ The `spin cloud apps` command is implemented by the [Fermyon Cloud Plugin](/clou
 The `spin cloud apps` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-apps).
 
 {{ blockEnd }}
+{{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin cloud deploy
@@ -423,6 +427,7 @@ The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](/cl
 
 The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-deploy).
 
+{{ blockEnd }}
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -453,6 +458,7 @@ The `spin cloud link` command is implemented by the [Fermyon Cloud Plugin](/clou
 The `spin cloud link` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-link).
 
 {{ blockEnd }}
+{{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin cloud login
@@ -481,6 +487,7 @@ The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](/clo
 
 The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-login).
 
+{{ blockEnd }}
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -511,6 +518,7 @@ The `spin cloud sqlite` command is implemented by the [Fermyon Cloud Plugin](/cl
 The `spin cloud sqlite` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-sqlite).
 
 {{ blockEnd }}
+{{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin cloud unlink
@@ -540,6 +548,7 @@ The `spin cloud unlink` command is implemented by the [Fermyon Cloud Plugin](/cl
 The `spin cloud unlink` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-unlink).
 
 {{ blockEnd }}
+{{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin cloud variables
@@ -568,6 +577,7 @@ The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](
 
 The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-variables).
 
+{{ blockEnd }}
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -667,6 +677,7 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+{{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin help
@@ -695,6 +706,7 @@ OPTIONS:
 
 > Please note: Spin `help` is a convenient way to access help using a subcommand, instead of using the `--help` option. For example, `spin help cloud` will give you the same output as `spin cloud --help`. Similarly, `spin help build` will give you the same output as `spin build --help` and so forth.
 
+{{ blockEnd }}
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -855,6 +867,7 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+{{ blockEnd }}
 
 **Please note: `spin new` vs `spin add`**.  These commands are similar except that:
 
@@ -976,6 +989,7 @@ SUBCOMMANDS:
     upgrade      Upgrade one or all plugins
 ```
 
+{{ blockEnd }}
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -1146,6 +1160,7 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+{{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin plugins list
@@ -1235,6 +1250,7 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+{{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin plugins search
@@ -1323,6 +1339,7 @@ OPTIONS:
     -h, --help    Print help information
 ```
 
+{{ blockEnd }}
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -1417,6 +1434,7 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+{{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin plugins update
@@ -1497,6 +1515,7 @@ OPTIONS:
     -h, --help    Print help information
 ```
 
+{{ blockEnd }}
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -1679,6 +1698,7 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+{{ blockEnd }}
 
 **Note:** For additional information, please see the [Managing Plugins](/spin/managing-plugins) and/or [Creating Plugins](/spin/plugin-authoring) sections of the documentation.
 
@@ -1781,6 +1801,7 @@ SUBCOMMANDS:
     push     Push a Spin application to a registry
 ```
 
+{{ blockEnd }}
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -1887,6 +1908,7 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+{{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin registry pull
@@ -1992,6 +2014,7 @@ OPTIONS:
     -k, --insecure    Ignore server certificate errors
 ```
 
+{{ blockEnd }}
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -2118,6 +2141,7 @@ OPTIONS:
     -k, --insecure                    Ignore server certificate errors
 ```
 
+{{ blockEnd }}
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -2327,6 +2351,7 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+{{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin templates list
@@ -2415,6 +2440,7 @@ OPTIONS:
         --verbose       Whether to show additional template details in the list
 ```
 
+{{ blockEnd }}
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -2510,6 +2536,7 @@ OPTIONS:
     -h, --help    Print help information
 ```
 
+{{ blockEnd }}
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -2651,6 +2678,7 @@ OPTIONS:
             prompting
 ```
 
+{{ blockEnd }}
 {{ blockEnd }}
 
 **Note:** For additional information, please see the [Managing Templates](/spin/managing-templates) and/or [Creating Templates](/spin/template-authoring) sections of the documentation.
@@ -2974,6 +3002,7 @@ HTTP TRIGGER OPTIONS:
 ```
 
 {{ blockEnd }}
+{{ blockEnd }}
 
 > **Please note:** If the `-f` or `--from` options do not accurately infer the intended registry or `.toml` file for your application, then you can explicitly specify either the `--from-registry` or  `--from-file` options to clarify this.
 
@@ -3082,6 +3111,7 @@ The following additional trigger options are available for the [spin up](#spin-u
     [env: SPIN_TLS_KEY=]
 ```
 
+{{ blockEnd }}
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -3204,6 +3234,7 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+{{ blockEnd }}
 
 ## Stability Table
 
@@ -3282,4 +3313,5 @@ CLI commands have four phases that indicate levels of stability:
 | <code>spin doctor</code>                                                              | Experimental |
 | <code>spin watch</code>                                                               | Experimental |
 
+{{ blockEnd }}
 {{ blockEnd }}

--- a/content/spin/v2/cli-reference.md
+++ b/content/spin/v2/cli-reference.md
@@ -742,7 +742,6 @@ OPTIONS:
     -h, --help                         Print help information
         --init                         Create the new application or component in the current
                                        directory
-        --no-vcs                       An optional argument that allows to skip creating .gitignore
     -o, --output <OUTPUT_PATH>         The directory in which to create the new application or
                                        component. The default is the name argument
     -t, --template <TEMPLATE_ID>       The template from which to create the new application or
@@ -854,6 +853,7 @@ OPTIONS:
     -h, --help                         Print help information
         --init                         Create the new application or component in the current
                                        directory
+        --no-vcs                       An optional argument that allows to skip creating .gitignore
     -o, --output <OUTPUT_PATH>         The directory in which to create the new application or
                                        component. The default is the name argument
     -t, --template <TEMPLATE_ID>       The template from which to create the new application or
@@ -2708,7 +2708,6 @@ USAGE:
 OPTIONS:
         --build                 For local apps, specifies to perform `spin build` before running the
                                 application [env: SPIN_ALWAYS_BUILD=]
-        --cache-dir <CACHE_DIR>    Cache directory for downloaded components and assets
         --direct-mounts         For local apps with directory mounts and no excluded files, mount
                                 them directly instead of using a temporary directory
     -e, --env <ENV>             Pass an environment variable (key=value) to all components of the
@@ -2940,6 +2939,7 @@ USAGE:
 OPTIONS:
         --build                 For local apps, specifies to perform `spin build` before running the
                                 application [env: SPIN_ALWAYS_BUILD=]
+        --cache-dir <CACHE_DIR>    Cache directory for downloaded components and assets
         --direct-mounts         For local apps with directory mounts and no excluded files, mount
                                 them directly instead of using a temporary directory
     -e, --env <ENV>             Pass an environment variable (key=value) to all components of the

--- a/content/spin/v2/cli-reference.md
+++ b/content/spin/v2/cli-reference.md
@@ -199,9 +199,6 @@ OPTIONS:
                                        specified in the file
 ```
 
-
-
-
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -339,8 +336,6 @@ OPTIONS:
             Run the application after building
 ```
 
-
-
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -369,8 +364,6 @@ The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](/cloud/clo
 {{ startTab "v2.4"}}
 
 The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference).
-
-
 
 {{ blockEnd }}
 
@@ -401,8 +394,6 @@ The `spin cloud apps` command is implemented by the [Fermyon Cloud Plugin](/clou
 
 The `spin cloud apps` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-apps).
 
-
-
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -431,8 +422,6 @@ The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](/cl
 {{ startTab "v2.4"}}
 
 The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-deploy).
-
-
 
 {{ blockEnd }}
 
@@ -463,8 +452,6 @@ The `spin cloud link` command is implemented by the [Fermyon Cloud Plugin](/clou
 
 The `spin cloud link` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-link).
 
-
-
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -493,8 +480,6 @@ The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](/clo
 {{ startTab "v2.4"}}
 
 The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-login).
-
-
 
 {{ blockEnd }}
 
@@ -525,8 +510,6 @@ The `spin cloud sqlite` command is implemented by the [Fermyon Cloud Plugin](/cl
 
 The `spin cloud sqlite` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-sqlite).
 
-
-
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -556,8 +539,6 @@ The `spin cloud unlink` command is implemented by the [Fermyon Cloud Plugin](/cl
 
 The `spin cloud unlink` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-unlink).
 
-
-
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -586,8 +567,6 @@ The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](
 {{ startTab "v2.4"}}
 
 The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-variables).
-
-
 
 {{ blockEnd }}
 
@@ -687,8 +666,6 @@ OPTIONS:
     -h, --help                        Print help information
 ```
 
-
-
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -717,8 +694,6 @@ OPTIONS:
 {{ startTab "v2.4"}}
 
 > Please note: Spin `help` is a convenient way to access help using a subcommand, instead of using the `--help` option. For example, `spin help cloud` will give you the same output as `spin cloud --help`. Similarly, `spin help build` will give you the same output as `spin build --help` and so forth.
-
-
 
 {{ blockEnd }}
 
@@ -755,6 +730,7 @@ OPTIONS:
     -h, --help                         Print help information
         --init                         Create the new application or component in the current
                                        directory
+        --no-vcs                       An optional argument that allows to skip creating .gitignore
     -o, --output <OUTPUT_PATH>         The directory in which to create the new application or
                                        component. The default is the name argument
     -t, --template <TEMPLATE_ID>       The template from which to create the new application or
@@ -877,8 +853,6 @@ OPTIONS:
                                        format. Parameters passed as CLI option overwrite parameters
                                        specified in the file
 ```
-
-
 
 {{ blockEnd }}
 
@@ -1001,8 +975,6 @@ SUBCOMMANDS:
     update       Fetch the latest Spin plugins from the spin-plugins repository
     upgrade      Upgrade one or all plugins
 ```
-
-
 
 {{ blockEnd }}
 
@@ -1173,8 +1145,6 @@ OPTIONS:
             Skips prompt to accept the installation of the plugin
 ```
 
-
-
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -1264,8 +1234,6 @@ OPTIONS:
         --installed          List only installed plugins
 ```
 
-
-
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -1354,8 +1322,6 @@ ARGS:
 OPTIONS:
     -h, --help    Print help information
 ```
-
-
 
 {{ blockEnd }}
 
@@ -1450,8 +1416,6 @@ OPTIONS:
     -h, --help    Print help information
 ```
 
-
-
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -1532,8 +1496,6 @@ USAGE:
 OPTIONS:
     -h, --help    Print help information
 ```
-
-
 
 {{ blockEnd }}
 
@@ -1716,8 +1678,6 @@ OPTIONS:
             Skips prompt to accept the installation of the plugin[s]
 ```
 
-
-
 {{ blockEnd }}
 
 **Note:** For additional information, please see the [Managing Plugins](/spin/managing-plugins) and/or [Creating Plugins](/spin/plugin-authoring) sections of the documentation.
@@ -1820,8 +1780,6 @@ SUBCOMMANDS:
     pull     Pull a Spin application from a registry
     push     Push a Spin application to a registry
 ```
-
-
 
 {{ blockEnd }}
 
@@ -1928,8 +1886,6 @@ OPTIONS:
     -u, --username <USERNAME>    Username for the registry
 ```
 
-
-
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -2035,8 +1991,6 @@ OPTIONS:
     -h, --help        Print help information
     -k, --insecure    Ignore server certificate errors
 ```
-
-
 
 {{ blockEnd }}
 
@@ -2163,8 +2117,6 @@ OPTIONS:
     -h, --help                        Print help information
     -k, --insecure                    Ignore server certificate errors
 ```
-
-
 
 {{ blockEnd }}
 
@@ -2374,8 +2326,6 @@ OPTIONS:
             If present, updates existing templates instead of skipping
 ```
 
-
-
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -2464,8 +2414,6 @@ OPTIONS:
         --tag <TAGS>    Filter templates matching all provided tags
         --verbose       Whether to show additional template details in the list
 ```
-
-
 
 {{ blockEnd }}
 
@@ -2561,8 +2509,6 @@ ARGS:
 OPTIONS:
     -h, --help    Print help information
 ```
-
-
 
 {{ blockEnd }}
 
@@ -2705,8 +2651,6 @@ OPTIONS:
             prompting
 ```
 
-
-
 {{ blockEnd }}
 
 **Note:** For additional information, please see the [Managing Templates](/spin/managing-templates) and/or [Creating Templates](/spin/template-authoring) sections of the documentation.
@@ -2736,6 +2680,7 @@ USAGE:
 OPTIONS:
         --build                 For local apps, specifies to perform `spin build` before running the
                                 application [env: SPIN_ALWAYS_BUILD=]
+        --cache-dir <CACHE_DIR>    Cache directory for downloaded components and assets
         --direct-mounts         For local apps with directory mounts and no excluded files, mount
                                 them directly instead of using a temporary directory
     -e, --env <ENV>             Pass an environment variable (key=value) to all components of the
@@ -3027,8 +2972,6 @@ HTTP TRIGGER OPTIONS:
             For local apps, this defaults to `.spin/` relative to the `spin.toml` file. For remote
             apps, this has no default (unset). Passing an empty value forces the value to be unset.
 ```
-
-
 
 {{ blockEnd }}
 
@@ -3138,8 +3081,6 @@ The following additional trigger options are available for the [spin up](#spin-u
     
     [env: SPIN_TLS_KEY=]
 ```
-
-
 
 {{ blockEnd }}
 
@@ -3262,8 +3203,6 @@ OPTIONS:
                                       artifacts change
 ```
 
-
-
 {{ blockEnd }}
 
 ## Stability Table
@@ -3342,7 +3281,5 @@ CLI commands have four phases that indicate levels of stability:
 | <code>spin registry</code>                                                            | Stabilizing  |
 | <code>spin doctor</code>                                                              | Experimental |
 | <code>spin watch</code>                                                               | Experimental |
-
-
 
 {{ blockEnd }}


### PR DESCRIPTION
Create new 2.4 code tabs for Spin Cli Reference to populate with new values:
Possibly `spin up --cache-dir` https://github.com/fermyon/spin/commit/731bc1ff7a2a43e3708b79b0477e8f4dbf1f9dfc
and (https://fermyon.slack.com/archives/D03NAM1JS4R/p1712202575784749)
`spin new --no-vcs` https://github.com/fermyon/spin/commit/0c05b2af3bf39f58d6f0537614bf704079897f7f


Bart check:

<img width="668" alt="Screenshot 2024-04-04 at 21 22 38" src="https://github.com/fermyon/developer/assets/9831342/852e0ba8-da55-4837-9381-1feccca2ae95">

Local preview:

![Screenshot 2024-04-04 at 21 26 13](https://github.com/fermyon/developer/assets/9831342/71d3bc12-38fa-410f-bcab-65408fcdac9e)
