### PR TITLE
SpinKube moved some docs around

### DIFF
--- a/content/spin/v2/cli-reference.md
+++ b/content/spin/v2/cli-reference.md
@@ -1026,13 +1026,13 @@ OPTIONS:
 
 {{ startTab "v2.5"}}
 
-The `spin kube` command is implemented by the [`spin-kube` plugin](https://www.spinkube.dev/docs/spin-plugin-kube/reference/).
+The `spin kube` command is implemented by the [`spin-kube` plugin](https://www.spinkube.dev/docs/reference/cli-reference/).
 
 {{ blockEnd }}
 
 {{ startTab "v2.6"}}
 
-The `spin kube` command is implemented by the [`spin-kube` plugin](https://www.spinkube.dev/docs/spin-plugin-kube/reference/).
+The `spin kube` command is implemented by the [`spin-kube` plugin](https://www.spinkube.dev/docs/reference/cli-reference/).
 
 {{ blockEnd }}
 
@@ -1045,13 +1045,13 @@ The `spin kube` command is implemented by the [`spin-kube` plugin](https://www.s
 
 {{ startTab "v2.5"}}
 
-The `spin kube completion` command is implemented by the [`spin-kube` plugin](https://www.spinkube.dev/docs/spin-plugin-kube/reference/#spin-kube-completion).
+The `spin kube completion` command is implemented by the [`spin-kube` plugin](https://www.spinkube.dev/docs/reference/cli-reference/#spin-kube-completion).
 
 {{ blockEnd }}
 
 {{ startTab "v2.6"}}
 
-The `spin kube completion` command is implemented by the [`spin-kube` plugin](https://www.spinkube.dev/docs/spin-plugin-kube/reference/#spin-kube-completion).
+The `spin kube completion` command is implemented by the [`spin-kube` plugin](https://www.spinkube.dev/docs/reference/cli-reference/#spin-kube-completion).
 
 {{ blockEnd }}
 
@@ -1064,13 +1064,13 @@ The `spin kube completion` command is implemented by the [`spin-kube` plugin](ht
 
 {{ startTab "v2.5"}}
 
-The `spin kube scaffold` command is implemented by the [`spin-kube` plugin](https://www.spinkube.dev/docs/spin-plugin-kube/reference/#spin-kube-scaffold).
+The `spin kube scaffold` command is implemented by the [`spin-kube` plugin](https://www.spinkube.dev/docs/reference/cli-reference/#spin-kube-scaffold).
 
 {{ blockEnd }}
 
 {{ startTab "v2.6"}}
 
-The `spin kube scaffold` command is implemented by the [`spin-kube` plugin](https://www.spinkube.dev/docs/spin-plugin-kube/reference/#spin-kube-scaffold).
+The `spin kube scaffold` command is implemented by the [`spin-kube` plugin](https://www.spinkube.dev/docs/reference/cli-reference/#spin-kube-scaffold).
 
 {{ blockEnd }}
 

--- a/content/spin/v2/spin-in-pods-legacy.md
+++ b/content/spin/v2/spin-in-pods-legacy.md
@@ -350,7 +350,7 @@ To install this plugin, run:
 spin plugin install -u https://raw.githubusercontent.com/chrismatteson/spin-plugin-k8s/main/k8s.json
 ```
 
-> **Warning: This is legacy content.** For a better experience, please visit [SpinKube](https://spinkube.dev/). In particular, the [SpinKube documentation](https://spinkube.dev/docs/spin-plugin-kube/installation/) that introduces the new `spin kube` command.
+> **Warning: This is legacy content.** For a better experience, please visit [SpinKube](https://spinkube.dev/). In particular, the [SpinKube documentation](https://www.spinkube.dev/docs/install/spin-kube-plugin/) that introduces the new `spin kube` command.
 
 ### Workflow
 


### PR DESCRIPTION
Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title`, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep $'\r' | wc -l` and expect 0 as a result)
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
