### PR TITLE
Document Redis per-trigger server address

### DIFF
--- a/content/spin/v2/manifest-reference.md
+++ b/content/spin/v2/manifest-reference.md
@@ -55,6 +55,7 @@ watch = ["src/**/*.rs", "Cargo.toml"]
 The following fields allow you to use [expressions](./variables.md#adding-variables-to-your-applications) in their values:
 
 * `application.trigger.redis.address`
+* `trigger.redis.address`
 * `trigger.redis.channel`
 * `component.*.allowed_outbound_hosts`
 
@@ -104,7 +105,7 @@ The `application.trigger` should contain only one key, the trigger type whose se
 
 | Name                    | Required?  | Type        | Value    | Example   |
 |-------------------------|------------|-------------|----------|-----------|
-| `address`               | Required   | String      | The address of the Redis instance the components are using the message subscriptions. Use the `redis:` URL scheme. | `"redis://localhost:6379"` |
+| `address`               | Required   | String      | The address of the Redis instance to which the components subscribe for messages, for triggers that do not specify an address themselves. Use the `redis:` URL scheme. | `"redis://localhost:6379"` |
 
 ## The `variables` Table
 
@@ -163,6 +164,7 @@ Each array entry contains a mix of common fields and trigger-specific fields.
 
 | Name                    | Required?  | Type        | Value    | Example   |
 |-------------------------|------------|-------------|----------|-----------|
+| `address`               | Optional   | String      | The address of the Redis instance to which the trigger subscribes. Use the `redis:` URL scheme. If omitted, defaults to `application.trigger.redis.address`. | `"redis://localhost:6379"` |
 | `channel`               | Required   | String      | The Redis channel which this component handles. Messages on this channel will cause the component to execute. | `"purchases"` |
 
 ## The `component` Table

--- a/content/spin/v2/redis-trigger.md
+++ b/content/spin/v2/redis-trigger.md
@@ -7,7 +7,8 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/v2/redis-trig
 
 ---
 - [Specifying a Redis Trigger](#specifying-a-redis-trigger)
-- [Redis Trigger Application Settings](#redis-trigger-application-settings)
+  - [Setting a Default Server](#setting-a-default-server)
+- [Redis Trigger Authentication](#redis-trigger-authentication)
 - [Redis Components](#redis-components)
   - [The Message Handler](#the-message-handler)
 - [Inside Redis Components](#inside-redis-components)
@@ -18,12 +19,15 @@ The Redis trigger in Spin subscribes to messages from a given Redis instance, an
 
 > This page deals with the Redis trigger for subscribing to pub-sub messages. For information about reading and writing the Redis key-value store, or for publishing messages, see the Language Guides.
 
+> The Redis trigger is not yet available in Fermyon Cloud.
+
 ## Specifying a Redis Trigger
 
 A Redis trigger maps a Redis channel to a component. For example:
 
 ```toml
 [[trigger.redis]]
+address = "redis://notifications.example.com:6379" # the Redis instance that the trigger subscribes to (optional - see below)
 channel = "messages"          # the channel that the trigger subscribes to
 component = "my-application"  # the name of the component to handle this route
 ```
@@ -32,11 +36,11 @@ Such a trigger says that Redis messages on the specified _channel_ should be han
 
 > Spin subscribes only to the channels that are mapped to components. Other channels are ignored. If multiple components subscribe to the same channel, a message on that channel will activate all of the components.
 
-You can use [application variables](./variables.md#adding-variables-to-your-applications) in the `channel` field. However, this feature is not yet available on Fermyon Cloud.
+You can use [application variables](./variables.md#adding-variables-to-your-applications) in the `address` and `channel` fields.
 
-## Redis Trigger Application Settings
+### Setting a Default Server
 
-Applications containing Redis triggers must specify the address of the Redis server to subscribe to. This is done via the `[application.trigger.redis]` section of manifest:
+In many applications, all components listen to the same Redis server (on different channels, of course). For this case, it is more convenient to specify the server at the application level instead of on each component. This is done via the `[application.trigger.redis]` section of manifest:
 
 ```toml
 [application.trigger.redis]
@@ -45,13 +49,17 @@ address = "redis://notifications.example.com:6379"
 
 > If you create an application from a Redis template, the trigger will be already set up for you.
 
+You can use [application variables](./variables.md#adding-variables-to-your-applications) in the `address` field.
+
+## Redis Trigger Authentication
+
 By default, Spin does not authenticate to Redis. You can work around this by providing a password in the `redis://` URL.  For example: `address = "redis://:p4ssw0rd@localhost:6379"`
 
 > Do not use passwords in code committed to version control systems.
 
 > We plan to offer secrets-based authentication in future versions of Spin.
 
-You can use [application variables](./variables.md#adding-variables-to-your-applications) in the `address` field. This can be particularly useful for credentials, allowing you to pass credentials in via [variables providers](./dynamic-configuration.md#application-variables-runtime-configuration) rather than including them in `spin.toml`. However, this feature is not yet available on Fermyon Cloud.
+As mentioned above, you can use [application variables](./variables.md#adding-variables-to-your-applications) in Redis `address` fields. This can be particularly useful for credentials, allowing you to pass credentials in via [variables providers](./dynamic-configuration.md#application-variables-runtime-configuration) rather than including them in `spin.toml`.
 
 ## Redis Components
 


### PR DESCRIPTION
Fixes #1352.

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title`, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep $'\r' | wc -l` and expect 0 as a result)
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
