### PR TITLE
Update all py2wasm to componentize-py

### DIFF
--- a/content/cloud/develop.md
+++ b/content/cloud/develop.md
@@ -212,7 +212,7 @@ The process of getting your system ready to write Wasm-powered Python applicatio
 <!-- @selectiveCpy -->
 
 ```bash
-# As shown above, we install the Python SDK (which provides us with Spin's http-py tempate)
+# As shown above, we install the Python SDK (which provides us with Spin's http-py template)
 $ spin templates install --git https://github.com/fermyon/spin-python-sdk --update
 ```
 

--- a/content/cloud/develop.md
+++ b/content/cloud/develop.md
@@ -398,7 +398,7 @@ Use the `spin new` command and the `http-py` template to scaffold a new Spin app
 $ spin new
 Pick a template to start your application with:
 > http-py (HTTP request handler using Python)
-Enter a name for your new application: hello_python
+Enter a name for your new application: hello-python
 Description: My first Python Spin application
 HTTP path: /...
 ```
@@ -413,7 +413,7 @@ spin_manifest_version = 2
 [application]
 authors = ["Your Name <your-name@example.com>"]
 description = "My first Python Spin application"
-name = "hello_python"
+name = "hello-python"
 version = "0.1.0"
 
 [[trigger.http]]
@@ -423,8 +423,8 @@ component = "hello-python"
 [component.hello-python]
 source = "app.wasm"
 [component.hello-python.build]
-command = "spin py2wasm app -o app.wasm"
-watch = ["app.py", "Pipfile"]
+command = "componentize-py -w spin-http componentize app -o app.wasm"
+watch = ["*.py", "requirements.txt"]
 ```
 
 {{ blockEnd }}
@@ -553,15 +553,14 @@ If the build fails, check:
 
 ```bash
 $ spin build
-Building component hello-python with `spin py2wasm app -o app.wasm`
-Spin-compatible module built successfully
+Building component hello-python with `componentize-py -w spin-http componentize app -o app.wasm`
+Component built successfully
 Finished building all Spin components
 ```
 
 If the build fails, check:
 
-* Are you in the `hello_python` directory?
-* Did you install the `py2wasm` plugin?
+* Are you in the `hello-python` directory?
 
 {{ blockEnd }}
 

--- a/content/cloud/develop.md
+++ b/content/cloud/develop.md
@@ -216,7 +216,7 @@ The process of getting your system ready to write Wasm-powered Python applicatio
 $ spin templates install --git https://github.com/fermyon/spin-python-sdk --update
 ```
 
-Once we have the Spin template(s) from the `spin-python-sdk` repository we can scaffold out a new app. For this example, we will be using the `http-py` template. The scaffolded app, that the `http-py` template creates, has a `requirements.txt` file that facilitates the installation of `spin-sdk` and `componentize-py`. While you could manually install these using Pip, the `requirements.txt` file has the appropriate version numbers set making the process quicker and also more robust. Let's create a new Spin app and run harness the `requirements.txt`:
+Once we have the Spin template(s) from the `spin-python-sdk` repository we can scaffold out a new app. For this example, we will be using the `http-py` template. The scaffolded app, that the `http-py` template creates, has a `requirements.txt` file that facilitates the installation of `spin-sdk` and `componentize-py`. While you could manually install these using Pip, the `requirements.txt` file has the appropriate version numbers set making the process quicker and also more robust. Let's create a new Spin app and install the contents of `requirements.txt`:
 
 <!-- @selectiveCpy -->
 

--- a/content/cloud/develop.md
+++ b/content/cloud/develop.md
@@ -205,13 +205,74 @@ $ spin plugins install js2wasm --yes
 
 {{ startTab "Python" }}
 
-You'll need the Spin `py2wasm` plugin:
+You may have see a `py2wasm` plugin in your travels. Please note, `py2wasm` (an experiment to build a Spin Python SDK using CPython, Wizer, and PyO3) has since been replaced by Componentize-Py. The process of getting your system ready to write Wasm-powered Python applications is as follows:
 
 <!-- @selectiveCpy -->
 
 ```bash
-$ spin plugins update
-$ spin plugins install py2wasm --yes
+# As shown above, we install the Python SDK (which provides us with Spin's http-py tempate)
+$ spin templates install --git https://github.com/fermyon/spin-python-sdk --update
+```
+
+Once we have the above `spin-python-sdk` installed we can scaffold out a new App using the `http-py` template. The scaffolded App has a `requirements.txt` file that facilitates the installation of `spin-sdk` and `componentize-py`. While you could manually install these using Pip, the `requirements.txt` file has the appropriate version numbers set making the process quicker and also more robust. Let's create a new Spin app and run harness the `requirements.txt`:
+
+<!-- @selectiveCpy -->
+
+```bash
+# We then create our App using http-py
+$ spin new -t http-py hello-python --accept-defaults
+```
+
+Once the component is created, we can change into the `hello-python` directory, create and activate a virtual environment and then install the component's requirements:
+
+<!-- @selectiveCpy -->
+
+```bash
+# Change into the App directory
+$ cd hello-python
+```
+
+Create a virtual environment directory (we are still inside the Spin app directory):
+
+<!-- @selectiveCpy -->
+
+```console
+# python<version> -m venv <virtual-environment-name>
+$ python3 -m venv venv-dir
+```
+
+Activate the virtual environment (this command depends on which operating system you are using):
+
+<!-- @selectiveCpy -->
+
+```console
+# macOS command to activate
+$ source venv-dir/bin/activate
+```
+
+The `(venv-dir)` will prefix your terminal prompt now:
+
+<!-- @nocpy -->
+
+```console
+(venv-dir) user@123-456-7-8 hello-python %
+```
+
+The `requirements.txt`, by default, contains the references to the `spin-sdk` and `componentize-py` packages. These can be installed in your virtual environment using the following command:
+
+<!-- @selectiveCpy -->
+
+```bash
+# Now we can install Componentize-Py and the Spin SDK via the requirements file
+$ pip3 install -r requirements.txt 
+```
+
+From here the App is ready to build and run:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin build -u
 ```
 
 [Learn more in the language guide.](/spin/python-components)

--- a/content/cloud/develop.md
+++ b/content/cloud/develop.md
@@ -205,7 +205,9 @@ $ spin plugins install js2wasm --yes
 
 {{ startTab "Python" }}
 
-You may have see a `py2wasm` plugin in your travels. Please note, `py2wasm` (an experiment to build a Spin Python SDK using CPython, Wizer, and PyO3) has since been replaced by Componentize-Py. The process of getting your system ready to write Wasm-powered Python applications is as follows:
+> Historic: You may have see a `py2wasm` plugin in your travels. Please note, `py2wasm` (an experiment to build a Spin Python SDK using CPython, Wizer, and PyO3) has since been replaced by `componentize-py`. 
+
+The process of getting your system ready to write Wasm-powered Python applications, using `componentize-py` is as follows:
 
 <!-- @selectiveCpy -->
 
