### PR TITLE
Fix variables in manifest

### DIFF
--- a/content/cloud/variables.md
+++ b/content/cloud/variables.md
@@ -123,7 +123,7 @@ command = "componentize-py -w spin-http componentize app -o app.wasm"
 watch = ["*.py", "requirements.txt"]
 
 [component.pw-checker.variables]
-password = "{{ secret }}"
+password = "\{{ secret }}"
 ```
 
 The resulting application manifest should look similar to the following:
@@ -155,7 +155,7 @@ command = "cargo build --target wasm32-wasi --release"
 watch = ["src/**/*.rs", "Cargo.toml"]
 
 [component.pw-checker.variables]
-password = "{{ secret }}"
+password = "\{{ secret }}"
 ```
 
 ## Using Variables in a Spin Application

--- a/content/spin/v2/variables.md
+++ b/content/spin/v2/variables.md
@@ -35,7 +35,7 @@ Variables are surfaced to a specific component by adding a `[component.(name).va
 
 ```toml
 [component.cart.variables]
-password = "{{ secret }}"
+password = "\{{ secret }}"
 api_host = "https://my-api.com"
 ```
 
@@ -63,7 +63,7 @@ component = "password-checker"
 [component.password-checker]
 source = "app.wasm"
 [component.password-checker.variables]
-password = "{{ secret }}"
+password = "\{{ secret }}"
 api_host = "https://my-api.com"
 ```
 


### PR DESCRIPTION
Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title`, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result)
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors
- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
