### PR TITLE
Adding Spin 2.5 documentation

### DIFF
--- a/content/spin/v2/cli-reference.md
+++ b/content/spin/v2/cli-reference.md
@@ -40,6 +40,7 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/v2/cli-refere
 - [spin templates list](#spin-templates-list)
 - [spin templates uninstall](#spin-templates-uninstall)
 - [spin templates upgrade](#spin-templates-upgrade)
+- [spin test](#spin-test)
 - [spin up](#spin-up)
   - [spin up (HTTP Trigger)](#spin-up-http-trigger)
 - [spin watch](#spin-watch)
@@ -3353,6 +3354,36 @@ OPTIONS:
 {{ blockEnd }}
 
 **Note:** For additional information, please see the [Managing Templates](/spin/managing-templates) and/or [Creating Templates](/spin/template-authoring) sections of the documentation.
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin test
+
+{{ startTab "v2.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin test --help
+
+By default `spin-test` will invoke the `run` subcommand.
+
+Usage: test [COMMAND]
+
+Commands:
+  run   Run a test suite against a Spin application
+  help  Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
+```
+
+{{ blockEnd }}
+
+{{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin up

--- a/content/spin/v2/cli-reference.md
+++ b/content/spin/v2/cli-reference.md
@@ -200,6 +200,44 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin add --help
+spin-add 
+Scaffold a new component into an existing application
+
+USAGE:
+    spin add [OPTIONS] [NAME]
+
+ARGS:
+    <NAME>    The name of the new application or component
+
+OPTIONS:
+    -a, --accept-defaults              An optional argument that allows to skip prompts for the
+                                       manifest file by accepting the defaults if available on the
+                                       template
+    -f, --file <APP_MANIFEST_FILE>     Path to spin.toml
+    -h, --help                         Print help information
+        --init                         Create the new application or component in the current
+                                       directory
+    -o, --output <OUTPUT_PATH>         The directory in which to create the new application or
+                                       component. The default is the name argument
+    -t, --template <TEMPLATE_ID>       The template from which to create the new application or
+                                       component. Run `spin templates list` to see available options
+        --tag <TAGS>                   Filter templates to select by tags
+    -v, --value <VALUES>               Parameter values to be passed to the template (in name=value
+                                       format)
+        --values-file <VALUES_FILE>    A TOML file which contains parameter values in name = "value"
+                                       format. Parameters passed as CLI option overwrite parameters
+                                       specified in the file
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -338,6 +376,40 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin build --help
+spin-build 
+Build the Spin application
+
+USAGE:
+    spin build [OPTIONS] [--] [UP_ARGS]...
+
+ARGS:
+    <UP_ARGS>...    
+
+OPTIONS:
+    -c, --component-id <COMPONENT_ID>...
+            Component ID to build. This can be specified multiple times. The default is all
+            components
+
+    -f, --from <APP_MANIFEST_FILE>
+            The application to build. This may be a manifest (spin.toml) file, or a directory
+            containing a spin.toml file. If omitted, it defaults to "spin.toml" [default: spin.toml]
+
+    -h, --help
+            Print help information
+
+    -u, --up
+            Run the application after building
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -368,6 +440,13 @@ The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](/cloud/clo
 The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference).
 
 {{ blockEnd }}
+
+{{ startTab "v2.5"}}
+
+The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference).
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -398,6 +477,13 @@ The `spin cloud apps` command is implemented by the [Fermyon Cloud Plugin](/clou
 The `spin cloud apps` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-apps).
 
 {{ blockEnd }}
+
+{{ startTab "v2.5"}}
+
+The `spin cloud apps` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-apps).
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -428,6 +514,13 @@ The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](/cl
 The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-deploy).
 
 {{ blockEnd }}
+
+{{ startTab "v2.5"}}
+
+The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-deploy).
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -458,6 +551,13 @@ The `spin cloud link` command is implemented by the [Fermyon Cloud Plugin](/clou
 The `spin cloud link` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-link).
 
 {{ blockEnd }}
+
+{{ startTab "v2.5"}}
+
+The `spin cloud link` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-link).
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -488,6 +588,13 @@ The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](/clo
 The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-login).
 
 {{ blockEnd }}
+
+{{ startTab "v2.5"}}
+
+The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-login).
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -518,6 +625,13 @@ The `spin cloud sqlite` command is implemented by the [Fermyon Cloud Plugin](/cl
 The `spin cloud sqlite` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-sqlite).
 
 {{ blockEnd }}
+
+{{ startTab "v2.5"}}
+
+The `spin cloud sqlite` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-sqlite).
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -548,6 +662,13 @@ The `spin cloud unlink` command is implemented by the [Fermyon Cloud Plugin](/cl
 The `spin cloud unlink` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-unlink).
 
 {{ blockEnd }}
+
+{{ startTab "v2.5"}}
+
+The `spin cloud unlink` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-unlink).
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -578,6 +699,13 @@ The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](
 The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-variables).
 
 {{ blockEnd }}
+
+{{ startTab "v2.5"}}
+
+The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-variables).
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -677,6 +805,29 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin doctor --help
+
+spin-doctor 
+Detect and fix problems with Spin applications
+
+USAGE:
+    spin doctor [OPTIONS]
+
+OPTIONS:
+    -f, --from <APP_MANIFEST_FILE>    The application to check. This may be a manifest (spin.toml)
+                                      file, or a directory containing a spin.toml file. If omitted,
+                                      it defaults to "spin.toml" [default: spin.toml]
+    -h, --help                        Print help information
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -707,6 +858,13 @@ OPTIONS:
 > Please note: Spin `help` is a convenient way to access help using a subcommand, instead of using the `--help` option. For example, `spin help cloud` will give you the same output as `spin cloud --help`. Similarly, `spin help build` will give you the same output as `spin build --help` and so forth.
 
 {{ blockEnd }}
+
+{{ startTab "v2.5"}}
+
+> Please note: Spin `help` is a convenient way to access help using a subcommand, instead of using the `--help` option. For example, `spin help cloud` will give you the same output as `spin cloud --help`. Similarly, `spin help build` will give you the same output as `spin build --help` and so forth.
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -867,6 +1025,45 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin new --help  
+
+spin-new 
+Scaffold a new application based on a template
+
+USAGE:
+    spin new [OPTIONS] [NAME]
+
+ARGS:
+    <NAME>    The name of the new application or component
+
+OPTIONS:
+    -a, --accept-defaults              An optional argument that allows to skip prompts for the
+                                       manifest file by accepting the defaults if available on the
+                                       template
+    -h, --help                         Print help information
+        --init                         Create the new application or component in the current
+                                       directory
+        --no-vcs                       An optional argument that allows to skip creating .gitignore
+    -o, --output <OUTPUT_PATH>         The directory in which to create the new application or
+                                       component. The default is the name argument
+    -t, --template <TEMPLATE_ID>       The template from which to create the new application or
+                                       component. Run `spin templates list` to see available options
+        --tag <TAGS>                   Filter templates to select by tags
+    -v, --value <VALUES>               Parameter values to be passed to the template (in name=value
+                                       format)
+        --values-file <VALUES_FILE>    A TOML file which contains parameter values in name = "value"
+                                       format. Parameters passed as CLI option overwrite parameters
+                                       specified in the file
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 **Please note: `spin new` vs `spin add`**.  These commands are similar except that:
@@ -990,6 +1187,35 @@ SUBCOMMANDS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins --help
+
+spin-plugins 
+Install/uninstall Spin plugins
+
+USAGE:
+    spin plugins <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    help         Print this message or the help of the given subcommand(s)
+    install      Install plugin from a manifest
+    list         List available or installed plugins
+    search       Search for plugins by name
+    uninstall    Remove a plugin from your installation
+    update       Fetch the latest Spin plugins from the spin-plugins repository
+    upgrade      Upgrade one or all plugins
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -1160,6 +1386,48 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins install --help
+
+spin-plugins-install 
+Install plugin from a manifest.
+
+The binary file and manifest of the plugin is copied to the local Spin plugins directory.
+
+USAGE:
+    spin plugins install [OPTIONS] [PLUGIN_NAME]
+
+ARGS:
+    <PLUGIN_NAME>
+            Name of Spin plugin
+
+OPTIONS:
+    -f, --file <LOCAL_PLUGIN_MANIFEST>
+            Path to local plugin manifest
+
+    -h, --help
+            Print help information
+
+        --override-compatibility-check
+            Overrides a failed compatibility check of the plugin with the current version of Spin
+
+    -u, --url <REMOTE_PLUGIN_MANIFEST>
+            URL of remote plugin manifest to install
+
+    -v, --version <VERSION>
+            Specific version of a plugin to be install from the centralized plugins repository
+
+    -y, --yes
+            Skips prompt to accept the installation of the plugin
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -1250,6 +1518,28 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins list --help   
+
+spin-plugins-list 
+List available or installed plugins
+
+USAGE:
+    spin plugins list [OPTIONS]
+
+OPTIONS:
+        --filter <FILTER>    Filter the list to plugins containing this string
+    -h, --help               Print help information
+        --installed          List only installed plugins
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -1340,6 +1630,28 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins search --help
+spin-plugins-search 
+Search for plugins by name
+
+USAGE:
+    spin plugins search [FILTER]
+
+ARGS:
+    <FILTER>    The text to search for. If omitted, all plugins are returned
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -1434,6 +1746,29 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins uninstall --help
+
+spin-plugins-uninstall 
+Remove a plugin from your installation
+
+USAGE:
+    spin plugins uninstall <NAME>
+
+ARGS:
+    <NAME>    Name of Spin plugin
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -1516,6 +1851,26 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins update --help
+
+spin-plugins-update 
+Fetch the latest Spin plugins from the spin-plugins repository
+
+USAGE:
+    spin plugins update
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -1698,6 +2053,51 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins upgrade --help
+
+spin-plugins-upgrade 
+Upgrade one or all plugins
+
+USAGE:
+    spin plugins upgrade [OPTIONS] [PLUGIN_NAME]
+
+ARGS:
+    <PLUGIN_NAME>    Name of Spin plugin to upgrade
+
+OPTIONS:
+    -a, --all
+            Upgrade all plugins
+
+    -d, --downgrade
+            Allow downgrading a plugin's version
+
+    -f, --file <LOCAL_PLUGIN_MANIFEST>
+            Path to local plugin manifest
+
+    -h, --help
+            Print help information
+
+        --override-compatibility-check
+            Overrides a failed compatibility check of the plugin with the current version of Spin
+
+    -u, --url <REMOTE_PLUGIN_MANIFEST>
+            Path to remote plugin manifest
+
+    -v, --version <VERSION>
+            Specific version of a plugin to be install from the centralized plugins repository
+
+    -y, --yes
+            Skips prompt to accept the installation of the plugin[s]
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 **Note:** For additional information, please see the [Managing Plugins](/spin/managing-plugins) and/or [Creating Plugins](/spin/plugin-authoring) sections of the documentation.
@@ -1802,6 +2202,31 @@ SUBCOMMANDS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry --help
+spin-registry 
+Commands for working with OCI registries to distribute applications
+
+USAGE:
+    spin registry <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    help     Print this message or the help of the given subcommand(s)
+    login    Log in to a registry
+    pull     Pull a Spin application from a registry
+    push     Push a Spin application to a registry
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -1908,6 +2333,32 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry login --help
+
+spin-registry-login 
+Log in to a registry
+
+USAGE:
+    spin registry login [OPTIONS] <SERVER>
+
+ARGS:
+    <SERVER>    OCI registry server (e.g. ghcr.io)
+
+OPTIONS:
+    -h, --help                   Print help information
+    -p, --password <PASSWORD>    Password for the registry
+        --password-stdin         Take the password from stdin
+    -u, --username <USERNAME>    Username for the registry
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -2015,6 +2466,33 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry pull --help
+
+spin-registry-pull 
+Pull a Spin application from a registry
+
+USAGE:
+    spin registry pull [OPTIONS] <REFERENCE>
+
+ARGS:
+    <REFERENCE>    Reference in the registry of the published Spin application. This is a string
+                   whose format is defined by the registry standard, and generally consists of
+                   <registry>/<username>/<application-name>:<version>. E.g.
+                   ghcr.io/ogghead/spin-test-app:0.1.0
+
+OPTIONS:
+    -h, --help        Print help information
+    -k, --insecure    Ignore server certificate errors
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -2142,6 +2620,38 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry push --help 
+
+spin-registry-push 
+Push a Spin application to a registry
+
+USAGE:
+    spin registry push [OPTIONS] <REFERENCE>
+
+ARGS:
+    <REFERENCE>    Reference in the registry of the Spin application. This is a string whose
+                   format is defined by the registry standard, and generally consists of
+                   <registry>/<username>/<application-name>:<version>. E.g.
+                   ghcr.io/ogghead/spin-test-app:0.1.0
+
+OPTIONS:
+        --build                       Specifies to perform `spin build` before pushing the
+                                      application [env: SPIN_ALWAYS_BUILD=]
+    -f, --from <APP_MANIFEST_FILE>    The application to push. This may be a manifest (spin.toml)
+                                      file, or a directory containing a spin.toml file. If omitted,
+                                      it defaults to "spin.toml" [default: spin.toml]
+    -h, --help                        Print help information
+    -k, --insecure                    Ignore server certificate errors
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -2351,6 +2861,43 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates install --help
+
+spin-templates-install 
+Install templates from a Git repository or local directory.
+
+The files of the templates are copied to the local template store: a directory in your data or home
+directory.
+
+USAGE:
+    spin templates install [OPTIONS]
+
+OPTIONS:
+        --branch <BRANCH>
+            The optional branch of the git repository
+
+        --dir <FROM_DIR>
+            Local directory containing the template(s) to install
+
+        --git <FROM_GIT>
+            The URL of the templates git repository. The templates must be in a git repository in a
+            "templates" directory
+
+    -h, --help
+            Print help information
+
+        --upgrade
+            If present, updates existing templates instead of skipping
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -2441,6 +2988,28 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates list --help   
+
+spin-templates-list 
+List the installed templates
+
+USAGE:
+    spin templates list [OPTIONS]
+
+OPTIONS:
+    -h, --help          Print help information
+        --tag <TAGS>    Filter templates matching all provided tags
+        --verbose       Whether to show additional template details in the list
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -2537,6 +3106,29 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates uninstall --help
+
+spin-templates-uninstall 
+Remove a template from your installation
+
+USAGE:
+    spin templates uninstall <TEMPLATE_ID>
+
+ARGS:
+    <TEMPLATE_ID>    The template to uninstall
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -2679,6 +3271,41 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates upgrade --help
+spin-templates-upgrade 
+Upgrade templates to match your current version of Spin.
+
+The files of the templates are copied to the local template store: a directory in your data or home
+directory.
+
+USAGE:
+    spin templates upgrade [OPTIONS]
+
+OPTIONS:
+        --all
+            By default, Spin displays the list of installed repositories and prompts you to choose
+            which to upgrade.  Pass this flag to upgrade all repositories without prompting
+
+        --branch <BRANCH>
+            The optional branch of the git repository, if a specific repository is given
+
+    -h, --help
+            Print help information
+
+        --repo <GIT_URL>
+            By default, Spin displays the list of installed repositories and prompts you to choose
+            which to upgrade.  Pass this flag to upgrade only the specified repository without
+            prompting
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 **Note:** For additional information, please see the [Managing Templates](/spin/managing-templates) and/or [Creating Templates](/spin/template-authoring) sections of the documentation.
@@ -3002,6 +3629,87 @@ HTTP TRIGGER OPTIONS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin up --help
+
+spin-up 
+Start the Spin application
+
+USAGE:
+    spin up [OPTIONS]
+
+OPTIONS:
+        --build                 For local apps, specifies to perform `spin build` before running the
+                                application [env: SPIN_ALWAYS_BUILD=]
+        --cache-dir <CACHE_DIR>    Cache directory for downloaded components and assets
+        --direct-mounts         For local apps with directory mounts and no excluded files, mount
+                                them directly instead of using a temporary directory
+    -e, --env <ENV>             Pass an environment variable (key=value) to all components of the
+                                application
+    -f, --from <APPLICATION>    The application to run. This may be a manifest (spin.toml) file, a
+                                directory containing a spin.toml file, or a remote registry
+                                reference. If omitted, it defaults to "spin.toml"
+    -h, --help                  
+    -k, --insecure              Ignore server certificate errors from a registry
+        --temp <TMP>            Temporary directory for the static assets of the components
+
+HTTP TRIGGER OPTIONS:
+        --allow-transient-write
+            Set the static assets of the components in the temporary directory as writable
+
+        --cache <WASMTIME_CACHE_FILE>
+            Wasmtime cache configuration file
+            
+            [env: WASMTIME_CACHE_FILE=]
+
+        --disable-cache
+            Disable Wasmtime cache
+            
+            [env: DISABLE_WASMTIME_CACHE=]
+
+        --disable-pooling
+            Disable Wasmtime's pooling instance allocator
+
+        --follow <FOLLOW_ID>
+            Print output to stdout/stderr only for given component(s)
+
+        --key-value <KEY_VALUES>
+            Set a key/value pair (key=value) in the application's default store. Any existing value
+            will be overwritten. Can be used multiple times
+
+    -L, --log-dir <APP_LOG_DIR>
+            Log directory for the stdout and stderr of components. Setting to the empty string
+            disables logging to disk
+            
+            [env: SPIN_LOG_DIR=]
+
+    -q, --quiet
+            Silence all component output to stdout/stderr
+
+        --runtime-config-file <RUNTIME_CONFIG_FILE>
+            Configuration file for config providers and wasmtime config
+            
+            [env: RUNTIME_CONFIG_FILE=]
+
+        --sqlite <SQLITE_STATEMENTS>
+            Run a SQLite statement such as a migration against the default database. To run from a
+            file, prefix the filename with @ e.g. spin up --sqlite @migration.sql
+
+        --state-dir <STATE_DIR>
+            Set the application state directory path. This is used in the default locations for
+            logs, key value stores, etc.
+            
+            For local apps, this defaults to `.spin/` relative to the `spin.toml` file. For remote
+            apps, this has no default (unset). Passing an empty value forces the value to be unset.
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 > **Please note:** If the `-f` or `--from` options do not accurately infer the intended registry or `.toml` file for your application, then you can explicitly specify either the `--from-registry` or  `--from-file` options to clarify this.
@@ -3112,6 +3820,32 @@ The following additional trigger options are available for the [spin up](#spin-u
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+--listen <ADDRESS>
+    IP address and port to listen on
+    
+    [default: 127.0.0.1:3000]
+
+--tls-cert <TLS_CERT>
+    The path to the certificate to use for https, if this is not set, normal http will be
+    used. The cert should be in PEM format
+    
+    [env: SPIN_TLS_CERT=]
+
+--tls-key <TLS_KEY>
+    The path to the certificate key to use for https, if this is not set, normal http will
+    be used. The key should be in PKCS#8 format
+    
+    [env: SPIN_TLS_KEY=]
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -3234,6 +3968,36 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.5"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin watch --help
+spin-watch 
+Build and run the Spin application, rebuilding and restarting it when files change
+
+USAGE:
+    spin watch [OPTIONS] [UP_ARGS]...
+
+ARGS:
+    <UP_ARGS>...    Arguments to be passed through to spin up
+
+OPTIONS:
+    -c, --clear                       Clear the screen before each run
+    -d, --debounce <DEBOUNCE>         Set the timeout between detected change and re-execution, in
+                                      milliseconds [default: 100]
+    -f, --from <APP_MANIFEST_FILE>    The application to watch. This may be a manifest (spin.toml)
+                                      file, or a directory containing a spin.toml file. If omitted,
+                                      it defaults to "spin.toml" [default: spin.toml]
+    -h, --help                        Print help information
+        --skip-build                  Only run the Spin application, restarting it when build
+                                      artifacts change
+```
+
+{{ blockEnd }}
+
 {{ blockEnd }}
 
 ## Stability Table
@@ -3314,4 +4078,22 @@ CLI commands have four phases that indicate levels of stability:
 | <code>spin watch</code>                                                               | Experimental |
 
 {{ blockEnd }}
+
+{{ startTab "v2.5"}}
+
+| Command                                                                               | Stability    |
+| ------------------------------------------------------------------------------------- | ------------ |
+| <code>spin add</code>                                                                 | Stable       |
+| <code>spin build</code>                                                               | Stable       |
+| <code>spin new</code>                                                                 | Stable       |
+| <code>spin plugins</code>                                                             | Stable       |
+| <code>spin templates</code>                                                           | Stable       |
+| <code>spin up</code>                                                                  | Stable       |
+| <code>spin cloud</code>                                                               | Stabilizing  |
+| <code>spin registry</code>                                                            | Stabilizing  |
+| <code>spin doctor</code>                                                              | Experimental |
+| <code>spin watch</code>                                                               | Experimental |
+
+{{ blockEnd }}
+
 {{ blockEnd }}

--- a/content/spin/v2/cli-reference.md
+++ b/content/spin/v2/cli-reference.md
@@ -19,6 +19,7 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/v2/cli-refere
 - [spin deploy](#spin-deploy)
 - [spin doctor](#spin-doctor)
 - [spin help](#spin-help)
+- [spin kube](#spin-kube)
 - [spin login](#spin-login)
 - [spin new](#spin-new)
 - [spin plugins](#spin-plugins)
@@ -863,6 +864,19 @@ OPTIONS:
 {{ startTab "v2.5"}}
 
 > Please note: Spin `help` is a convenient way to access help using a subcommand, instead of using the `--help` option. For example, `spin help cloud` will give you the same output as `spin cloud --help`. Similarly, `spin help build` will give you the same output as `spin build --help` and so forth.
+
+{{ blockEnd }}
+
+{{ blockEnd }}
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin kube
+
+{ tabs "spin-version" }}
+
+{{ startTab "v2.5"}}
+
+The `spin kube` command is implemented by the [spin-plugin-kube](https://www.spinkube.dev/docs/spin-plugin-kube/reference/).
 
 {{ blockEnd }}
 
@@ -4099,7 +4113,7 @@ CLI commands have four phases that indicate levels of stability:
 | <code>spin registry</code>                                                            | Stabilizing  |
 | <code>spin doctor</code>                                                              | Experimental |
 | <code>spin watch</code>                                                               | Experimental |
-
+| <code>spin test</code>                                                               | Experimental |
 {{ blockEnd }}
 
 {{ blockEnd }}

--- a/content/spin/v2/cli-reference.md
+++ b/content/spin/v2/cli-reference.md
@@ -4113,7 +4113,7 @@ CLI commands have four phases that indicate levels of stability:
 | <code>spin registry</code>                                                            | Stabilizing  |
 | <code>spin doctor</code>                                                              | Experimental |
 | <code>spin watch</code>                                                               | Experimental |
-| <code>spin test</code>                                                               | Experimental |
+| <code>spin test</code>                                                                | Experimental |
 {{ blockEnd }}
 
 {{ blockEnd }}

--- a/content/spin/v2/cli-reference.md
+++ b/content/spin/v2/cli-reference.md
@@ -224,6 +224,7 @@ OPTIONS:
     -h, --help                         Print help information
         --init                         Create the new application or component in the current
                                        directory
+        --no-vcs                       An optional argument that allows to skip creating .gitignore
     -o, --output <OUTPUT_PATH>         The directory in which to create the new application or
                                        component. The default is the name argument
     -t, --template <TEMPLATE_ID>       The template from which to create the new application or
@@ -2487,8 +2488,9 @@ ARGS:
                    ghcr.io/ogghead/spin-test-app:0.1.0
 
 OPTIONS:
-    -h, --help        Print help information
-    -k, --insecure    Ignore server certificate errors
+        --cache-dir <CACHE_DIR>    Cache directory for downloaded registry data
+    -h, --help                     Print help information
+    -k, --insecure                 Ignore server certificate errors
 ```
 
 {{ blockEnd }}
@@ -2641,8 +2643,12 @@ ARGS:
                    ghcr.io/ogghead/spin-test-app:0.1.0
 
 OPTIONS:
+        --annotation <ANNOTATIONS>    Specifies the OCI image manifest annotations (in key=value
+                                      format). Any existing value will be overwritten. Can be used
+                                      multiple times
         --build                       Specifies to perform `spin build` before pushing the
                                       application [env: SPIN_ALWAYS_BUILD=]
+        --cache-dir <CACHE_DIR>       Cache directory for downloaded registry data
     -f, --from <APP_MANIFEST_FILE>    The application to push. This may be a manifest (spin.toml)
                                       file, or a directory containing a spin.toml file. If omitted,
                                       it defaults to "spin.toml" [default: spin.toml]
@@ -3644,19 +3650,19 @@ USAGE:
     spin up [OPTIONS]
 
 OPTIONS:
-        --build                 For local apps, specifies to perform `spin build` before running the
-                                application [env: SPIN_ALWAYS_BUILD=]
+        --build                    For local apps, specifies to perform `spin build` before running
+                                   the application [env: SPIN_ALWAYS_BUILD=]
         --cache-dir <CACHE_DIR>    Cache directory for downloaded components and assets
-        --direct-mounts         For local apps with directory mounts and no excluded files, mount
-                                them directly instead of using a temporary directory
-    -e, --env <ENV>             Pass an environment variable (key=value) to all components of the
-                                application
-    -f, --from <APPLICATION>    The application to run. This may be a manifest (spin.toml) file, a
-                                directory containing a spin.toml file, or a remote registry
-                                reference. If omitted, it defaults to "spin.toml"
-    -h, --help                  
-    -k, --insecure              Ignore server certificate errors from a registry
-        --temp <TMP>            Temporary directory for the static assets of the components
+        --direct-mounts            For local apps with directory mounts and no excluded files, mount
+                                   them directly instead of using a temporary directory
+    -e, --env <ENV>                Pass an environment variable (key=value) to all components of the
+                                   application
+    -f, --from <APPLICATION>       The application to run. This may be a manifest (spin.toml) file,
+                                   a directory containing a spin.toml file, or a remote registry
+                                   reference. If omitted, it defaults to "spin.toml"
+    -h, --help                     
+    -k, --insecure                 Ignore server certificate errors from a registry
+        --temp <TMP>               Temporary directory for the static assets of the components
 
 HTTP TRIGGER OPTIONS:
         --allow-transient-write
@@ -3826,22 +3832,22 @@ The following additional trigger options are available for the [spin up](#spin-u
 <!-- @selectiveCpy -->
 
 ```console
---listen <ADDRESS>
-    IP address and port to listen on
-    
-    [default: 127.0.0.1:3000]
+    --listen <ADDRESS>
+        IP address and port to listen on
+        
+        [default: 127.0.0.1:3000]
 
---tls-cert <TLS_CERT>
-    The path to the certificate to use for https, if this is not set, normal http will be
-    used. The cert should be in PEM format
-    
-    [env: SPIN_TLS_CERT=]
+    --tls-cert <TLS_CERT>
+        The path to the certificate to use for https, if this is not set, normal http will be
+        used. The cert should be in PEM format
+        
+        [env: SPIN_TLS_CERT=]
 
---tls-key <TLS_KEY>
-    The path to the certificate key to use for https, if this is not set, normal http will
-    be used. The key should be in PKCS#8 format
-    
-    [env: SPIN_TLS_KEY=]
+    --tls-key <TLS_KEY>
+        The path to the certificate key to use for https, if this is not set, normal http will
+        be used. The key should be in PKCS#8 format
+        
+        [env: SPIN_TLS_KEY=]
 ```
 
 {{ blockEnd }}

--- a/content/spin/v2/cli-reference.md
+++ b/content/spin/v2/cli-reference.md
@@ -20,6 +20,8 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/v2/cli-refere
 - [spin doctor](#spin-doctor)
 - [spin help](#spin-help)
 - [spin kube](#spin-kube)
+- [spin kube completion](#spin-kube-completion)
+- [spin kube scaffold](#spin-kube-scaffold)
 - [spin login](#spin-login)
 - [spin new](#spin-new)
 - [spin plugins](#spin-plugins)
@@ -872,11 +874,33 @@ OPTIONS:
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin kube
 
-{ tabs "spin-version" }}
+{ tabs "spin-version" }
 
 {{ startTab "v2.5"}}
 
-The `spin kube` command is implemented by the [spin-plugin-kube](https://www.spinkube.dev/docs/spin-plugin-kube/reference/).
+The `spin kube` command is implemented by the [`spin-kube` plugin](https://www.spinkube.dev/docs/spin-plugin-kube/reference/).
+
+{{ blockEnd }}
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin kube completion
+
+{ tabs "spin-version" }
+
+{{ startTab "v2.5"}}
+
+The `spin kube completion` command is implemented by the [`spin-kube` plugin](https://www.spinkube.dev/docs/spin-plugin-kube/reference/#spin-kube-completion).
+
+{{ blockEnd }}
+
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## spin kube scaffold
+
+{ tabs "spin-version" }
+
+{{ startTab "v2.5"}}
+
+The `spin kube scaffold` command is implemented by the [`spin-kube` plugin](https://www.spinkube.dev/docs/spin-plugin-kube/reference/#spin-kube-scaffold).
 
 {{ blockEnd }}
 

--- a/content/spin/v2/cli-reference.md
+++ b/content/spin/v2/cli-reference.md
@@ -3832,22 +3832,22 @@ The following additional trigger options are available for the [spin up](#spin-u
 <!-- @selectiveCpy -->
 
 ```console
-    --listen <ADDRESS>
-        IP address and port to listen on
-        
-        [default: 127.0.0.1:3000]
+--listen <ADDRESS>
+    IP address and port to listen on
+    
+    [default: 127.0.0.1:3000]
 
-    --tls-cert <TLS_CERT>
-        The path to the certificate to use for https, if this is not set, normal http will be
-        used. The cert should be in PEM format
-        
-        [env: SPIN_TLS_CERT=]
+--tls-cert <TLS_CERT>
+    The path to the certificate to use for https, if this is not set, normal http will be
+    used. The cert should be in PEM format
+    
+    [env: SPIN_TLS_CERT=]
 
-    --tls-key <TLS_KEY>
-        The path to the certificate key to use for https, if this is not set, normal http will
-        be used. The key should be in PKCS#8 format
-        
-        [env: SPIN_TLS_KEY=]
+--tls-key <TLS_KEY>
+    The path to the certificate key to use for https, if this is not set, normal http will
+    be used. The key should be in PKCS#8 format
+    
+    [env: SPIN_TLS_KEY=]
 ```
 
 {{ blockEnd }}

--- a/content/spin/v2/cli-reference.md
+++ b/content/spin/v2/cli-reference.md
@@ -3358,6 +3358,8 @@ OPTIONS:
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## spin test
 
+{{ tabs "spin-version" }}
+
 {{ startTab "v2.5"}}
 
 <!-- @selectiveCpy -->

--- a/content/spin/v2/triggers.md
+++ b/content/spin/v2/triggers.md
@@ -115,7 +115,7 @@ spin_manifest_version = 2
 [application]
 name = "http-trigger-example"
 version = "0.1.0"
-authors = ["tpmccallum <tim.mccallum@fermyon.com>"]
+authors = ["Your Name <your-name@example.com>"]
 description = "A HTTP trigger example"
 
 [[trigger.http]]

--- a/content/spin/v2/triggers.md
+++ b/content/spin/v2/triggers.md
@@ -87,24 +87,22 @@ If you are not sure, or are not experienced, we recommend using named components
 
 In this section, we build an application that contains multiple triggers.
 
-> Note: Not all templates support the `spin add` command. In particular, at the time of writing, none of the default Redis templates support being added to existing applications. Therefore, if you want to use `spin add` to build an application with both Redis and HTTP triggers, you should first create a Redis application, then use `spin add` to add HTTP triggers, as shown below. (You won't be able to add additiona Redis triggers this way; if you need those, you'll need to set them up manually for now.)
-
 Here is an example of creating an application with both HTTP and Redis triggers:
 
 <!-- @nocpy -->
 
 ```bash
-# Start with a Redis trigger application
-$ spin new -t redis-rust trigger-example
+# Start with HTTP trigger application
+$ spin new -t http-rust http-trigger-example  
+Description: A HTTP trigger example
+HTTP path: /...
+# Change into to the application directory
+$ cd trigger-example 
+# Add a Redis trigger application
+$ spin add -t redis-rust trigger-example
 Description: A multiple trigger example
 Redis address: redis://localhost:6379
 Redis channel: one
-# Change into to the application directory
-$ cd trigger-example 
-# Create HTTP trigger application
-$ spin add -t http-rust http-trigger-example  
-Description: A HTTP trigger example
-HTTP path: /...
 ```
 
 The above `spin new` and `spin add` commands will scaffold a Spin manifest (`spin.toml` file) with the following triggers:
@@ -115,7 +113,21 @@ The above `spin new` and `spin add` commands will scaffold a Spin manifest (`spi
 spin_manifest_version = 2
 
 [application]
-name = "trigger-example"
+name = "http-trigger-example"
+version = "0.1.0"
+authors = ["Your Name <your-name@example.com>"]
+description = "A HTTP trigger example"
+
+[[trigger.http]]
+route = "/..."
+component = "http-trigger-example"
+
+[component.http-trigger-example]
+source = "target/wasm32-wasi/release/http_trigger_example.wasm"
+allowed_outbound_hosts = []
+[component.http-trigger-example.build]
+command = "cargo build --target wasm32-wasi --release"
+watch = ["src/**/*.rs", "Cargo.toml"]
 
 [application.trigger.redis]
 address = "redis://localhost:6379"
@@ -124,7 +136,11 @@ address = "redis://localhost:6379"
 channel = "one"
 component = "trigger-example"
 
-[[trigger.http]]
-route = "/..."
-component = "http-trigger-example"
+[component.trigger-example]
+source = "trigger-example/target/wasm32-wasi/release/trigger_example.wasm"
+allowed_outbound_hosts = []
+[component.trigger-example.build]
+command = "cargo build --target wasm32-wasi --release"
+workdir = "trigger-example"
+watch = ["src/**/*.rs", "Cargo.toml"]                                
 ```

--- a/content/spin/v2/triggers.md
+++ b/content/spin/v2/triggers.md
@@ -92,15 +92,18 @@ Here is an example of creating an application with both HTTP and Redis triggers:
 <!-- @nocpy -->
 
 ```bash
-# Start with HTTP trigger application
-$ spin new -t http-rust http-trigger-example  
-Description: A HTTP trigger example
-HTTP path: /...
+# Start with an empty application
+$ spin new -t http-empty multiple-trigger-example
+Description: An application that handles both HTTP requests and Redis messages
 # Change into to the application directory
-$ cd http-trigger-example 
+$ cd multiple-trigger-example
+# Add an HTTP trigger application
+$ spin add -t http-rust rust-http-trigger-example
+Description: A Rust HTTP example
+HTTP path: /...
 # Add a Redis trigger application
-$ spin add -t redis-rust redis-trigger-example
-Description: A multiple trigger example
+$ spin add -t redis-rust rust-redis-trigger-example
+Description: A Rust redis example
 Redis address: redis://localhost:6379
 Redis channel: one
 ```
@@ -113,34 +116,35 @@ The above `spin new` and `spin add` commands will scaffold a Spin manifest (`spi
 spin_manifest_version = 2
 
 [application]
-name = "http-trigger-example"
+name = "multiple-trigger-example"
 version = "0.1.0"
 authors = ["Your Name <your-name@example.com>"]
-description = "A HTTP trigger example"
+description = "An application that handles both HTTP requests and Redis messages"
 
 [[trigger.http]]
 route = "/..."
-component = "http-trigger-example"
+component = "rust-http-trigger-example"
 
-[component.http-trigger-example]
-source = "target/wasm32-wasi/release/http_trigger_example.wasm"
+[component.rust-http-trigger-example]
+source = "rust-http-trigger-example/target/wasm32-wasi/release/rust_http_trigger_example.wasm"
 allowed_outbound_hosts = []
-[component.http-trigger-example.build]
+[component.rust-http-trigger-example.build]
 command = "cargo build --target wasm32-wasi --release"
-watch = ["src/**/*.rs", "Cargo.toml"]
-
-[[trigger.redis]]
-channel = "one"
-component = "redis-trigger-example"
-
-[component.redis-trigger-example]
-source = "redis-trigger-example/target/wasm32-wasi/release/redis_trigger_example.wasm"
-allowed_outbound_hosts = []
-[component.redis-trigger-example.build]
-command = "cargo build --target wasm32-wasi --release"
-workdir = "redis-trigger-example"
+workdir = "rust-http-trigger-example"
 watch = ["src/**/*.rs", "Cargo.toml"]
 
 [application.trigger.redis]
-address = "redis://localhost:6379"                               
+address = "redis://localhost:6379"
+
+[[trigger.redis]]
+channel = "one"
+component = "rust-redis-trigger-example"
+
+[component.rust-redis-trigger-example]
+source = "rust-redis-trigger-example/target/wasm32-wasi/release/rust_redis_trigger_example.wasm"
+allowed_outbound_hosts = []
+[component.rust-redis-trigger-example.build]
+command = "cargo build --target wasm32-wasi --release"
+workdir = "rust-redis-trigger-example"
+watch = ["src/**/*.rs", "Cargo.toml"]                             
 ```

--- a/content/spin/v2/triggers.md
+++ b/content/spin/v2/triggers.md
@@ -97,9 +97,9 @@ $ spin new -t http-rust http-trigger-example
 Description: A HTTP trigger example
 HTTP path: /...
 # Change into to the application directory
-$ cd trigger-example 
+$ cd http-trigger-example 
 # Add a Redis trigger application
-$ spin add -t redis-rust trigger-example
+$ spin add -t redis-rust redis-trigger-example
 Description: A multiple trigger example
 Redis address: redis://localhost:6379
 Redis channel: one
@@ -115,7 +115,7 @@ spin_manifest_version = 2
 [application]
 name = "http-trigger-example"
 version = "0.1.0"
-authors = ["Your Name <your-name@example.com>"]
+authors = ["tpmccallum <tim.mccallum@fermyon.com>"]
 description = "A HTTP trigger example"
 
 [[trigger.http]]
@@ -129,18 +129,18 @@ allowed_outbound_hosts = []
 command = "cargo build --target wasm32-wasi --release"
 watch = ["src/**/*.rs", "Cargo.toml"]
 
-[application.trigger.redis]
-address = "redis://localhost:6379"
-
 [[trigger.redis]]
 channel = "one"
-component = "trigger-example"
+component = "redis-trigger-example"
 
-[component.trigger-example]
-source = "trigger-example/target/wasm32-wasi/release/trigger_example.wasm"
+[component.redis-trigger-example]
+source = "redis-trigger-example/target/wasm32-wasi/release/redis_trigger_example.wasm"
 allowed_outbound_hosts = []
-[component.trigger-example.build]
+[component.redis-trigger-example.build]
 command = "cargo build --target wasm32-wasi --release"
-workdir = "trigger-example"
-watch = ["src/**/*.rs", "Cargo.toml"]                                
+workdir = "redis-trigger-example"
+watch = ["src/**/*.rs", "Cargo.toml"]
+
+[application.trigger.redis]
+address = "redis://localhost:6379"                               
 ```


### PR DESCRIPTION
Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title`, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result)
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors
- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
