### PR TITLE
Add improved search for `async` in Rust documentation.

### DIFF
--- a/content/spin/v2/rust-components.md
+++ b/content/spin/v2/rust-components.md
@@ -330,7 +330,7 @@ mod api {
 }
 ```
 
-> For further reference, see the [Spin SDK HTTP router](https://fermyon.github.io/rust-docs/spin/main/spin_sdk/http/struct.Router.html).
+> The Spin SDK HTTP router has additional async methods. For example, the `get_async` and `post_async` methods register an async handler at the path for the HTTP GET and HTTP POST methods. For further reference, see the [Spin SDK HTTP router](https://fermyon.github.io/rust-docs/spin/main/spin_sdk/http/struct.Router.html).
 
 ## Storing Data in Redis From Rust Components
 

--- a/content/spin/v2/rust-components.md
+++ b/content/spin/v2/rust-components.md
@@ -293,6 +293,8 @@ proxies or URL shorteners.
 
 ## Routing in a Component
 
+<!-- @searchTerm "async" -->
+
 The Rust SDK [provides a router](https://github.com/fermyon/spin-rust-sdk/tree/main/examples/http-router) that makes it easier to handle routing within a component:
 
 ```rust

--- a/content/spin/v2/rust-components.md
+++ b/content/spin/v2/rust-components.md
@@ -330,7 +330,9 @@ mod api {
 }
 ```
 
-> The Spin SDK HTTP router has additional async methods. For example, the `get_async` and `post_async` methods register an async handler at the path for the HTTP GET and HTTP POST methods. For further reference, see the [Spin SDK HTTP router](https://fermyon.github.io/rust-docs/spin/main/spin_sdk/http/struct.Router.html).
+Handlers within a `Router` can be sync or async. Use `Router`'s "plain" methods (e.g. `get`, `post`) to assign synchronous handlers, and its "async" methods (e.g. `get_async`, `post_async`) for asynchronous handlers.  You can mix sync and async handlers in the same `Router`, and can use `handle` or `handle_async` to invoke `Router` processing, regardless of whether invididual handlers are sync or async.
+
+> For further reference, see the [Spin SDK HTTP router](https://fermyon.github.io/rust-docs/spin/main/spin_sdk/http/struct.Router.html).
 
 ## Storing Data in Redis From Rust Components
 


### PR DESCRIPTION
Fixes https://github.com/fermyon/developer/issues/1253


This has already been documented, but it is not easily found. Therefore, this PR has been created to hoist that page to the surface. And still leave the other search results intact.

Before:

![Screenshot 2024-04-16 at 11 19 59](https://github.com/fermyon/developer/assets/9831342/0f51862a-e086-4883-aa3f-129f637c2cbe)

After:

![Screenshot 2024-04-16 at 11 19 42](https://github.com/fermyon/developer/assets/9831342/1de25def-e9e4-4782-a05f-d5c592c71a97)

This takes the user to the example shown below:

![Screenshot 2024-04-16 at 11 20 48](https://github.com/fermyon/developer/assets/9831342/50972aa3-4e74-45e9-940f-b7cd37fd824a)
