### PR TITLE
Add spin-path-info usage example

### DIFF
--- a/content/spin/v2/http-trigger.md
+++ b/content/spin/v2/http-trigger.md
@@ -377,6 +377,8 @@ As well as any headers passed by the client, Spin sets several headers on the re
 | `spin-base-path`             | The application base path | `/shop` |
 | `spin-client-addr`           | The IP address and port of the client | `127.0.0.1:53152` |
 
+> Accessing detailed information about HTTP requests can be particularly useful for identifying and handling specific cases, such as requests for `favicon.ico`. When a user's browser requests your application and automatically sends a subsequent request for `favicon.ico`, it may inadvertently trigger your component to execute twice. Instead of creating a new route in the application manifest to manage this, a more straightforward approach is to handle `favicon.ico` requests uniquely within your application's source code using the `spin-path-info` header name.
+
 ### Inside HTTP Components
 
 For the most part, you'll build HTTP component modules using a language SDK (see the Language Guides section), such as a JavaScript module or a Rust crate.  If you're interested in what happens inside the SDK, or want to implement HTTP components in another language, read on!


### PR DESCRIPTION
Signed-off-by: tpmccallum tim.mccallum@fermyon.com

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title`, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep $'\r' | wc -l` and expect 0 as a result)
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors
- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
