### PR TITLE
Adding spin test documentation

### DIFF
--- a/content/spin/v2/testing-apps.md
+++ b/content/spin/v2/testing-apps.md
@@ -10,9 +10,11 @@ The `spin-test` plugin allows you to run tests, written in WebAssembly, against 
 
 To use `spin-test` you write test scenarios for your app in any language, with WebAssembly component support, and mock out all interactions your app has with the outside world without requiring any code changes to the app itself. That means the code you test in development is the same code that runs in production.
 
+> Note: `spin-test` is still under active development and so the details here may have changed since this post was first published. Check [the spin-test repo](https://github.com/fermyon/spin-test) for the latest information on installation and usage.
+
 ## Prerequisites
 
-Spin test requires Spin 2.5 or newer. Please [install](./install.md) or [upgrade](./upgrade.md) Spin to begin.
+The example below uses the [Rust programming language](https://www.rust-lang.org/) and [cargo components](https://github.com/bytecodealliance/cargo-component)(a cargo subcommand for building WebAssembly components).
 
 ## Installing the Plugin
 
@@ -22,71 +24,164 @@ To run `spin-test` , you’ll first need to install the canary release of the pl
 spin plugin install -u https://github.com/fermyon/spin-test/releases/download/canary/spin-test.json
 ```
 
-This will install the plugin which can be invoked with `spin test`:
+This will install the plugin which can be invoked with `spin test`.
+
+## Creating App and Component
+
+First, create an empty Spin app, change into that app folder and then add a component inside it:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin new -t http-empty my-component --accept-defaults
+$ cd my-component/
+$ spin add -t http-rust my-component --accept-defaults
+```
+
+## Creating Test Suite
+
+We use `cargo new` to create a test suite, and then change into that directory:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ cargo new tests --lib
+$ cd tests
+```
+
+From within that test suite, we then add the spin-test SDK reference:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ cargo add spin-test-sdk --git https://github.com/fermyon/spin-test
+```
+
+Then, we open the `Cargo.toml` file and edit to add the crate-type of `cdylib`:
+
+<!-- @selectiveCpy -->
+
+```toml
+[lib]
+crate-type = ["cdylib"]
+```
+
+The `my-component/tests/Cargo.toml` file will look like this after editing:
+
+```toml
+[package]
+name = "tests"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+spin-test-sdk = { git = "https://github.com/fermyon/spin-test", version = "0.1.0" }
+```
 
 ## Writing a Test
 
-Next, you'll need a test that `spin-test` can run compiled to a WebAssembly component.
+Next, create a test test that `spin-test` can run as a compiled WebAssembly component.
 
 There is currently first-class support for Rust, but any language with support for writing WebAssembly components can be used as long as the `fermyon:spin-test/test` world is targeted. You can find the definition of this world [here](https://github.com/fermyon/spin-test/blob/4dcaf79c10fc29a8da2750bdaa383b5869db1715/host-wit/world.wit#L13-L16).
 
-Here’s an example of a test written in Rust using the [Spin Test Rust SDK](https://github.com/fermyon/spin-test) that tests to ensure that the Spin app responds properly when the key-value store has a certain key already set:
+Here’s an example of a test written in Rust using the [Spin Test Rust SDK](https://github.com/fermyon/spin-test/tree/main/crates/spin-test-sdk) that tests to ensure that the Spin app responds properly when the key-value store has a certain key already set.
+
+Open the `my-component/my-component/src/lib.rs` file and fill it with the following content:
 
 ```rust
 use spin_test_sdk::{
-    bindings::{fermyon::spin_test_virt, wasi},
+    bindings::{
+        // fermyon::spin_test_virt::{http_handler, key_value},
+        wasi::http,
+    },
     spin_test,
 };
 
 #[spin_test]
-fn cache_hit() {
-    let user_json = r#"{"id":123,"name":"Ryan"}"#;
+fn it_works() {
+    make_request();
+}
 
-    // Configure the app's 'cache' key-value store
-    let key_value = spin_test_virt::key_value::Store::open("cache");
-    // Set a specific key with a specific value
-    key_value.set("123", user_json.as_bytes());
-
-    // Make the request against the Spin app
-    let request = wasi::http::types::OutgoingRequest::new(wasi::http::types::Headers::new());
+fn make_request() {
+    // Perform the request
+    let request = http::types::OutgoingRequest::new(http::types::Headers::new());
     request.set_path_with_query(Some("/?user_id=123")).unwrap();
     let response = spin_test_sdk::perform_request(request);
 
-    // Assert the response status and body
+    // Assert response status and body
     assert_eq!(response.status(), 200);
-    let body = response.body_as_string().unwrap();
-    assert_eq!(body, user_json);
-
-    // Assert the key-value store was queried
-    assert_eq!(
-        key_value.calls(),
-        vec![spin_test_virt::key_value::Call::Get("123".to_owned())]
-    );
 }
 ```
 
-The test above will run inside of WebAssembly. The calls to the key-value store and the Spin app itself never leave the WebAssembly sandbox. This means your tests are quick and reproducible as you don’t need to rely on running an actual web server, and you don’t need to ensure any of your app’s dependencies are running. Everything your app interacts with is mocked for you.
+The following points are intended to unpack the above example for your understanding:
+
+- Each function marked with `#[spin_test]` will be run as a separate test.
+- Each test can perform any setup to their environment by using the APIs available in `spin_test_sdk::bindings::fermyon::spin_test_virt`.
+- Requests are made to the Spin application using the `spin_test_sdk::perform_request` function.
+- After requests are made, you can use the APIs in `spin_test_sdk::bindings::fermyon::spin_test_virt` to check how the request has changed the state of various resources (such as the key/value store) and make assertions that things changed in the way you expected.
+
+The test above will run inside of WebAssembly. Calls, such as Key Value storage and retrieval, never actually leave the WebAssembly sandbox. This means your tests are quick and reproducible as you don’t need to rely on running an actual web server, and you don’t need to ensure any of your app’s dependencies are running. Everything your app interacts with is mocked for you.
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## Configure `spin-test`
 
-Before you can run the test, you'll need to tell `spin-test` where your test lives and how to build it. You do this from inside our app’s manifest (the `spin.toml` file). Let's imagine your app has a component named "my-component" that you want to test. In the manifest, you would add the following configuration:
+Before you can run the test, you'll need to tell `spin-test` where your test lives and how to build it. You do this from inside our app’s manifest (the `spin.toml` file). We change back up into our application's root directory:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ cd ..
+```
+
+Then we edit the application's manifest (the `spin.toml` file) as shown below:
+
+<!-- @selectiveCpy -->
 
 ```toml
 [component.my-component.tool.spin-test]
-# A relative path to where the built test component binary will live.
-source = "my-test/target/wasm32-wasi/release/test.wasm"
-# A command for building the test component.
+source = "tests/target/wasm32-wasi/release/tests.wasm"
 build = "cargo component build --release"
-# The directory where the `build` command should be run.
-dir = "my-test"
+dir = "tests"
 ```
 
-## Running the Test
+The whole file will look like the following:
+
+```toml
+spin_manifest_version = 2
+
+[application]
+name = "my-component"
+version = "0.1.0"
+authors = ["tpmccallum <tim.mccallum@fermyon.com>"]
+description = ""
+
+[[trigger.http]]
+route = "/..."
+component = "my-component"
+
+[component.my-component]
+source = "my-component/target/wasm32-wasi/release/my_component.wasm"
+allowed_outbound_hosts = []
+[component.my-component.build]
+command = "cargo build --target wasm32-wasi --release"
+workdir = "my-component"
+watch = ["src/**/*.rs", "Cargo.toml"]
+
+[component.my-component.tool.spin-test]
+source = "tests/target/wasm32-wasi/release/tests.wasm"
+build = "cargo component build --release"
+dir = "tests"
+```
+
+## Building and Running the Test
 
 Finally, we're ready for our test to be run. We can do this by invoking `spin-test` from the directory where our Spin application lives:
 
 ```bash
+$ spin build
 $ spin-test
 
 running 1 test
@@ -97,4 +192,4 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
 
 ## Next Steps
 
-`spin-test` is still in the early days of development, so you’re likely to run into things that don’t quite work yet. We’d love to hear about your experience so we can prioritize which features and bugs to fix first. We’re excited about the future of testing powered by WebAssembly components, and we look forward to hearing about your experiences as we continue the development of `spin-test`.
+`spin-test` is still in the early days of development, so you’re likely to run into things that don’t quite work yet. We’d love to hear about your experience so we can prioritize which features and bugs to fix first. We’re excited about the future potential of using WebAssembly components for testing, and we look forward to hearing about your experiences as we continue the development of `spin-test`.

--- a/content/spin/v2/testing-apps.md
+++ b/content/spin/v2/testing-apps.md
@@ -185,9 +185,10 @@ $ spin build
 $ spin-test
 
 running 1 test
-test cache-hit ... ok
+Handling request to Some(HeaderValue { inner: String("http://localhost/?user_id=123") })
+test it-works ... ok
 
-test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.46s
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.68s
 ```
 
 ## Next Steps

--- a/content/spin/v2/testing-apps.md
+++ b/content/spin/v2/testing-apps.md
@@ -84,7 +84,7 @@ dir = "my-test"
 
 ## Running the Test
 
-Finally, we're ready for our test to be run. We can do this simply by invoking `spin-test` from the directory where our Spin application lives:
+Finally, we're ready for our test to be run. We can do this by invoking `spin-test` from the directory where our Spin application lives:
 
 ```bash
 $ spin-test

--- a/content/spin/v2/testing-apps.md
+++ b/content/spin/v2/testing-apps.md
@@ -67,7 +67,8 @@ fn cache_hit() {
 
 The test above will run inside of WebAssembly. The calls to the key-value store and the Spin app itself never leave the WebAssembly sandbox. This means your tests are quick and reproducible as you don’t need to rely on running an actual web server, and you don’t need to ensure any of your app’s dependencies are running. Everything your app interacts with is mocked for you.
 
-## Configure Spin Test
+<!-- markdownlint-disable-next-line titlecase-rule -->
+## Configure `spin-test`
 
 Before we can run the test, we'll need to tell `spin-test` where our test lives and how to build it. We do this from inside our app’s manifest (the `spin.toml` file). Let's imagine our app has a component named "my-component" that we want to test. In the manifest we can add the following configuration:
 

--- a/content/spin/v2/testing-apps.md
+++ b/content/spin/v2/testing-apps.md
@@ -1,0 +1,99 @@
+title = "Testing Applications"
+template = "spin_main"
+date = "2024-05-05T00:00:01Z"
+[extra]
+url = "https://github.com/fermyon/developer/blob/main/content/spin/v2/testing-apps.md"
+
+---
+
+The `spin-test` plugin allows you to run tests, written in WebAssembly, against a Spin application (where all Spin and WASI APIs are configurable mocks).
+
+To use `spin-test` you write test scenarios for your app in any language, with WebAssembly component support, and mock out all interactions your app has with the outside world without requiring any code changes to the app itself. That means the code you test in development is the same code that runs in production.
+
+## Prerequisites
+
+Spin test requires Spin 2.5 or newer. Please [install](./install.md) or [upgrade](./upgrade.md) Spin to begin.
+
+## Installing the Plugin
+
+To run `spin-test` , you’ll first need to install the canary release of the plugin. As `spin-test` matures, we’ll be making stable releases:
+
+```bash
+spin plugin install -u https://github.com/fermyon/spin-test/releases/download/canary/spin-test.json
+```
+
+This will install the plugin which can be invoked with `spin test`:
+
+## Writing a Test
+
+Next, you'll need a test that `spin-test` can run compiled to a WebAssembly component.
+
+There is currently first-class support for Rust, but any language with support for writing WebAssembly components can be used as long as the `fermyon:spin-test/test` world is targeted. You can find the definition of this world [here](https://github.com/fermyon/spin-test/blob/4dcaf79c10fc29a8da2750bdaa383b5869db1715/host-wit/world.wit#L13-L16).
+
+Here’s an example of a test written in Rust using the [Spin Test Rust SDK](https://github.com/fermyon/spin-test) that tests to ensure that the Spin app responds properly when the key-value store has a certain key already set:
+
+```rust
+use spin_test_sdk::{
+    bindings::{fermyon::spin_test_virt, wasi},
+    spin_test,
+};
+
+#[spin_test]
+fn cache_hit() {
+    let user_json = r#"{"id":123,"name":"Ryan"}"#;
+
+    // Configure the app's 'cache' key-value store
+    let key_value = spin_test_virt::key_value::Store::open("cache");
+    // Set a specific key with a specific value
+    key_value.set("123", user_json.as_bytes());
+
+    // Make the request against the Spin app
+    let request = wasi::http::types::OutgoingRequest::new(wasi::http::types::Headers::new());
+    request.set_path_with_query(Some("/?user_id=123")).unwrap();
+    let response = spin_test_sdk::perform_request(request);
+
+    // Assert the response status and body
+    assert_eq!(response.status(), 200);
+    let body = response.body_as_string().unwrap();
+    assert_eq!(body, user_json);
+
+    // Assert the key-value store was queried
+    assert_eq!(
+        key_value.calls(),
+        vec![spin_test_virt::key_value::Call::Get("123".to_owned())]
+    );
+}
+```
+
+The test above will run inside of WebAssembly. The calls to the key-value store and the Spin app itself never leave the WebAssembly sandbox. This means your tests are quick and reproducible as you don’t need to rely on running an actual web server, and you don’t need to ensure any of your app’s dependencies are running. Everything your app interacts with is mocked for you.
+
+## Configure Spin Test
+
+Before we can run the test, we'll need to tell `spin-test` where our test lives and how to build it. We do this from inside our app’s manifest (the `spin.toml` file). Let's imagine our app has a component named "my-component" that we want to test. In the manifest we can add the following configuration:
+
+```toml
+[component.my-component.tool.spin-test]
+# A relative path to where the built test component binary will live.
+source = "my-test/target/wasm32-wasi/release/test.wasm"
+# A command for building the target component.
+build = "cargo component build --release"
+# The directory where the `build` command should be run.
+dir = "my-test"
+```
+
+## Running the Test
+
+Finally, we're ready for our test to be run. We can do this simply by invoking `spin-test` from the directory where our Spin application lives:
+
+```bash
+$ spin-test
+
+running 1 test
+test cache-hit ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.46s
+```
+
+## Next Steps
+
+`spin-test` is still in the early days of development, so you’re likely to run into things that don’t quite work yet. We’d love to hear about your experience so we can prioritize which features and bugs to fix first. We’re excited about the future of testing powered by WebAssembly components, and we look forward to hearing about your experiences as we continue the development of `spin-test`.

--- a/content/spin/v2/testing-apps.md
+++ b/content/spin/v2/testing-apps.md
@@ -47,7 +47,7 @@ cd my-component
 cargo add spin-test-sdk --git https://github.com/fermyon/spin-test
 ```
 
-## Creating Test Suite
+## Creating a Test Suite
 
 We, change back into the app's root directory and use `cargo new` to create a test suite, and then change into that directory:
 

--- a/content/spin/v2/testing-apps.md
+++ b/content/spin/v2/testing-apps.md
@@ -76,7 +76,7 @@ Before you can run the test, you'll need to tell `spin-test` where your test liv
 [component.my-component.tool.spin-test]
 # A relative path to where the built test component binary will live.
 source = "my-test/target/wasm32-wasi/release/test.wasm"
-# A command for building the target component.
+# A command for building the test component.
 build = "cargo component build --release"
 # The directory where the `build` command should be run.
 dir = "my-test"

--- a/content/spin/v2/testing-apps.md
+++ b/content/spin/v2/testing-apps.md
@@ -38,15 +38,6 @@ $ cd my-component/
 $ spin add -t http-rust my-component --accept-defaults
 ```
 
-We then go into the component directory and add the spin-test SDK:
-
-<!-- @selectiveCpy -->
-
-```bash
-cd my-component
-cargo add spin-test-sdk --git https://github.com/fermyon/spin-test
-```
-
 ## Creating a Test Suite
 
 We, change back into the app's root directory and use `cargo new` to create a test suite, and then change into that directory:
@@ -54,7 +45,6 @@ We, change back into the app's root directory and use `cargo new` to create a te
 <!-- @selectiveCpy -->
 
 ```bash
-$ cd ..
 $ cargo new tests --lib
 $ cd tests
 ```
@@ -99,7 +89,7 @@ There is currently first-class support for Rust, but any language with support f
 
 Here’s an example of a test written in Rust using the [Spin Test Rust SDK](https://github.com/fermyon/spin-test/tree/main/crates/spin-test-sdk) that tests to ensure that the Spin app responds properly when the key-value store has a certain key already set.
 
-Open the `my-component/my-component/src/lib.rs` file and fill it with the following content:
+Open the `my-component/tests/src/lib.rs` file and fill it with the following content:
 
 ```rust
 use spin_test_sdk::{

--- a/content/spin/v2/testing-apps.md
+++ b/content/spin/v2/testing-apps.md
@@ -40,7 +40,7 @@ $ spin add -t http-rust my-component --accept-defaults
 
 ## Creating a Test Suite
 
-We, change back into the app's root directory and use `cargo new` to create a test suite, and then change into that directory:
+We use `cargo new` to create a test suite, and then change into that `tests` directory:
 
 <!-- @selectiveCpy -->
 
@@ -57,7 +57,7 @@ From within that test suite, we then add the spin-test SDK reference:
 $ cargo add spin-test-sdk --git https://github.com/fermyon/spin-test
 ```
 
-Then, we open the `Cargo.toml` file and edit to add the crate-type of `cdylib`:
+Then, we open the `Cargo.toml` file from within in the `tests` directory and edit to add the `crate-type` of `cdylib`:
 
 <!-- @selectiveCpy -->
 
@@ -83,7 +83,7 @@ spin-test-sdk = { git = "https://github.com/fermyon/spin-test", version = "0.1.0
 
 ## Writing a Test
 
-Next, create a test test that `spin-test` can run as a compiled WebAssembly component.
+Next, create a test that `spin-test` can run as a compiled WebAssembly component.
 
 There is currently first-class support for Rust, but any language with support for writing WebAssembly components can be used as long as the `fermyon:spin-test/test` world is targeted. You can find the definition of this world [here](https://github.com/fermyon/spin-test/blob/4dcaf79c10fc29a8da2750bdaa383b5869db1715/host-wit/world.wit#L13-L16).
 
@@ -155,7 +155,7 @@ spin_manifest_version = 2
 [application]
 name = "my-component"
 version = "0.1.0"
-authors = ["tpmccallum <tim.mccallum@fermyon.com>"]
+authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 description = ""
 
 [[trigger.http]]

--- a/content/spin/v2/testing-apps.md
+++ b/content/spin/v2/testing-apps.md
@@ -38,13 +38,23 @@ $ cd my-component/
 $ spin add -t http-rust my-component --accept-defaults
 ```
 
-## Creating Test Suite
-
-We use `cargo new` to create a test suite, and then change into that directory:
+We then go into the component directory and add the spin-test SDK:
 
 <!-- @selectiveCpy -->
 
 ```bash
+cd my-component
+cargo add spin-test-sdk --git https://github.com/fermyon/spin-test
+```
+
+## Creating Test Suite
+
+We, change back into the app's root directory and use `cargo new` to create a test suite, and then change into that directory:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ cd ..
 $ cargo new tests --lib
 $ cd tests
 ```

--- a/content/spin/v2/testing-apps.md
+++ b/content/spin/v2/testing-apps.md
@@ -70,7 +70,7 @@ The test above will run inside of WebAssembly. The calls to the key-value store 
 <!-- markdownlint-disable-next-line titlecase-rule -->
 ## Configure `spin-test`
 
-Before we can run the test, we'll need to tell `spin-test` where our test lives and how to build it. We do this from inside our app’s manifest (the `spin.toml` file). Let's imagine our app has a component named "my-component" that we want to test. In the manifest we can add the following configuration:
+Before you can run the test, you'll need to tell `spin-test` where your test lives and how to build it. You do this from inside our app’s manifest (the `spin.toml` file). Let's imagine your app has a component named "my-component" that you want to test. In the manifest, you would add the following configuration:
 
 ```toml
 [component.my-component.tool.spin-test]

--- a/templates/spin_sidebar_v2.hbs
+++ b/templates/spin_sidebar_v2.hbs
@@ -187,6 +187,10 @@
                                         class="active" {{/if}}
                                         href="{{site.info.base_url}}/spin/v2/managing-plugins">Managing Plugins</a>
                         </li>
+                        <li><a {{#if (active_project request.spin-full-url "/spin/v2/testing-apps" )}}
+                                        class="active" {{/if}}
+                                        href="{{site.info.base_url}}/spin/v2/testing-apps">Testing Applications</a>
+                        </li>
                 </ul>
         </div>
         <div class="accordion-menu-item">


### PR DESCRIPTION
Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title`, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result)
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)

```
$ bart check content/spin/v2/testing-apps.md 
✅ content/spin/v2/testing-apps.md
```

- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)

![image](https://github.com/fermyon/developer/assets/9831342/42740da3-cf00-48b8-88f6-e0b1275a35a4)

- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors
- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
