### PR TITLE
Use npm ci instead of npm install

### DIFF
--- a/content/spin/v2/contributing-docs.md
+++ b/content/spin/v2/contributing-docs.md
@@ -296,12 +296,12 @@ If you create content with many headings it is highly recommended to place a ToC
 
 Once you are satisfied with your contribution, you can programmatically check your content.
 
-If you have not done so already, please go ahead and perform the `npm install` command; to enable Node dependencies such as `markdownlint-cli2`. Simply run the following command, from the root of the developer repository:
+If you have not done so already, please go ahead and perform the `npm ci` (npm clean install) command; to enable Node dependencies such as `markdownlint-cli2`. Simply run the following command, from the root of the developer repository:
 
 <!-- @selectiveCpy -->
 
 ```bash
-$ npm install
+$ npm ci
 ```
 
 On top of the Node dependencies the `timeout` executable must be installed on your system and added to the `PATH` environment variable. The `timeout` executable is included in the [gnu coreutils package](https://www.gnu.org/software/coreutils/) which should be present in most Linux distributions. 
@@ -456,9 +456,9 @@ You can host your changes to the developer documentation on your own machine (lo
 <!-- @selectiveCpy -->
 
 ```bash
-$ npm install
+$ npm ci
 $ cd spin-up-hub
-$ npm install
+$ npm ci
 $ cd ..
 $ spin build
 $ spin up -e "PREVIEW_MODE=1"


### PR DESCRIPTION
Signed-off-by: tpmccallum tim.mccallum@fermyon.com
Content must go through a pre-merge checklist.

Fixes https://github.com/fermyon/developer/issues/922

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title`, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep $'\r' | wc -l` and expect 0 as a result)
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors
- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
