### PR TITLE
Update docs and tutorials to place `llama2-chat` and `codellama-instruct` in the correct directory

### DIFF
--- a/content/spin/v1/ai-sentiment-analysis-api-tutorial.md
+++ b/content/spin/v1/ai-sentiment-analysis-api-tutorial.md
@@ -162,8 +162,8 @@ Next, we need to create the appropriate folder structure from within the applica
 
 ```bash
 # llama2-chat
-$ mkdir -p .spin/ai-models
-$ cd .spin/ai-models
+$ mkdir -p .spin/ai-models/llama
+$ cd .spin/ai-models/llama
 $ wget https://huggingface.co/TheBloke/Llama-2-13B-chat-GGML/resolve/a17885f653039bd07ed0f8ff4ecc373abf5425fd/llama-2-13b-chat.ggmlv3.q3_K_L.bin
 $ mv llama-2-13b-chat.ggmlv3.q3_K_L.bin llama2-chat
 ```
@@ -174,7 +174,8 @@ $ mv llama-2-13b-chat.ggmlv3.q3_K_L.bin llama2-chat
 tree .spin
 .spin
 └── ai-models
-    └── llama2-chat
+    └── llama
+        └── llama2-chat
 ```
 
 **codellama-instruct example download**
@@ -185,8 +186,8 @@ tree .spin
 
 ```bash
 # codellama-instruct
-$ mkdir -p .spin/ai-models
-$ cd .spin/ai-models
+$ mkdir -p .spin/ai-models/llama
+$ cd .spin/ai-models/llama
 $ wget https://huggingface.co/TheBloke/CodeLlama-13B-Instruct-GGML/resolve/b3dc9d8df8b4143ee18407169f09bc12c0ae09ef/codellama-13b-instruct.ggmlv3.Q3_K_L.bin
 $ mv codellama-13b-instruct.ggmlv3.Q3_K_L.bin codellama-instruct
 ```
@@ -197,7 +198,8 @@ $ mv codellama-13b-instruct.ggmlv3.Q3_K_L.bin codellama-instruct
 tree .spin
 .spin
 └── ai-models
-    └── codellama-instruct
+    └── llama
+        └── codellama-instruct
 ```
 
 **all-minilm-l6-v2 example download**

--- a/content/spin/v1/serverless-ai-api-guide.md
+++ b/content/spin/v1/serverless-ai-api-guide.md
@@ -38,7 +38,7 @@ ai_models = ["codellama-instruct"]
 By default, the Spin framework will expect any already trained model files (which are configured as per the previous section) to be downloaded by the user and made available inside a `.spin/ai-models/` file path of a given application. For example:
 
 ```bash
-code-generator-rs/.spin/ai-models/codellama-instruct
+code-generator-rs/.spin/ai-models/llama/codellama-instruct
 ```
 
 See the [serverless AI Tutorial](./ai-sentiment-analysis-api-tutorial) documentation for more concrete examples of implementing the Fermyon Serverless AI API, in your favorite language.

--- a/content/spin/v1/serverless-ai-hello-world.md
+++ b/content/spin/v1/serverless-ai-hello-world.md
@@ -336,7 +336,7 @@ Available Routes:
 hello-world: https://hello-world-XXXXXX.fermyon.app (wildcard)
 ```
  
-The app’s manifest file reads the line `ai-models = ["llama2-chat"]` and uses that model in the cloud. For any changes to take effect in the app, it needs to be re-deployed to the cloud.
+The app’s manifest file reads the line `ai_models = ["llama2-chat"]` and uses that model in the cloud. For any changes to take effect in the app, it needs to be re-deployed to the cloud.
  
 **Using the Cloud-GPU plugin to test locally**
  

--- a/content/spin/v2/ai-sentiment-analysis-api-tutorial.md
+++ b/content/spin/v2/ai-sentiment-analysis-api-tutorial.md
@@ -183,8 +183,8 @@ Next, we need to create the appropriate folder structure from within the applica
 
 ```bash
 # llama2-chat
-$ mkdir -p .spin/ai-models
-$ cd .spin/ai-models
+$ mkdir -p .spin/ai-models/llama
+$ cd .spin/ai-models/llama
 $ wget https://huggingface.co/TheBloke/Llama-2-13B-chat-GGML/resolve/a17885f653039bd07ed0f8ff4ecc373abf5425fd/llama-2-13b-chat.ggmlv3.q3_K_L.bin
 $ mv llama-2-13b-chat.ggmlv3.q3_K_L.bin llama2-chat
 ```
@@ -195,7 +195,8 @@ $ mv llama-2-13b-chat.ggmlv3.q3_K_L.bin llama2-chat
 tree .spin
 .spin
 └── ai-models
-    └── llama2-chat
+    └── llama
+        └── llama2-chat
 ```
 
 **codellama-instruct example download**
@@ -206,8 +207,8 @@ tree .spin
 
 ```bash
 # codellama-instruct
-$ mkdir -p .spin/ai-models
-$ cd .spin/ai-models
+$ mkdir -p .spin/ai-models/llama
+$ cd .spin/ai-models/llama
 $ wget https://huggingface.co/TheBloke/CodeLlama-13B-Instruct-GGML/resolve/b3dc9d8df8b4143ee18407169f09bc12c0ae09ef/codellama-13b-instruct.ggmlv3.Q3_K_L.bin
 $ mv codellama-13b-instruct.ggmlv3.Q3_K_L.bin codellama-instruct
 ```
@@ -218,7 +219,8 @@ $ mv codellama-13b-instruct.ggmlv3.Q3_K_L.bin codellama-instruct
 tree .spin
 .spin
 └── ai-models
-    └── codellama-instruct
+    └── llama
+        └── codellama-instruct
 ```
 
 **all-minilm-l6-v2 example download**

--- a/content/spin/v2/serverless-ai-api-guide.md
+++ b/content/spin/v2/serverless-ai-api-guide.md
@@ -37,7 +37,7 @@ ai_models = ["codellama-instruct"]
 By default, the Spin framework will expect any already trained model files (which are configured as per the previous section) to be downloaded by the user and made available inside a `.spin/ai-models/` file path of a given application. For example:
 
 ```bash
-code-generator-rs/.spin/ai-models/codellama-instruct
+code-generator-rs/.spin/ai-models/llama/codellama-instruct
 ```
 
 See the [serverless AI Tutorial](./ai-sentiment-analysis-api-tutorial) documentation for more concrete examples of implementing the Fermyon Serverless AI API, in your favorite language.

--- a/content/spin/v2/serverless-ai-hello-world.md
+++ b/content/spin/v2/serverless-ai-hello-world.md
@@ -332,7 +332,7 @@ Available Routes:
 hello-world: https://hello-world-XXXXXX.fermyon.app (wildcard)
 ```
  
-The app’s manifest file reads the line `ai-models = ["llama2-chat"]` and uses that model in the cloud. For any changes to take effect in the app, it needs to be re-deployed to the cloud.
+The app’s manifest file reads the line `ai_models = ["llama2-chat"]` and uses that model in the cloud. For any changes to take effect in the app, it needs to be re-deployed to the cloud.
  
 **Using the Cloud-GPU plugin to test locally**
  


### PR DESCRIPTION
As discussed in the following issues, this PR updates the documentation and instructs users to place `llama2-chat` and `codellama-instruct` models at `.spin/ai-models/llama/` instead of `.spin/ai-models/`

- https://github.com/fermyon/spin/issues/2467
- https://github.com/fermyon/developer/issues/1260

closes #1260 

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title`, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result)
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors
- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
