### PR TITLE
Update Dart docs

### DIFF
--- a/content/wasm-languages/dart.md
+++ b/content/wasm-languages/dart.md
@@ -5,7 +5,7 @@ tags = ["dart", "webassembly"]
 template = "page_lang"
 [extra]
 author = "Fermyon Staff"
-last_modified = "2023-10-26T00:50:50Z"
+last_modified = "2024-04-11T00:50:50Z"
 url = "https://github.com/fermyon/developer/blob/main/content/wasm-languages/dart.md"
 
 ---
@@ -15,9 +15,6 @@ actively developing support for Wasm along with the Chrome team's work on
 [Wasm-GC](https://chromestatus.com/feature/6062715726462976). The source code
 for this work-in-process can be found
 [in the Dart SDK repository](https://github.com/dart-lang/sdk/tree/main/pkg/dart2wasm).
-
-Dart also supports loading and running Wasm modules via
-[package:wasm](https://github.com/dart-lang/wasm).
 
 ## Pros and Cons
 
@@ -39,6 +36,6 @@ Here are some great resources:
 - There is a [tracking issue](https://github.com/dart-lang/sdk/issues/32894) for
   Dart-to-Wasm work.
 - [Source code](https://github.com/dart-lang/wasm) for `package:wasm`.
-- Flutter now has [WebAssembly support for the browser](https://docs.flutter.dev/platform-integration/web/wasm)
+- Flutter now has [WebAssembly support for the browser](https://flutter.dev/wasm)
 - There was a great [presentation about Dart at Wasm I/O](https://youtu.be/Nkjc9r0WDNo?si=mWY8hJ7tw6mx3-Ne)
 - In May, 2023, The New Stack ran an [article about WebAssembly in Dart 3 and Flutter 3.10](https://thenewstack.io/dev-news-dart-3-meets-wasm-flutter-3-10-and-qwik-streamable-javascript/)


### PR DESCRIPTION
Drop reference to discontinued `wasm` package.
Updated link to Flutter support

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title`, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result)
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
