### PR TITLE
Add new enterprise architectures and patterns to the Spin Up Hub

### DIFF
--- a/content/api/hub/pattern_aggregates.md
+++ b/content/api/hub/pattern_aggregates.md
@@ -1,0 +1,33 @@
+title = "Aggregate Pattern"
+template = "render_hub_content_body"
+date = "2024-04-11T06:50:00Z"
+content-type = "text/plain"
+tags = ["Patterns", "Service Chaining", "Polyglot"]
+
+[extra]
+author = "Thorsten Hans"
+type = "hub_document"
+category = "Pattern"
+language = "Polyglot"
+created_at = "2024-04-11T06:50:00Z"
+last_updated = "2024-04-11T06:50:00Z"
+spin_version = ">=v2.4.2"
+summary = "Polyglot implementation of the Aggregate Pattern using Service Chaining capabilities provided by Spin"
+url = "https://github.com/fermyon/enterprise-architectures-and-patterns/tree/main/aggregate-pattern"
+keywords = "Patterns, Service Chaining, Polyglot"
+
+---
+
+This folder contains an implementation of the Aggregate Pattern. The sample consists of two backend services (written in Go and TypeScript) and an aggregate (written in Rust).
+
+### What Is the Aggregate Pattern?
+
+In the context of a microservices architecture, the Aggregate Design Pattern refers to a strategy for composing multiple microservices to fulfill a single business operation or query. Instead of relying on a single microservice to handle complex operations, aggregates distribute the workload across multiple services, each responsible for managing a specific aspect of the operation. This pattern helps in achieving scalability, fault isolation, and autonomy among microservices. By decomposing large operations into smaller, manageable tasks distributed across microservices, the Aggregate Design Pattern enables more efficient and resilient systems in microservices architecture.
+
+## Sample Scenario
+
+For demonstration purposes, take the two backend services [`customers-service`](https://github.com/fermyon/enterprise-architectures-and-patterns/tree/main/aggregate-pattern/customers-service) and [`incidents-service`](https://github.com/fermyon/enterprise-architectures-and-patterns/tree/main/aggregate-pattern/incidents-service) as given. Although they expose necessary data directly, developers must issue many requests to create a dashboard displaying information provided by those backend services. 
+
+Instead, an **aggregate** is implemented ([`aggregates-service](https://github.com/fermyon/enterprise-architectures-and-patterns/tree/main/aggregate-pattern/aggregates-service)) which is responsible for loading data from backend services (via service chaining) and composing a uniform representation for data that should be visualized on the dashboard. 
+
+In addition to calling into backend services using service chaining, the *Aggregates Service* is responsible to transform data according to the use-case.

--- a/content/api/hub/pattern_long_running_jobs_over_http.md
+++ b/content/api/hub/pattern_long_running_jobs_over_http.md
@@ -1,0 +1,29 @@
+title = "Long-Running Jobs over HTTP"
+template = "render_hub_content_body"
+date = "2024-04-11T06:55:00Z"
+content-type = "text/plain"
+tags = ["patterns", "Rust", "MQTT", "HTTP"]
+
+[extra]
+author = "Thorsten Hans"
+type = "hub_document"
+category = "Pattern"
+language = "Rust"
+created_at = "2024-04-11T06:55:00Z"
+last_updated = "2024-04-11T06:55:00Z"
+spin_version = ">=v2.4.2"
+summary = "This sample illustrates how to offload time-intense computing from an HTTP API to a background app using MQTT"
+url = "https://github.com/fermyon/enterprise-architectures-and-patterns/tree/main/long-running-jobs-over-http"
+keywords = "Patterns, MQTT, HTTP, Rust"
+
+---
+
+This sample demonstrates how you can add support for long-running jobs over HTTP using Spin and its `MQTT` capabilities.
+
+### What are Long-Running Jobs over HTTP
+
+In some situations you may want to perform data processing which takes longer than usual HTTP requests and could result in users facing timeouts. By using the `MQTT` capabilities provided by Spin, you can move the time-consuming actions (or jobs) to a different (background) process.
+
+For demonstration purposes, this application uses [Eclipse Mosquitto](https://mosquitto.org/) as a message broker to offload time-consuming tasks from the [`API`](https://github.com/fermyon/enterprise-architectures-and-patterns/tree/main/long-running-jobs-over-http/api) app to either the [`Spin Worker`](https://github.com/fermyon/enterprise-architectures-and-patterns/tree/main/long-running-jobs-over-http/spin-worker) or the [`Native Worker`](https://github.com/fermyon/enterprise-architectures-and-patterns/tree/main/long-running-jobs-over-http/native-worker). Upon creating a new job, a unique identifier for the job is created and used to track its status and report back to the callee (using response payload and the response `Location` header).
+
+The API and both workers track the state of the jobs using a SQLite database.


### PR DESCRIPTION
This commit adds "Long-Running Jobs over HTTP" and "Aggregate Pattern" to the Hub

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title`, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result)
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors
- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