@@ -214,12 +216,12 @@ You may have see a `py2wasm` plugin in your travels. Please note, `py2wasm` (an 
 $ spin templates install --git https://github.com/fermyon/spin-python-sdk --update
 ```
 
-Once we have the above `spin-python-sdk` installed we can scaffold out a new App using the `http-py` template. The scaffolded App has a `requirements.txt` file that facilitates the installation of `spin-sdk` and `componentize-py`. While you could manually install these using Pip, the `requirements.txt` file has the appropriate version numbers set making the process quicker and also more robust. Let's create a new Spin app and run harness the `requirements.txt`:
+Once we have the Spin template(s) from the `spin-python-sdk` repository we can scaffold out a new app. For this example, we will be using the `http-py` template. The scaffolded app, that the `http-py` template creates, has a `requirements.txt` file that facilitates the installation of `spin-sdk` and `componentize-py`. While you could manually install these using Pip, the `requirements.txt` file has the appropriate version numbers set making the process quicker and also more robust. Let's create a new Spin app and run harness the `requirements.txt`:
 
 <!-- @selectiveCpy -->
 
 ```bash
-# We then create our App using http-py
+# We then create our app using http-py
 $ spin new -t http-py hello-python --accept-defaults
 ```
 
@@ -228,7 +230,7 @@ Once the component is created, we can change into the `hello-python` directory, 
 <!-- @selectiveCpy -->
 
 ```bash
-# Change into the App directory
+# Change into the app directory
 $ cd hello-python
 ```
 
@@ -250,6 +252,13 @@ Activate the virtual environment (this command depends on which operating system
 $ source venv-dir/bin/activate
 ```
 
+If you are using Windows, use the following commands:
+
+```bash
+C:\Work> python3 -m venv venv
+C:\Work> venv\Scripts\activate
+```
+
 The `(venv-dir)` will prefix your terminal prompt now:
 
 <!-- @nocpy -->
@@ -267,12 +276,12 @@ The `requirements.txt`, by default, contains the references to the `spin-sdk` an
 $ pip3 install -r requirements.txt 
 ```
 
-From here the App is ready to build and run:
+From here the app is ready to build and run:
 
 <!-- @selectiveCpy -->
 
 ```bash
-$ spin build -u
+$ spin build --up
 ```
 
 [Learn more in the language guide.](/spin/python-components)

--- a/content/cloud/develop.md
+++ b/content/cloud/develop.md
@@ -570,6 +570,8 @@ Finished building all Spin components
 If the build fails, check:
 
 * Are you in the `hello-python` directory?
+* Did you install the requirements?
+* Is your virtual environment still activated?
 
 {{ blockEnd }}
 

--- a/content/cloud/develop.md
+++ b/content/cloud/develop.md
@@ -205,7 +205,7 @@ $ spin plugins install js2wasm --yes
 
 {{ startTab "Python" }}
 
-> Historic: You may have see a `py2wasm` plugin in your travels. Please note, `py2wasm` (an experiment to build a Spin Python SDK using CPython, Wizer, and PyO3) has since been replaced by `componentize-py`. 
+> Historic: You may have seen a `py2wasm` plugin in your travels. Please note, `py2wasm` has since been replaced by `componentize-py`. 
 
 The process of getting your system ready to write Wasm-powered Python applications, using `componentize-py` is as follows:
 

--- a/content/cloud/develop.md
+++ b/content/cloud/develop.md
@@ -248,7 +248,7 @@ Activate the virtual environment (this command depends on which operating system
 <!-- @selectiveCpy -->
 
 ```console
-# macOS command to activate
+# macOS & Linux command to activate
 $ source venv-dir/bin/activate
 ```
 

--- a/content/cloud/variables.md
+++ b/content/cloud/variables.md
@@ -33,7 +33,7 @@ Since this example is written in Python, make sure you have the required tools i
 $ spin templates install --git https://github.com/fermyon/spin-python-sdk --update
 ```
 
-Once we have the Spin template(s) from the `spin-python-sdk` repository we can scaffold out a new app. For this example, we will be using the `http-py` template. The scaffolded app, that the `http-py` template creates, has a `requirements.txt` file that facilitates the installation of `spin-sdk` and `componentize-py`. While you could manually install these using Pip, the `requirements.txt` file has the appropriate version numbers set making the process quicker and also more robust. Let's create a new Spin app and run harness the `requirements.txt`:
+Once we have the Spin template(s) from the `spin-python-sdk` repository we can scaffold out a new app. For this example, we will be using the `http-py` template. The scaffolded app, that the `http-py` template creates, has a `requirements.txt` file that facilitates the installation of `spin-sdk` and `componentize-py`. While you could manually install these using Pip, the `requirements.txt` file has the appropriate version numbers set making the process quicker and also more robust. Let's create a new Spin app and install the contents of `requirements.txt`:
 
 <!-- @selectiveCpy -->
 

--- a/content/cloud/variables.md
+++ b/content/cloud/variables.md
@@ -29,7 +29,7 @@ Since this example is written in Python, make sure you have the required tools i
 <!-- @selectiveCpy -->
 
 ```bash
-# As shown above, we install the Python SDK (which provides us with Spin's http-py tempate)
+# As shown above, we install the Python SDK (which provides us with Spin's http-py template)
 $ spin templates install --git https://github.com/fermyon/spin-python-sdk --update
 ```
 

--- a/content/cloud/variables.md
+++ b/content/cloud/variables.md
@@ -118,7 +118,7 @@ command = "componentize-py -w spin-http componentize app -o app.wasm"
 watch = ["*.py", "requirements.txt"]
 
 [component.pw-checker.variables]
-password = "\{{ secret }}"
+password = "{{ secret }}"
 ```
 
 The resulting application manifest should look similar to the following:
@@ -173,9 +173,8 @@ class IncomingHandler(IncomingHandler):
         response = f'\{{"authentication": "{access}"}}'
         return Response(
             200,
-            {"content-type": "text/plain"},
-            bytes("Hello from Python!", "utf-8")
-        )
+            {"content-type": "application/json"},
+            bytes(response, "utf-8"))
 ```
 
 Build and run the application locally to test it out. We will use the [environment variable provider](/spin/dynamic-configuration.md#environment-variable-provider) to set the variable values locally. The provider gets the variable values from the `spin` process's environment, searching for environment variables prefixed with `SPIN_VARIABLE_`:

--- a/content/cloud/variables.md
+++ b/content/cloud/variables.md
@@ -166,7 +166,7 @@ from spin_sdk.variables import get
 class IncomingHandler(IncomingHandler):
     def handle_request(self, request: Request) -> Response:
         password = request.body.decode("utf-8")
-        expected = config_get("password")
+        expected = get("password")
         access = "denied"
         if expected == password:
             access = "accepted"

--- a/content/cloud/variables.md
+++ b/content/cloud/variables.md
@@ -8,7 +8,6 @@ url = "https://github.com/fermyon/developer/blob/main/content/cloud/variables.md
 ---
 
 - [Prerequisites](#prerequisites)
-- [Creating Our Spin Application](#creating-our-spin-application)
 - [Adding Variables to an Application Component](#adding-variables-to-an-application-component)
 - [Using Variables in a Spin Application](#using-variables-in-a-spin-application)
 - [Deploying the Application to Fermyon Cloud](#deploying-the-application-to-fermyon-cloud)
@@ -25,51 +24,68 @@ This tutorial will guide you through the process of creating a simple applicatio
 
 Before starting, ensure that you have Spin v1.3.0 or greater installed on your computer. You can follow the official Fermyon Cloud Quickstart guide to [install Spin](/cloud/quickstart#install-spin) and [log into Fermyon Cloud](/cloud/quickstart#log-in-to-the-fermyon-cloud).
 
-Since this example is written in Python, make sure you have the required tools installed to write Spin applications in Python. The Spin CLI facilitates the creation of new Spin applications using application [templates](/cloud/cli-reference#templates). In this tutorial, we will use the `http-py` template. Install it along with the `py2wasm` Spin plugin, which enables compiling Python apps to Wasm, using the following commands:
+Since this example is written in Python, make sure you have the required tools installed to write Spin applications in Python. The Spin CLI facilitates the creation of new Spin applications using application [templates](/cloud/cli-reference#templates). In this tutorial, we will use the `http-py` template that provides a `requirements.txt` file to handle dependencies:
+
+You may have see a `py2wasm` plugin in your travels. Please note, `py2wasm` (an experiment to build a Spin Python SDK using CPython, Wizer, and PyO3) has since been replaced by Componentize-Py. The process of getting your system ready to write Wasm-powered Python applications is as follows:
 
 <!-- @selectiveCpy -->
 
 ```bash
-$ spin templates install --git https://github.com/fermyon/spin-python-sdk --upgrade
-$ spin plugins update
-$ spin plugins install py2wasm --yes
+# As shown above, we install the Python SDK (which provides us with Spin's http-py tempate)
+$ spin templates install --git https://github.com/fermyon/spin-python-sdk --update
 ```
 
-The output from the above commands should be similar to the following:
+Once we have the above `spin-python-sdk` installed we can scaffold out a new App using the `http-py` template. The scaffolded App has a `requirements.txt` file that facilitates the installation of `spin-sdk` and `componentize-py`. While you could manually install these using Pip, the `requirements.txt` file has the appropriate version numbers set making the process quicker and also more robust. Let's create a new Spin app and run harness the `requirements.txt`:
+
+<!-- @selectiveCpy -->
+
+```bash
+# We then create our App using http-py
+$ spin new -t http-py pw_checker --accept-defaults
+```
+
+Once the component is created, we can change into the `pw_checker` directory, create and activate a virtual environment and then install the component's requirements:
+
+<!-- @selectiveCpy -->
+
+```bash
+# Change into the App directory
+$ cd pw_checker
+```
+
+Create a virtual environment directory (we are still inside the Spin app directory):
+
+<!-- @selectiveCpy -->
+
+```console
+# python<version> -m venv <virtual-environment-name>
+$ python3 -m venv venv-dir
+```
+
+Activate the virtual environment (this command depends on which operating system you are using):
+
+<!-- @selectiveCpy -->
+
+```console
+# macOS command to activate
+$ source venv-dir/bin/activate
+```
+
+The `(venv-dir)` will prefix your terminal prompt now:
 
 <!-- @nocpy -->
 
-```text
-Copying remote template source
-Installing template http-py...
-Installed 1 template(s)
-
-+---------------------------------------------+
-| Name      Description                       |
-+=============================================+
-| http-py   HTTP request handler using Python |
-+---------------------------------------------+
-
-Plugin 'py2wasm' was installed successfully!
-
-Description:
-	A plugin to convert Python applications to Spin compatible modules
-
-Homepage:
-	https://github.com/fermyon/spin-python-sdk
+```console
+(venv-dir) user@123-456-7-8 pw_checker %
 ```
 
-## Creating Our Spin Application
-
-Let's start by [creating a new Spin application](/cloud/cli-reference#new) using the Python template. Follow the steps below:
+The `requirements.txt`, by default, contains the references to the `spin-sdk` and `componentize-py` packages. These can be installed in your virtual environment using the following command:
 
 <!-- @selectiveCpy -->
 
 ```bash
-$ spin new -t http-py           
-Enter a name for your new application: pw_checker
-Description: A Spin app that validates a password
-HTTP path: /...
+# Now we can install Componentize-Py and the Spin SDK via the requirements file
+$ pip3 install -r requirements.txt 
 ```
 
 ## Adding Variables to an Application Component
@@ -81,9 +97,13 @@ In reality, you'd have multiple usernames and password hashes in a database, but
 <!-- @nocpy -->
 
 ```toml
-# Add this above the [component.pw-checker] section
+# Add the [variables] above the [component.pw-checker] section, as shown below
+
 [variables]
 secret = { required = true }
+
+[component.pw-checker]
+source = "app.wasm"
 ```
 
 To surface the variable to the `pw-checker` component, add a `[component.pw-checker.variables]` section in the component and specify the variable within it. Instead of statically assigning the value of the config variable, we are referencing the dynamic variable with [mustache](https://mustache.github.io/)-inspired string templates. Only components that explicitly use the variables in their configuration section will get access to them. This enables only exposing variables and secrets to the desired components of an application:
@@ -91,7 +111,12 @@ To surface the variable to the `pw-checker` component, add a `[component.pw-chec
 <!-- @nocpy -->
 
 ```toml
-# Add this below the [component.pw-checker.build] section
+# Add the [component.pw-checker.variables] below the [component.pw-checker.build] section, as shown below
+
+[component.pw-checker.build]
+command = "componentize-py -w spin-http componentize app -o app.wasm"
+watch = ["*.py", "requirements.txt"]
+
 [component.pw-checker.variables]
 password = "\{{ secret }}"
 ```
@@ -125,27 +150,32 @@ command = "cargo build --target wasm32-wasi --release"
 watch = ["src/**/*.rs", "Cargo.toml"]
 
 [component.pw-checker.variables]
-password = "\{{ secret }}"
+password = "{{ secret }}"
 ```
 
 ## Using Variables in a Spin Application
 
 Now that we have defined our variables and surfaced them to our component, we are ready to implement our Spin application. The application should get the user-provided password from the body of the HTTP request, compare it to the expected password set in our configuration variable, and authenticate accordingly. We will use the Spin `spin_config` module to retrieve the value of the `password` variable:
 
+<!-- @selectiveCpy -->
+
 ```py
-from spin_http import Response
+from spin_sdk.http import IncomingHandler, Request, Response
 from spin_config import config_get
 
-def handle_request(request):
-    password = request.body.decode("utf-8")
-    expected = config_get("password")
-    access = "denied"
-    if expected == password:
-        access = "accepted"
-    response = f'\{{"authentication": "{access}"}}'
-    return Response(200,
-                    {"content-type": "application/json"},
-                    bytes(response, "utf-8"))
+class IncomingHandler(IncomingHandler):
+    def handle_request(self, request: Request) -> Response:
+        password = request.body.decode("utf-8")
+        expected = config_get("password")
+        access = "denied"
+        if expected == password:
+            access = "accepted"
+        response = f'\{{"authentication": "{access}"}}'
+        return Response(
+            200,
+            {"content-type": "text/plain"},
+            bytes("Hello from Python!", "utf-8")
+        )
 ```
 
 Build and run the application locally to test it out. We will use the [environment variable provider](/spin/dynamic-configuration.md#environment-variable-provider) to set the variable values locally. The provider gets the variable values from the `spin` process's environment, searching for environment variables prefixed with `SPIN_VARIABLE_`:

--- a/content/cloud/variables.md
+++ b/content/cloud/variables.md
@@ -26,8 +26,6 @@ Before starting, ensure that you have Spin v1.3.0 or greater installed on your c
 
 Since this example is written in Python, make sure you have the required tools installed to write Spin applications in Python. The Spin CLI facilitates the creation of new Spin applications using application [templates](/cloud/cli-reference#templates). In this tutorial, we will use the `http-py` template that provides a `requirements.txt` file to handle dependencies:
 
-You may have see a `py2wasm` plugin in your travels. Please note, `py2wasm` (an experiment to build a Spin Python SDK using CPython, Wizer, and PyO3) has since been replaced by Componentize-Py. The process of getting your system ready to write Wasm-powered Python applications is as follows:
-
 <!-- @selectiveCpy -->
 
 ```bash
@@ -35,12 +33,12 @@ You may have see a `py2wasm` plugin in your travels. Please note, `py2wasm` (an 
 $ spin templates install --git https://github.com/fermyon/spin-python-sdk --update
 ```
 
-Once we have the above `spin-python-sdk` installed we can scaffold out a new App using the `http-py` template. The scaffolded App has a `requirements.txt` file that facilitates the installation of `spin-sdk` and `componentize-py`. While you could manually install these using Pip, the `requirements.txt` file has the appropriate version numbers set making the process quicker and also more robust. Let's create a new Spin app and run harness the `requirements.txt`:
+Once we have the Spin template(s) from the `spin-python-sdk` repository we can scaffold out a new app. For this example, we will be using the `http-py` template. The scaffolded app, that the `http-py` template creates, has a `requirements.txt` file that facilitates the installation of `spin-sdk` and `componentize-py`. While you could manually install these using Pip, the `requirements.txt` file has the appropriate version numbers set making the process quicker and also more robust. Let's create a new Spin app and run harness the `requirements.txt`:
 
 <!-- @selectiveCpy -->
 
 ```bash
-# We then create our App using http-py
+# We then create our app using http-py
 $ spin new -t http-py pw_checker --accept-defaults
 ```
 
@@ -49,7 +47,7 @@ Once the component is created, we can change into the `pw_checker` directory, cr
 <!-- @selectiveCpy -->
 
 ```bash
-# Change into the App directory
+# Change into the app directory
 $ cd pw_checker
 ```
 
@@ -69,6 +67,13 @@ Activate the virtual environment (this command depends on which operating system
 ```console
 # macOS command to activate
 $ source venv-dir/bin/activate
+```
+
+If you are using Windows, use the following commands:
+
+```bash
+C:\Work> python3 -m venv venv
+C:\Work> venv\Scripts\activate
 ```
 
 The `(venv-dir)` will prefix your terminal prompt now:

--- a/content/cloud/variables.md
+++ b/content/cloud/variables.md
@@ -65,7 +65,7 @@ Activate the virtual environment (this command depends on which operating system
 <!-- @selectiveCpy -->
 
 ```console
-# macOS command to activate
+# macOS & Linux command to activate
 $ source venv-dir/bin/activate
 ```
 

--- a/content/cloud/variables.md
+++ b/content/cloud/variables.md
@@ -161,7 +161,7 @@ Now that we have defined our variables and surfaced them to our component, we ar
 
 ```py
 from spin_sdk.http import IncomingHandler, Request, Response
-from spin_config import config_get
+from spin_sdk.variables import get
 
 class IncomingHandler(IncomingHandler):
     def handle_request(self, request: Request) -> Response:

--- a/content/spin/v2/install.md
+++ b/content/spin/v2/install.md
@@ -286,7 +286,7 @@ Then install plugins by name.
 
 Python:
 
-> Historic: You may have seen a `py2wasm` plugin in your travels. Please note, that `py2wasm` has since been replaced by `componentize-py`. (The `componentize-py` workflow is different from the historical `py2wasm` plugin-based approach.)
+> Historic: You may have seen a `py2wasm` plugin in your travels. Please note, that `py2wasm` has since been replaced by `componentize-py`.  You no longer need to install additional tools as part of Spin installation.  (Refer to [Building Spin Components in Python](./python-components.md#componentize-py) for the new way of building Python applications.)
 
 The process of getting your system ready to write Wasm-powered Python applications using `componentize-py` can now be found in (the Building Spin Components in Python)[./python-components.md#componentize-py] area of the documentation.
 

--- a/content/spin/v2/install.md
+++ b/content/spin/v2/install.md
@@ -286,21 +286,22 @@ Then install plugins by name.
 
 Python:
 
-You may have see a `py2wasm` plugin in your travels. Please note, `py2wasm` (an experiment to build a Spin Python SDK using CPython, Wizer, and PyO3) has since been replaced by Componentize-Py. The process of getting your system ready to write Wasm-powered Python applications is as follows:
+> Historic: You may have see a `py2wasm` plugin in your travels. Please note, `py2wasm` (an experiment to build a Spin Python SDK using CPython, Wizer, and PyO3) has since been replaced by `componentize-py`. 
+
+The process of getting your system ready to write Wasm-powered Python applications, using `componentize-py` is as follows:
 
 <!-- @selectiveCpy -->
 
 ```bash
-# As shown above, we install the Python SDK (which provides us with Spin's http-py tempate)
 $ spin templates install --git https://github.com/fermyon/spin-python-sdk --update
 ```
 
-Once we have the above `spin-python-sdk` installed we can scaffold out a new App using the `http-py` template. The scaffolded App has a `requirements.txt` file that facilitates the installation of `spin-sdk` and `componentize-py`. While you could manually install these using Pip, the `requirements.txt` file has the appropriate version numbers set making the process quicker and also more robust. Let's create a new Spin app and run harness the `requirements.txt`:
+Once we have the above `spin-python-sdk` installed we can scaffold out a new app using the `http-py` template. The scaffolded app has a `requirements.txt` file that facilitates the installation of `spin-sdk` and `componentize-py`. While you could manually install these using Pip, the `requirements.txt` file has the appropriate version numbers set making the process quicker and also more robust. Let's create a new Spin app and run harness the `requirements.txt`:
 
 <!-- @selectiveCpy -->
 
 ```bash
-# We then create our App using http-py
+# We then create our app using http-py
 $ spin new -t http-py hello-python --accept-defaults
 ```
 
@@ -309,7 +310,7 @@ Once the component is created, we can change into the `hello-python` directory, 
 <!-- @selectiveCpy -->
 
 ```bash
-# Change into the App directory
+# Change into the app directory
 $ cd hello-python
 ```
 
@@ -329,6 +330,13 @@ Activate the virtual environment (this command depends on which operating system
 ```console
 # macOS command to activate
 $ source venv-dir/bin/activate
+```
+
+If you are using Windows, use the following commands:
+
+```bash
+C:\Work> python3 -m venv venv
+C:\Work> venv\Scripts\activate
 ```
 
 The `(venv-dir)` will prefix your terminal prompt now:

--- a/content/spin/v2/install.md
+++ b/content/spin/v2/install.md
@@ -288,30 +288,12 @@ Python:
 
 > Historic: You may have seen a `py2wasm` plugin in your travels. Please note, `py2wasm` has since been replaced by `componentize-py`. 
 
-The process of getting your system ready to write Wasm-powered Python applications, using `componentize-py` is as follows:
+The process of getting your system ready to write Wasm-powered Python applications using `componentize-py` is as follows:
 
 <!-- @selectiveCpy -->
 
 ```bash
 $ spin templates install --git https://github.com/fermyon/spin-python-sdk --update
-```
-
-Once we have the above `spin-python-sdk` installed we can scaffold out a new app using the `http-py` template. The scaffolded app has a `requirements.txt` file that facilitates the installation of `spin-sdk` and `componentize-py`. While you could manually install these using Pip, the `requirements.txt` file has the appropriate version numbers set making the process quicker and also more robust. Let's create a new Spin app and install the `requirements.txt`:
-
-<!-- @selectiveCpy -->
-
-```bash
-# We then create our app using http-py
-$ spin new -t http-py hello-python --accept-defaults
-```
-
-Once the component is created, we can change into the `hello-python` directory, create and activate a virtual environment and then install the component's requirements:
-
-<!-- @selectiveCpy -->
-
-```bash
-# Change into the app directory
-$ cd hello-python
 ```
 
 Create a virtual environment directory (we are still inside the Spin app directory):
@@ -347,14 +329,16 @@ The `(venv-dir)` will prefix your terminal prompt now:
 (venv-dir) user@123-456-7-8 hello-python %
 ```
 
-The `requirements.txt`, by default, contains the references to the `spin-sdk` and `componentize-py` packages. These can be installed in your virtual environment using the following command:
+The `spin-python=sdk` template contains a [requirements.txt file] that specifies the `spin-sdk` and `componentize-py` packages (as well as the version numbers). You can fetch the requirements.txt file and install the dependencies in your virtual environment using the following command:
 
 <!-- @selectiveCpy -->
 
 ```bash
-# Now we can install Componentize-Py and the Spin SDK via the requirements file
+$ wget https://raw.githubusercontent.com/fermyon/spin-python-sdk/main/templates/http-py/content/requirements.txt
 $ pip3 install -r requirements.txt 
 ```
+
+> You may prefer to reference the [requirements.txt file](https://github.com/fermyon/spin-python-sdk/blob/main/templates/http-py/content/requirements.txt) and install each of the dependencies manually.
 
 Javascript:
 

--- a/content/spin/v2/install.md
+++ b/content/spin/v2/install.md
@@ -286,10 +286,74 @@ Then install plugins by name.
 
 Python:
 
+You may have see a `py2wasm` plugin in your travels. Please note, `py2wasm` (an experiment to build a Spin Python SDK using CPython, Wizer, and PyO3) has since been replaced by Componentize-Py. The process of getting your system ready to write Wasm-powered Python applications is as follows:
+
 <!-- @selectiveCpy -->
 
 ```bash
-$ spin plugins install py2wasm --yes
+# As shown above, we install the Python SDK (which provides us with Spin's http-py tempate)
+$ spin templates install --git https://github.com/fermyon/spin-python-sdk --update
+```
+
+Once we have the above `spin-python-sdk` installed we can scaffold out a new App using the `http-py` template. The scaffolded App has a `requirements.txt` file that facilitates the installation of `spin-sdk` and `componentize-py`. While you could manually install these using Pip, the `requirements.txt` file has the appropriate version numbers set making the process quicker and also more robust. Let's create a new Spin app and run harness the `requirements.txt`:
+
+<!-- @selectiveCpy -->
+
+```bash
+# We then create our App using http-py
+$ spin new -t http-py hello-python --accept-defaults
+```
+
+Once the component is created, we can change into the `hello-python` directory, create and activate a virtual environment and then install the component's requirements:
+
+<!-- @selectiveCpy -->
+
+```bash
+# Change into the App directory
+$ cd hello-python
+```
+
+Create a virtual environment directory (we are still inside the Spin app directory):
+
+<!-- @selectiveCpy -->
+
+```console
+# python<version> -m venv <virtual-environment-name>
+$ python3 -m venv venv-dir
+```
+
+Activate the virtual environment (this command depends on which operating system you are using):
+
+<!-- @selectiveCpy -->
+
+```console
+# macOS command to activate
+$ source venv-dir/bin/activate
+```
+
+The `(venv-dir)` will prefix your terminal prompt now:
+
+<!-- @nocpy -->
+
+```console
+(venv-dir) user@123-456-7-8 hello-python %
+```
+
+The `requirements.txt`, by default, contains the references to the `spin-sdk` and `componentize-py` packages. These can be installed in your virtual environment using the following command:
+
+<!-- @selectiveCpy -->
+
+```bash
+# Now we can install Componentize-Py and the Spin SDK via the requirements file
+$ pip3 install -r requirements.txt 
+```
+
+From here the App is ready to build and run:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin build -u
 ```
 
 Javascript:

--- a/content/spin/v2/install.md
+++ b/content/spin/v2/install.md
@@ -348,14 +348,6 @@ The `requirements.txt`, by default, contains the references to the `spin-sdk` an
 $ pip3 install -r requirements.txt 
 ```
 
-From here the App is ready to build and run:
-
-<!-- @selectiveCpy -->
-
-```bash
-$ spin build -u
-```
-
 Javascript:
 
 <!-- @selectiveCpy -->

--- a/content/spin/v2/install.md
+++ b/content/spin/v2/install.md
@@ -288,8 +288,6 @@ Python:
 
 > Historic: You may have seen a `py2wasm` plugin in your travels. Please note, that `py2wasm` has since been replaced by `componentize-py`.  You no longer need to install additional tools as part of Spin installation.  (Refer to [Building Spin Components in Python](./python-components.md#componentize-py) for the new way of building Python applications.)
 
-The process of getting your system ready to write Wasm-powered Python applications using `componentize-py` can now be found in (the Building Spin Components in Python)[./python-components.md#componentize-py] area of the documentation.
-
 Javascript:
 
 <!-- @selectiveCpy -->

--- a/content/spin/v2/install.md
+++ b/content/spin/v2/install.md
@@ -296,7 +296,7 @@ The process of getting your system ready to write Wasm-powered Python applicatio
 $ spin templates install --git https://github.com/fermyon/spin-python-sdk --update
 ```
 
-Once we have the above `spin-python-sdk` installed we can scaffold out a new app using the `http-py` template. The scaffolded app has a `requirements.txt` file that facilitates the installation of `spin-sdk` and `componentize-py`. While you could manually install these using Pip, the `requirements.txt` file has the appropriate version numbers set making the process quicker and also more robust. Let's create a new Spin app and run harness the `requirements.txt`:
+Once we have the above `spin-python-sdk` installed we can scaffold out a new app using the `http-py` template. The scaffolded app has a `requirements.txt` file that facilitates the installation of `spin-sdk` and `componentize-py`. While you could manually install these using Pip, the `requirements.txt` file has the appropriate version numbers set making the process quicker and also more robust. Let's create a new Spin app and install the `requirements.txt`:
 
 <!-- @selectiveCpy -->
 

--- a/content/spin/v2/install.md
+++ b/content/spin/v2/install.md
@@ -288,15 +288,7 @@ Python:
 
 > Historic: You may have seen a `py2wasm` plugin in your travels. Please note, `py2wasm` has since been replaced by `componentize-py`. 
 
-The process of getting your system ready to write Wasm-powered Python applications using `componentize-py` is as follows:
-
-<!-- @selectiveCpy -->
-
-```bash
-$ spin templates install --git https://github.com/fermyon/spin-python-sdk --update
-```
-
-Create a virtual environment directory (we are still inside the Spin app directory):
+The process of getting your system ready to write Wasm-powered Python applications using `componentize-py` is as follows. Create a virtual environment directory (we are still inside the Spin app directory):
 
 <!-- @selectiveCpy -->
 

--- a/content/spin/v2/install.md
+++ b/content/spin/v2/install.md
@@ -286,7 +286,7 @@ Then install plugins by name.
 
 Python:
 
-> Historic: You may have see a `py2wasm` plugin in your travels. Please note, `py2wasm` (an experiment to build a Spin Python SDK using CPython, Wizer, and PyO3) has since been replaced by `componentize-py`. 
+> Historic: You may have seen a `py2wasm` plugin in your travels. Please note, `py2wasm` has since been replaced by `componentize-py`. 
 
 The process of getting your system ready to write Wasm-powered Python applications, using `componentize-py` is as follows:
 

--- a/content/spin/v2/install.md
+++ b/content/spin/v2/install.md
@@ -286,51 +286,9 @@ Then install plugins by name.
 
 Python:
 
-> Historic: You may have seen a `py2wasm` plugin in your travels. Please note, `py2wasm` has since been replaced by `componentize-py`. 
+> Historic: You may have seen a `py2wasm` plugin in your travels. Please note, that `py2wasm` has since been replaced by `componentize-py`. (The `componentize-py` workflow is different from the historical `py2wasm` plugin-based approach.)
 
-The process of getting your system ready to write Wasm-powered Python applications using `componentize-py` is as follows. Create a virtual environment directory (we are still inside the Spin app directory):
-
-<!-- @selectiveCpy -->
-
-```console
-# python<version> -m venv <virtual-environment-name>
-$ python3 -m venv venv-dir
-```
-
-Activate the virtual environment (this command depends on which operating system you are using):
-
-<!-- @selectiveCpy -->
-
-```console
-# macOS command to activate
-$ source venv-dir/bin/activate
-```
-
-If you are using Windows, use the following commands:
-
-```bash
-C:\Work> python3 -m venv venv
-C:\Work> venv\Scripts\activate
-```
-
-The `(venv-dir)` will prefix your terminal prompt now:
-
-<!-- @nocpy -->
-
-```console
-(venv-dir) user@123-456-7-8 hello-python %
-```
-
-The `spin-python=sdk` template contains a [requirements.txt file] that specifies the `spin-sdk` and `componentize-py` packages (as well as the version numbers). You can fetch the requirements.txt file and install the dependencies in your virtual environment using the following command:
-
-<!-- @selectiveCpy -->
-
-```bash
-$ wget https://raw.githubusercontent.com/fermyon/spin-python-sdk/main/templates/http-py/content/requirements.txt
-$ pip3 install -r requirements.txt 
-```
-
-> You may prefer to reference the [requirements.txt file](https://github.com/fermyon/spin-python-sdk/blob/main/templates/http-py/content/requirements.txt) and install each of the dependencies manually.
+The process of getting your system ready to write Wasm-powered Python applications using `componentize-py` can now be found in (the Building Spin Components in Python)[./python-components.md#componentize-py] area of the documentation.
 
 Javascript:
 

--- a/content/spin/v2/managing-plugins.md
+++ b/content/spin/v2/managing-plugins.md
@@ -91,7 +91,6 @@ $ spin plugins search
 befunge2wasm 1.4.0 [incompatible]
 js2wasm 0.3.0 [installed]
 js2wasm 0.4.0
-py2wasm 0.1.0 [installed]
 trigger-sqs 0.1.0
 ```
 

--- a/content/spin/v2/python-components.md
+++ b/content/spin/v2/python-components.md
@@ -112,6 +112,13 @@ Activate the virtual environment (this command depends on which operating system
 $ source venv-dir/bin/activate
 ```
 
+If you are using Windows, use the following commands:
+
+```bash
+C:\Work> python3 -m venv venv
+C:\Work> venv\Scripts\activate
+```
+
 The `(venv-dir)` will prefix your terminal prompt now:
 
 <!-- @nocpy -->

--- a/content/spin/v2/python-components.md
+++ b/content/spin/v2/python-components.md
@@ -198,8 +198,6 @@ The important things to note in the implementation above:
 - the `handle_request` method is the entry point for the Spin component.
 - the component returns a `spin_sdk.http.Response`.
 
-The source code for this Python HTTP component example is in the `app.py` file. The `app.py` file is compiled into a `.wasm` module thanks to the `py2wasm` plugin. This all happens behind the scenes. 
-
 ### Building and Running the Application
 
 All you need to do is run the `spin build` command from within the project's directory; as shown below:

--- a/content/spin/v2/python-components.md
+++ b/content/spin/v2/python-components.md
@@ -363,7 +363,8 @@ component = "hello-world"
 source = "app.wasm"
 allowed_outbound_hosts = ["https://random-data-api.fermyon.app"]
 [component.hello-world.build]
-command = "spin py2wasm app -o app.wasm"
+command = "componentize-py -w spin-http componentize app -o app.wasm"
+watch = ["*.py", "requirements.txt"]
 ```
 
 ### Building and Running the Application

--- a/content/spin/v2/quickstart.md
+++ b/content/spin/v2/quickstart.md
@@ -12,6 +12,7 @@ keywords = "quickstart"
   - [Install a Template](#install-a-template)
   - [Install the Tools](#install-the-tools)
 - [Create Your First Application](#create-your-first-application)
+- [Structure of a Python Component](#structure-of-a-python-component)
 - [Build Your Application](#build-your-application)
 - [Run Your Application](#run-your-application)
 - [Deploy Your Application to Fermyon Cloud](#deploy-your-application-to-fermyon-cloud)
@@ -420,27 +421,97 @@ export const handleRequest: HandleRequest = async function (request: HttpRequest
 
 {{ startTab "Python"}}
 
-Use the `spin new` command and the `http-py` template to scaffold a new Spin application.
+Spin's Python HTTP Request Handler Template can be installed from [spin-python-sdk repository](https://github.com/fermyon/spin-python-sdk/tree/main/) using the following command:
 
 <!-- @selectiveCpy -->
 
 ```bash
-$ spin new
-Pick a template to start your application with:
-> http-py (HTTP request handler using Python)
-Enter a name for your new application: hello_python
-Description: My first Python Spin application
-HTTP path: /...
+$ spin templates install --git https://github.com/fermyon/spin-python-sdk --update
 ```
+
+The above command will install the `http-py` template and produce an output similar to the following:
+
+<!-- @nocpy -->
+
+```text
+Copying remote template source
+Installing template http-py...
+Installed 1 template(s)
+
++---------------------------------------------+
+| Name      Description                       |
++=============================================+
+| http-py   HTTP request handler using Python |
++---------------------------------------------+
+```
+
+**Please note:** For more information about managing `spin templates`, see the [templates section](./cli-reference#templates) in the Spin Command Line Interface (CLI) documentation.
 
 This command created a directory with the necessary files needed to build and run a Python Spin application.  Change to that directory, and look at the files.  It contains a minimal Python application:
 
 <!-- @selectiveCpy -->
 
 ```bash
-$ cd hello_python
-$ tree
-.
+$ spin new -t http-py hello-python --accept-defaults
+```
+
+Once the component is created, we can change into the `hello-python` directory, create and activate a virtual environment and then install the component's requirements:
+
+<!-- @selectiveCpy -->
+
+```console
+$ cd hello-python
+```
+
+Create a virtual environment directory (we are still inside the Spin app directory):
+
+<!-- @selectiveCpy -->
+
+```console
+# python<version> -m venv <virtual-environment-name>
+$ python3 -m venv venv-dir
+```
+
+Activate the virtual environment (this command depends on which operating system you are using):
+
+<!-- @selectiveCpy -->
+
+```console
+# macOS command to activate
+$ source venv-dir/bin/activate
+```
+
+The `(venv-dir)` will prefix your terminal prompt now:
+
+<!-- @nocpy -->
+
+```console
+(venv-dir) user@123-456-7-8 hello-python %
+```
+
+The `requirements.txt`, by default, contains the references to the `spin-sdk` and `componentize-py` packages. These can be installed in your virtual environment using the following command:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ pip3 install -r requirements.txt 
+Collecting spin-sdk==3.1.0 (from -r requirements.txt (line 1))
+  Using cached spin_sdk-3.1.0-py3-none-any.whl.metadata (16 kB)
+Collecting componentize-py==0.13.3 (from -r requirements.txt (line 2))
+  Using cached componentize_py-0.13.3-cp37-abi3-macosx_10_12_x86_64.whl.metadata (3.4 kB)
+Using cached spin_sdk-3.1.0-py3-none-any.whl (94 kB)
+Using cached componentize_py-0.13.3-cp37-abi3-macosx_10_12_x86_64.whl (38.8 MB)
+Installing collected packages: spin-sdk, componentize-py
+Successfully installed componentize-py-0.13.3 spin-sdk-3.1.0
+```
+
+## Structure of a Python Component
+
+The `hello-python` directory structure created by the Spin `http-py` template is shown below:
+
+<!-- @nocpy -->
+
+```text
 ├── app.py
 ├── spin.toml
 └── requirements.txt 
@@ -454,10 +525,10 @@ The additional `spin.toml` file is the manifest file, which tells Spin what even
 spin_manifest_version = 2
 
 [application]
-name = "hello_python"
+name = "hello-python"
 version = "0.1.0"
 authors = ["Your Name <your-name@example.com>"]
-description = "My first Python Spin application"
+description = ""
 
 [[trigger.http]]
 route = "/..."
@@ -466,30 +537,30 @@ component = "hello-python"
 [component.hello-python]
 source = "app.wasm"
 [component.hello-python.build]
-command = "spin py2wasm app -o app.wasm"
+command = "componentize-py -w spin-http componentize app -o app.wasm"
 ```
-
 This represents a simple Spin HTTP application (triggered by an HTTP request).  It has:
 
-* A single HTTP trigger, for the `/...` route, associated with the `hello-python` component.  `/...` is a wildcard, meaning it will match any route.  When the application gets an HTTP request that matches this route - that is, any HTTP request at all! - Spin will run the `hello-python` component.
+* A single HTTP trigger, for the `/...` route, is associated with the `hello-python` component.  `/...` is a wildcard, meaning it will match any route.  When the application gets an HTTP request that matches this route - that is, any HTTP request at all! - Spin will run the `hello-python` component.
 * A single component called `hello-python`, whose implementation is in the associated `app.wasm` WebAssembly component.  When, in response to the HTTP trigger, Spin runs this component, it will execute the HTTP handler in `app.wasm`.  (We're about to see the source code for that.)
 
 [Learn more about the manifest here.](./writing-apps)
 
 Now let's have a look at the code. Below is the complete source
 code for a Spin HTTP component written in Python — a regular function named `handle_request` that
-takes an HTTP request as a parameter and returns an HTTP response.  The Spin `py2wasm` plugin looks for the `handle_request` function by name when building your application into a Wasm module.
+takes an HTTP request as a parameter and returns an HTTP response.
+
+<!-- @nocpy -->
 
 ```python
-from spin_sdk import http
-from spin_sdk.http import Request, Response
+from spin_sdk.http import IncomingHandler, Request, Response
 
-class IncomingHandler(http.IncomingHandler):
+class IncomingHandler(IncomingHandler):
     def handle_request(self, request: Request) -> Response:
         return Response(
             200,
             {"content-type": "text/plain"},
-            bytes("Hello from the Python SDK!", "utf-8")
+            bytes("Hello from Python!", "utf-8")
         )
 ```
 
@@ -693,7 +764,6 @@ You can always run this command manually; `spin build` is a shortcut.
 
 As a standard practice for Python, create and activate a virtual env:
 
-
 If you are on a Mac/linux based operating system use the following commands:
 
 ```bash
@@ -728,7 +798,7 @@ Finished building all Spin components
 
 If the build fails, check:
 
-* Are you in the `hello_python` directory?
+* Are you in the `hello-python` directory?
 * Did you install the requirements?
 * Is your virtual environment still activated?
 

--- a/content/spin/v2/quickstart.md
+++ b/content/spin/v2/quickstart.md
@@ -481,6 +481,13 @@ Activate the virtual environment (this command depends on which operating system
 $ source venv-dir/bin/activate
 ```
 
+If you are using Windows, use the following commands:
+
+```bash
+C:\Work> python3 -m venv venv
+C:\Work> venv\Scripts\activate
+```
+
 The `(venv-dir)` will prefix your terminal prompt now:
 
 <!-- @nocpy -->

--- a/content/spin/v2/quickstart.md
+++ b/content/spin/v2/quickstart.md
@@ -477,7 +477,7 @@ Activate the virtual environment (this command depends on which operating system
 <!-- @selectiveCpy -->
 
 ```console
-# macOS command to activate
+# macOS & Linux command to activate
 $ source venv-dir/bin/activate
 ```
 

--- a/content/spin/v2/quickstart.md
+++ b/content/spin/v2/quickstart.md
@@ -421,7 +421,7 @@ export const handleRequest: HandleRequest = async function (request: HttpRequest
 
 {{ startTab "Python"}}
 
-Spin's Python HTTP Request Handler Template can be installed from [spin-python-sdk repository](https://github.com/fermyon/spin-python-sdk/tree/main/) using the following command:
+You can install the Spin template for Python HTTP handlers from the [spin-python-sdk repository](https://github.com/fermyon/spin-python-sdk) using the following command:
 
 <!-- @selectiveCpy -->
 
@@ -541,7 +541,7 @@ command = "componentize-py -w spin-http componentize app -o app.wasm"
 ```
 This represents a simple Spin HTTP application (triggered by an HTTP request).  It has:
 
-* A single HTTP trigger, for the `/...` route, is associated with the `hello-python` component.  `/...` is a wildcard, meaning it will match any route.  When the application gets an HTTP request that matches this route - that is, any HTTP request at all! - Spin will run the `hello-python` component.
+* A single HTTP trigger, for the `/...` route, associated with the `hello-python` component.  `/...` is a wildcard, meaning it will match any route.  When the application gets an HTTP request that matches this route - that is, any HTTP request at all! - Spin will run the `hello-python` component.
 * A single component called `hello-python`, whose implementation is in the associated `app.wasm` WebAssembly component.  When, in response to the HTTP trigger, Spin runs this component, it will execute the HTTP handler in `app.wasm`.  (We're about to see the source code for that.)
 
 [Learn more about the manifest here.](./writing-apps)

--- a/content/spin/v2/quickstart.md
+++ b/content/spin/v2/quickstart.md
@@ -528,7 +528,7 @@ spin_manifest_version = 2
 name = "hello-python"
 version = "0.1.0"
 authors = ["Your Name <your-name@example.com>"]
-description = ""
+description = "My first Python Spin application"
 
 [[trigger.http]]
 route = "/..."
@@ -560,7 +560,7 @@ class IncomingHandler(IncomingHandler):
         return Response(
             200,
             {"content-type": "text/plain"},
-            bytes("Hello from Python!", "utf-8")
+            bytes("Hello from the Python SDK!", "utf-8")
         )
 ```
 

--- a/content/spin/v2/serverless-ai-hello-world.md
+++ b/content/spin/v2/serverless-ai-hello-world.md
@@ -54,8 +54,30 @@ $ spin templates install --git https://github.com/fermyon/spin-js-sdk --upgrade
 ```
  
 **Python**
+
+Spin's Python HTTP Request Handler Template can be installed from [spin-python-sdk repository](https://github.com/fermyon/spin-python-sdk/tree/main/) using the following command:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin templates install --git https://github.com/fermyon/spin-python-sdk --update
+```
  
-The above installation script automatically installs the latest SDKs for Python, which enables Serverless AI functionality.
+As a standard practice for Python, create and activate a virtual env:
+
+If you are on a Mac/linux based operating system use the following commands:
+
+```bash
+$ python3 -m venv venv
+$ source venv/bin/activate
+```
+
+If you are using Windows, use the following commands:
+
+```bash
+C:\Work> python3 -m venv venv
+C:\Work> venv\Scripts\activate
+```
  
 ## Licenses
  
@@ -91,10 +113,47 @@ The Python code snippets below are taken from the [Fermyon Serverless AI Example
 <!-- @selectiveCpy -->
  
 ```bash
-$ spin new -t http-py
+# Create new App
+$ spin new -t http-py hello-world --accept-defaults
+# Change into App directory
+$ cd hello-world
 Enter a name for your new application: hello-world
 Description: My first Serverless AI app
 HTTP path: /...
+```
+
+Create a virtual environment directory (we are still inside the Spin app directory):
+
+<!-- @selectiveCpy -->
+
+```console
+# python<version> -m venv <virtual-environment-name>
+$ python3 -m venv venv-dir
+```
+
+Activate the virtual environment (this command depends on which operating system you are using):
+
+<!-- @selectiveCpy -->
+
+```console
+# macOS command to activate
+$ source venv-dir/bin/activate
+```
+
+The `(venv-dir)` will prefix your terminal prompt now:
+
+<!-- @nocpy -->
+
+```console
+(venv-dir) user@123-456-7-8 hello-world %
+```
+
+The `requirements.txt`, by default, contains the references to the `spin-sdk` and `componentize-py` packages. These can be installed in your virtual environment using the following command:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ pip3 install -r requirements.txt 
 ```
  
 {{ blockEnd }}
@@ -190,10 +249,10 @@ command = "npm run build"
 spin_manifest_version = 2
 
 [application]
+authors = ["Your Name <your-name@example.com>"]
+description = ""
 name = "hello-world"
 version = "0.1.0"
-authors = ["Your Name <your-name@example.com>"]
-description = "My first Serverless AI app"
 
 [[trigger.http]]
 route = "/..."
@@ -201,9 +260,9 @@ component = "hello-world"
 
 [component.hello-world]
 source = "app.wasm"
-ai_models = ["llama2-chat"]
 [component.hello-world.build]
-command = "spin py2wasm app -o app.wasm"
+command = "componentize-py -w spin-http componentize app -o app.wasm"
+watch = ["*.py", "requirements.txt"]
 ```
  
 {{ blockEnd }}

--- a/content/spin/v2/serverless-ai-hello-world.md
+++ b/content/spin/v2/serverless-ai-hello-world.md
@@ -113,9 +113,9 @@ The Python code snippets below are taken from the [Fermyon Serverless AI Example
 <!-- @selectiveCpy -->
  
 ```bash
-# Create new App
+# Create new app
 $ spin new -t http-py hello-world --accept-defaults
-# Change into App directory
+# Change into app directory
 $ cd hello-world
 Enter a name for your new application: hello-world
 Description: My first Serverless AI app

--- a/content/spin/v2/variables.md
+++ b/content/spin/v2/variables.md
@@ -35,7 +35,7 @@ Variables are surfaced to a specific component by adding a `[component.(name).va
 
 ```toml
 [component.cart.variables]
-password = "\{{ secret }}"
+password = "{{ secret }}"
 api_host = "https://my-api.com"
 ```
 
@@ -63,7 +63,7 @@ component = "password-checker"
 [component.password-checker]
 source = "app.wasm"
 [component.password-checker.variables]
-password = "\{{ secret }}"
+password = "{{ secret }}"
 api_host = "https://my-api.com"
 ```
 

--- a/content/wasm-languages/python.md
+++ b/content/wasm-languages/python.md
@@ -127,10 +127,12 @@ Compile a Wasm binary with the scripts preloaded, and then start up a local serv
 
 ```console
 $ spin build --up
-Building component python-example with `spin py2wasm app -o app.wasm`
-Spin-compatible module built successfully
+Building component python-example with `componentize-py -w spin-http componentize app -o app.wasm`
+Component built successfully
 Finished building all Spin components
 Logging component stdio to ".spin/logs/"
+Preparing Wasm modules is taking a few seconds...
+
 
 Serving http://127.0.0.1:3000
 Available Routes:


### PR DESCRIPTION
Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title`, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result)
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)

✅ content/cloud/develop.md
✅ content/cloud/variables.md
✅ content/spin/v2/install.md
✅ content/spin/v2/managing-plugins.md
✅ content/spin/v2/python-components.md
✅ content/spin/v2/quickstart.md
✅ content/spin/v2/serverless-ai-hello-world.md
✅ content/spin/v2/variables.md

- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors
- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
