### PR TITLE
Use Spin SDK 3.1.0 and Componentize-Py 0.13.3

### DIFF
--- a/content/spin/v2/python-components.md
+++ b/content/spin/v2/python-components.md
@@ -41,7 +41,7 @@ The Python SDK is built using [`componentize-py`](https://github.com/bytecodeall
 <!-- @selectiveCpy -->
 
 ```bash
-$ pip3 install componentize-py==0.12.0
+$ pip3 install componentize-py==0.13.3
 ```
 
 > **Please note:** The `hello-world` sample below installs `componentize-py` automatically via the `pip3 install -r requirements.txt` command - so feel free to skip this step if you are following the `hello-world` sample with us.
@@ -127,7 +127,15 @@ The `requirements.txt`, by default, contains the references to the `spin-sdk` an
 <!-- @selectiveCpy -->
 
 ```bash
-$ pip3 install -r requirements.txt
+$ pip3 install -r requirements.txt 
+Collecting spin-sdk==3.1.0 (from -r requirements.txt (line 1))
+  Using cached spin_sdk-3.1.0-py3-none-any.whl.metadata (16 kB)
+Collecting componentize-py==0.13.3 (from -r requirements.txt (line 2))
+  Using cached componentize_py-0.13.3-cp37-abi3-macosx_10_12_x86_64.whl.metadata (3.4 kB)
+Using cached spin_sdk-3.1.0-py3-none-any.whl (94 kB)
+Using cached componentize_py-0.13.3-cp37-abi3-macosx_10_12_x86_64.whl (38.8 MB)
+Installing collected packages: spin-sdk, componentize-py
+Successfully installed componentize-py-0.13.3 spin-sdk-3.1.0
 ```
 
 ## Structure of a Python Component
@@ -174,15 +182,14 @@ Building a Spin HTTP component using the Python SDK means defining a top-level c
 <!-- @nocpy -->
 
 ```python
-from spin_sdk import http
-from spin_sdk.http import Request, Response
+from spin_sdk.http import IncomingHandler, Request, Response
 
-class IncomingHandler(http.IncomingHandler):
+class IncomingHandler(IncomingHandler):
     def handle_request(self, request: Request) -> Response:
         return Response(
             200,
             {"content-type": "text/plain"},
-            bytes("Hello from the Python SDK!", "utf-8")
+            bytes("Hello from Python!", "utf-8")
         )
 ```
 

--- a/content/wasm-languages/python.md
+++ b/content/wasm-languages/python.md
@@ -10,9 +10,6 @@ url = "https://github.com/fermyon/developer/blob/main/content/wasm-languages/pyt
 ---
 
 Python is one of the most popular programming languages in the world, and its WebAssembly implementation seems to be coming along quickly.
-While it is not yet ready for use, we anticipate it will be functional in the first half of 2022.
-
-The most momentum is in the CPython community, which is approaching both Emscripten-based and WASI-based implementations.
 
 ## Available Implementations
 


### PR DESCRIPTION
Fixes https://github.com/fermyon/developer/issues/1254
Related https://github.com/fermyon/spin-python-sdk/pull/99

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title`, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result)
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors
- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
