### PR TITLE
Add Rust version dynamically

### DIFF
--- a/content/spin/v2/contributing-spin.md
+++ b/content/spin/v2/contributing-spin.md
@@ -28,7 +28,7 @@ from the community and the maintainers before you start working on your feature.
 The following guide is intended to make sure your contribution can get merged as
 soon as possible. First, make sure you have Rust installed.
 
-![Rust Version](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2Ffermyon%2Fspin%2Fmain%2FCargo.toml&query=$[%27workspace%27][%27package%27][%27rust-version%27]&label=Rust%20Version&logo=Rust)
+![Rust Version](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2Ffermyon%2Fspin%2Fmain%2FCargo.toml&query=$[%27workspace%27][%27package%27][%27rust-version%27]&label=Rust%20Version&logo=Rust&color=orange)
 
 After [installing Rust](https://www.rust-lang.org/tools/install) please ensure the `wasm32-wasi` and
   `wasm32-unknown-unknown` targets are configured. For example:

--- a/content/spin/v2/contributing-spin.md
+++ b/content/spin/v2/contributing-spin.md
@@ -26,24 +26,26 @@ from the community and the maintainers before you start working on your feature.
 ## Making Code Contributions to Spin
 
 The following guide is intended to make sure your contribution can get merged as
-soon as possible. First, make sure you have the following prerequisites
-configured:
+soon as possible. First, make sure you have Rust installed.
 
-- [Rust](https://www.rust-lang.org/) at
-  [1.68+](https://www.rust-lang.org/tools/install) with the `wasm32-wasi` and
-  `wasm32-unknown-unknown` targets configured
-  (`rustup target add wasm32-wasi && rustup target add wasm32-unknown-unknown`)
-- [`rustfmt`](https://github.com/rust-lang/rustfmt) and
-  [`clippy`](https://github.com/rust-lang/rust-clippy) configured for your Rust
-  installation
+![Rust Version](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2Ffermyon%2Fspin%2Fmain%2FCargo.toml&query=$[%27workspace%27][%27package%27][%27rust-version%27]&label=Rust%20Version&logo=Rust)
+
+After [installing Rust](https://www.rust-lang.org/tools/install) please ensure the `wasm32-wasi` and
+  `wasm32-unknown-unknown` targets are configured. For example:
+  
+```bash
+rustup target add wasm32-wasi && rustup target add wasm32-unknown-unknown
+```
+
+In addition, make sure you have the following prerequisites configured:
+
+- [`rustfmt`](https://github.com/rust-lang/rustfmt)
+- [`clippy`](https://github.com/rust-lang/rust-clippy) 
 - `make`
-- if you are a VS Code user, we recommend the [`rust-analyzer`](https://rust-analyzer.github.io/) extension.
-- please ensure you
-  [configure adding a GPG signature to your commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)
-  as well as appending a sign-off message (`git commit -S -s`)
+- [`rust-analyzer`](https://rust-analyzer.github.io/) extension (for Visual Studio Code users)
+- [GPG signature verification for your GitHub commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) and remember to use a sign-off message (`git commit -S -s`) on each of your commits
 
-Once you have set up the prerequisites and identified the contribution you want
-to make to Spin, make sure you can correctly build the project:
+Once you have set up the prerequisites and identified the contribution you want to make to Spin, make sure you can correctly build the project:
 
 <!-- @selectiveCpy -->
 

--- a/content/spin/v2/rust-components.md
+++ b/content/spin/v2/rust-components.md
@@ -544,9 +544,12 @@ For more information about using Serverless AI from Rust, see the [Serverless AI
 
 If you bump into issues building and running your Rust component, here are some common causes of problems:
 
-- Make sure `cargo` is present in your path
+- Make sure `cargo` is present in your path.
 - Make sure the [Rust](https://www.rust-lang.org/) version is recent.
-  - To check: run  `cargo --version`.  The Spin SDK needs Rust 1.64 or above.
+
+![Rust Version](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2Ffermyon%2Fspin%2Fmain%2FCargo.toml&query=$[%27workspace%27][%27package%27][%27rust-version%27]&label=Rust%20Version&logo=Rust)
+
+  - To check: run  `cargo --version`.  
   - To update: run `rustup update`.
 - Make sure the `wasm32-wasi` compiler target is installed.
   - To check: run `rustup target list --installed` and check that `wasm32-wasi` is on the list.

--- a/content/spin/v2/rust-components.md
+++ b/content/spin/v2/rust-components.md
@@ -547,7 +547,7 @@ If you bump into issues building and running your Rust component, here are some 
 - Make sure `cargo` is present in your path.
 - Make sure the [Rust](https://www.rust-lang.org/) version is recent.
 
-![Rust Version](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2Ffermyon%2Fspin%2Fmain%2FCargo.toml&query=$[%27workspace%27][%27package%27][%27rust-version%27]&label=Rust%20Version&logo=Rust)
+![Rust Version](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2Ffermyon%2Fspin%2Fmain%2FCargo.toml&query=$[%27workspace%27][%27package%27][%27rust-version%27]&label=Rust%20Version&logo=Rust&color=orange)
 
   - To check: run  `cargo --version`.  
   - To update: run `rustup update`.


### PR DESCRIPTION
Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title`, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result)
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)

<img width="930" alt="Screenshot 2024-04-23 at 17 59 07" src="https://github.com/fermyon/developer/assets/9831342/ac04fce0-d1a2-434d-a3c7-fb0ac64906bc">

- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)

![Screenshot 2024-04-23 at 17 57 34](https://github.com/fermyon/developer/assets/9831342/37cf6365-58d7-4ebd-ac19-b6f1bc477fc0)

![Screenshot 2024-04-23 at 17 57 11](https://github.com/fermyon/developer/assets/9831342/8335f4cc-d44a-421b-9561-a927dbc5a12a)

- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors
- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
