### PR TITLE
update js content to v2 sdk

### DIFF
--- a/content/spin/v1/http-outbound.md
+++ b/content/spin/v1/http-outbound.md
@@ -83,7 +83,7 @@ const response = await fetch("https://example.com/users");
 
 * Although the underlying Spin interface is blocking, the `fetch` function is defined by JavaScript as async. You must await the response, but the request will always block, and the promise will resolve as soon as the request is returned.
 
-You can find a complete example of using outbound HTTP in the JavaScript SDK repository on GitHub ([TypeScript](https://github.com/fermyon/spin-js-sdk/tree/main/examples/typescript/outbound_http), [JavaScript](https://github.com/fermyon/spin-js-sdk/tree/main/examples/javascript/outbound-http)).
+You can find a complete example of using outbound HTTP in the JavaScript SDK repository on GitHub ([TypeScript](https://github.com/fermyon/spin-js-sdk/tree/sdk-v1/examples/typescript/outbound_http), [JavaScript](https://github.com/fermyon/spin-js-sdk/tree/sdk-v1/examples/javascript/outbound-http)).
 
 {{ blockEnd }}
 

--- a/content/spin/v1/javascript-components.md
+++ b/content/spin/v1/javascript-components.md
@@ -30,7 +30,7 @@ With JavaScript being a very popular language, Spin provides support for buildin
 > This guide assumes you are familiar with the JavaScript programming language,
 > but if you are just getting started, be sure to check [the MDN guide](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide).
 
-> All examples from this page can be found in [the JavaScript SDK repository on GitHub](https://github.com/fermyon/spin-js-sdk/tree/main/examples).
+> All examples from this page can be found in [the JavaScript SDK repository on GitHub](https://github.com/fermyon/spin-js-sdk/tree/sdk-v1/examples).
 
 In order to compile JavaScript programs to Spin components, you also need to install a Spin plugin `js2wasm` using the following command:
 
@@ -121,7 +121,7 @@ $ spin up
 
 ## A Quick Note About NPM Scripts
 
-Please note that using pre-built NPM scripts can have different effects on different Operating Systems (OSs). Let's take the `npm run build` command (like [the one in the spin-js-sdk](https://github.com/fermyon/spin-js-sdk/blob/main/examples/javascript/hello_world/package.json)) as an example:
+Please note that using pre-built NPM scripts can have different effects on different Operating Systems (OSs). Let's take the `npm run build` command (like [the one in the spin-js-sdk](https://github.com/fermyon/spin-js-sdk/blob/sdk-v1/examples/javascript/hello_world/package.json)) as an example:
 
 <!-- @nocpy -->
 
@@ -305,7 +305,7 @@ proxies or URL shorteners.
 ## Storing Data in Redis From JS/TS Components
 
 > You can find a complete example for using outbound Redis from an HTTP component
-> in the [spin-js-sdk repository on GitHub](https://github.com/fermyon/spin-js-sdk/blob/main/examples/typescript/outbound_redis/src/index.ts).
+> in the [spin-js-sdk repository on GitHub](https://github.com/fermyon/spin-js-sdk/blob/sdk-v1/examples/typescript/outbound_redis/src/index.ts).
 
 Using the Spin's JS SDK, you can use the Redis key/value store and to publish messages to Redis channels.
 

--- a/content/spin/v1/rdbms-storage.md
+++ b/content/spin/v1/rdbms-storage.md
@@ -63,7 +63,7 @@ You can find complete examples for using relational databases in the Spin reposi
 
 {{ startTab "TypeScript"}}
 
-The JavaScript/TypeScript SDK doesn't surface the MySQL or PostgreSQL APIs. However, you can use hosted relational database services that are accessible over HTTP. For an example, see the JavaScript SDK repository on GitHub ([TypeScript](https://github.com/fermyon/spin-js-sdk/tree/main/examples/typescript/planetscale), [JavaScript](https://github.com/fermyon/spin-js-sdk/tree/main/examples/javascript/planetscale)).
+The JavaScript/TypeScript SDK doesn't surface the MySQL or PostgreSQL APIs. However, you can use hosted relational database services that are accessible over HTTP. For an example, see the JavaScript SDK repository on GitHub ([TypeScript](https://github.com/fermyon/spin-js-sdk/tree/sdk-v1/examples/typescript/planetscale), [JavaScript](https://github.com/fermyon/spin-js-sdk/tree/sdk-v1/examples/javascript/planetscale)).
 
 {{ blockEnd }}
 

--- a/content/spin/v1/redis-outbound.md
+++ b/content/spin/v1/redis-outbound.md
@@ -92,7 +92,7 @@ const value = Redis.get(address, key);
 
 * The arguments and results can be either numbers or buffers. (In TypeScript they are union types, e.g. `BigInt | ArrayBuffer`.)
 
-You can find a complete TypeScript example for using outbound Redis from an HTTP component in the [JavaScript SDK repository on GitHub](https://github.com/fermyon/spin-js-sdk/tree/main/examples/typescript/outbound_redis). Please also see this, related, [outbound Redis (using TypeScript) section](./javascript-components#storing-data-in-redis-from-jsts-components).
+You can find a complete TypeScript example for using outbound Redis from an HTTP component in the [JavaScript SDK repository on GitHub](https://github.com/fermyon/spin-js-sdk/tree/sdk-v1/examples/typescript/outbound_redis). Please also see this, related, [outbound Redis (using TypeScript) section](./javascript-components#storing-data-in-redis-from-jsts-components).
 
 {{ blockEnd }}
 

--- a/content/spin/v2/build.md
+++ b/content/spin/v2/build.md
@@ -66,23 +66,17 @@ command = "cargo build --target wasm32-wasi --release"
 
 {{ startTab "TypeScript" }}
 
-For JavaScript and TypeScript applications, you must have the `js2wasm` Spin plugin installed:
+For JavaScript and TypeScript applications, you must have `node.js`.
 
-<!-- @selectiveCpy -->
 
-```bash
-$ spin plugins update
-$ spin plugins install js2wasm --yes
-```
-
-It's normally convenient to put the detailed build instructions in `package.json`:
+It's normally convenient to put the detailed build instructions in `package.json`, The build script calls out to [`webpack`](https://webpack.js.org/) and `j2w` which is a script provided by the `@fermyon/spin-sdk` package that utilizes [`ComponentizeJS`](https://github.com/bytecodealliance/ComponentizeJS). The build script looks like:
 
 <!-- @nocpy -->
 
 ```json
 {
   "scripts": {
-    "build": "npx webpack --mode=production && mkdir -p target && spin js2wasm -o target/spin-http-js.wasm dist/spin.js"
+   "build": "npx webpack --mode=production && npx mkdirp target && npx j2w -i dist.js -d combined-wit -n combined -o target/spin-http-js.wasm"
   }
 }
 ```

--- a/content/spin/v2/build.md
+++ b/content/spin/v2/build.md
@@ -69,17 +69,19 @@ command = "cargo build --target wasm32-wasi --release"
 For JavaScript and TypeScript applications, you must have [Node.js](https://nodejs.org).
 
 
-It's normally convenient to put the detailed build instructions in `package.json`. The build script calls out to [`webpack`](https://webpack.js.org/) and `j2w` which is a script provided by the `@fermyon/spin-sdk` package that utilizes [`ComponentizeJS`](https://github.com/bytecodealliance/ComponentizeJS). The build script looks like:
+It's normally convenient to put the detailed build instructions in `package.json`. The build script looks like:
 
 <!-- @nocpy -->
 
 ```json
 {
   "scripts": {
-   "build": "npx webpack --mode=production && npx mkdirp target && npx j2w -i dist.js -d combined-wit -n combined -o target/spin-http-js.wasm"
+    "build": "npx webpack --mode=production && npx mkdirp target && npx j2w -i dist.js -d combined-wit -n combined -o target/spin-http-js.wasm"
   }
 }
 ```
+
+{{ details "Parts of the build script" "The build script calls out to [`webpack`](https://webpack.js.org/) and `j2w` which is a script provided by the `@fermyon/spin-sdk` package that utilizes [`ComponentizeJS`](https://github.com/bytecodealliance/ComponentizeJS)."}}
 
 The build command can then call the NPM script:
 

--- a/content/spin/v2/build.md
+++ b/content/spin/v2/build.md
@@ -66,10 +66,10 @@ command = "cargo build --target wasm32-wasi --release"
 
 {{ startTab "TypeScript" }}
 
-For JavaScript and TypeScript applications, you must have `node.js`.
+For JavaScript and TypeScript applications, you must have [Node.js](https://nodejs.org).
 
 
-It's normally convenient to put the detailed build instructions in `package.json`, The build script calls out to [`webpack`](https://webpack.js.org/) and `j2w` which is a script provided by the `@fermyon/spin-sdk` package that utilizes [`ComponentizeJS`](https://github.com/bytecodealliance/ComponentizeJS). The build script looks like:
+It's normally convenient to put the detailed build instructions in `package.json`. The build script calls out to [`webpack`](https://webpack.js.org/) and `j2w` which is a script provided by the `@fermyon/spin-sdk` package that utilizes [`ComponentizeJS`](https://github.com/bytecodealliance/ComponentizeJS). The build script looks like:
 
 <!-- @nocpy -->
 

--- a/content/spin/v2/http-outbound.md
+++ b/content/spin/v2/http-outbound.md
@@ -102,8 +102,7 @@ const response = await fetch("https://example.com/users");
 
 **Notes**
 
-// TODO: Add example and update link
-You can find a complete example of using outbound HTTP in the JavaScript SDK repository on [GitHub](https://github.com/fermyon/spin-js-sdk/tree/main/examples/typescript/outbound_http)
+You can find a complete example of using outbound HTTP in the JavaScript SDK repository on [GitHub](https://github.com/fermyon/spin-js-sdk/tree/main/examples/common-patterns/outbound-http)
 
 **Note**: `fetch` currently only works when building for the HTTP trigger.  
 

--- a/content/spin/v2/http-outbound.md
+++ b/content/spin/v2/http-outbound.md
@@ -102,9 +102,10 @@ const response = await fetch("https://example.com/users");
 
 **Notes**
 
-* Although the underlying Spin interface is blocking, the `fetch` function is defined by JavaScript as async. You must await the response, but the request will always block, and the promise will resolve as soon as the request is returned.
+// TODO: Add example and update link
+You can find a complete example of using outbound HTTP in the JavaScript SDK repository on [GitHub](https://github.com/fermyon/spin-js-sdk/tree/main/examples/typescript/outbound_http)
 
-You can find a complete example of using outbound HTTP in the JavaScript SDK repository on GitHub ([TypeScript](https://github.com/fermyon/spin-js-sdk/tree/main/examples/typescript/outbound_http), [JavaScript](https://github.com/fermyon/spin-js-sdk/tree/main/examples/javascript/outbound-http)).
+**Note**: `fetch` currently only works when building for the HTTP trigger.  
 
 {{ blockEnd }}
 

--- a/content/spin/v2/http-trigger.md
+++ b/content/spin/v2/http-trigger.md
@@ -267,31 +267,14 @@ For a full Rust SDK reference, see the [Rust Spin SDK documentation](https://doc
 
 > [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/)
 
-In JavaScript or TypeScript, the handler is identified by name.  It must be called `handleRequest`.  The way you declare it is slightly different between the two languages.
+In TypeScript, the user must a define a function named `handler` which the SDK attaches to the [`fetch` event listener](https://developer.mozilla.org/en-US/docs/Web/API/FetchEvent).
 
-In **JavaScript**, `handleRequest` is declared as `export async function`.  It takes a JavaScript [object representing the request](https://fermyon.github.io/spin-js-sdk/interfaces/HttpRequest.html), and returns a [response object](https://fermyon.github.io/spin-js-sdk/interfaces/HttpResponse.html).  The fields of these objects are exactly the same as in TypeScript:
+```ts
+import { ResponseBuilder } from "@fermyon/spin-sdk";
 
-```javascript
-export async function handleRequest(request) {
-    return {
-        status: 200,
-        headers: { "content-type": "text/plain" },
-        body: "Hello from JS-SDK"
-    }
-}
-```
-
-In **TypeScript**, `handleRequest` is declared as an `export const` of the [`HandleRequest` function type](https://fermyon.github.io/spin-js-sdk/types/HandleRequest.html) - that is, a function literal rather than a function declaration.  It takes a [`HttpRequest` object](https://fermyon.github.io/spin-js-sdk/interfaces/HttpRequest.html), and returns a [`HttpResponse` object](https://fermyon.github.io/spin-js-sdk/interfaces/HttpResponse.html), both defined in the `@fermyon/spin-sdk` package:
-
-```javascript
-import { HandleRequest, HttpRequest, HttpResponse} from "@fermyon/spin-sdk"
-
-export const handleRequest: HandleRequest = async function(request: HttpRequest): Promise<HttpResponse> {
-    return {
-      status: 200,
-        headers: { "content-type": "text/plain" },
-      body: "Hello from TS-SDK"
-    }
+export async function handler(req: Request, res: ResponseBuilder) {
+    console.log(req);
+    res.send("hello universe");
 }
 ```
 

--- a/content/spin/v2/http-trigger.md
+++ b/content/spin/v2/http-trigger.md
@@ -267,7 +267,9 @@ For a full Rust SDK reference, see the [Rust Spin SDK documentation](https://doc
 
 > [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/)
 
-In TypeScript, the user must a define a function named `handler` which the SDK attaches to the [`fetch` event listener](https://developer.mozilla.org/en-US/docs/Web/API/FetchEvent).
+The user must a define a function named `handler` which the SDK attaches to the [`FetchEvent` listener](https://developer.mozilla.org/en-US/docs/Web/API/FetchEvent). Note that the incoming HTTP event is translated to a `FetchEvent`.
+
+The handler function takes in two arguments a [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) and a [ResponseBuilder](https://fermyon.github.io/spin-js-sdk/classes/ResponseBuilder.html)
 
 ```ts
 import { ResponseBuilder } from "@fermyon/spin-sdk";

--- a/content/spin/v2/javascript-components.md
+++ b/content/spin/v2/javascript-components.md
@@ -382,4 +382,4 @@ These are some of the suggested libraries that have been tested and confirmed to
 ## Caveats
 
 - All `spin-sdk` related functions and methods (like `Variables`, `Redis`, `Mysql`, `Pg`, `Kv` and `Sqlite`) can be called only inside the `handler` function. This includes `fetch`. Any attempts to use it outside the function will lead to an error. This is due to Wizer using only Wasmtime to execute the script at build time, which does not include any Spin SDK support.
-- No operation that involve handling private keys are suported. 
+- No crypto operation that involve handling private keys are supported. 

--- a/content/spin/v2/javascript-components.md
+++ b/content/spin/v2/javascript-components.md
@@ -17,12 +17,12 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/v2/javascript
 - [Storing Data in SQLite](#storing-data-in-sqlite)
 - [Storing Data in MySQL and PostgreSQL Relational Databases](#storing-data-in-mysql-and-postgresql-relational-databases)
 - [AI Inferencing From JS/TS Components](#ai-inferencing-from-jsts-components)
-- [`Node.js` Compatibility](#nodejs-compatibility)
+- [Node.js Compatibility](#nodejs-compatibility)
 - [Using External NPM Libraries](#using-external-npm-libraries)
   - [Suggested Libraries for Common Tasks](#suggested-libraries-for-common-tasks)
 - [Caveats](#caveats)
 
-With JavaScript being a very popular language, Spin provides an SDK to support building components. The development of the JavaScript SDK is continually being worked on to improve user experience and add features. The SDK is based on [ComponentizeJS](https://github.com/bytecodealliance/ComponentizeJS).
+With JavaScript being a very popular language, Spin provides an SDK to support building components. The development of the JavaScript SDK is continually being worked on to improve user experience and add features. The SDK is based on [`ComponentizeJS`](https://github.com/bytecodealliance/ComponentizeJS).
 
 > This guide assumes you have Spin installed. If this is your first encounter with Spin, please see the [Quick Start](quickstart), which includes information about installing Spin with the JavaScript templates and creating JavaScript and TypeScript applications.
 
@@ -87,7 +87,9 @@ hello-world/
 └── webpack.config.js
 ```
 
-The source for the component is present in `src/index.ts`. [Webpack](https://webpack.js.org) is used to bundle the component into a single `.js` file which will then be compiled to a `.wasm` module using the `j2w` node executable provided by the `@fermyon/spin-sdk` which is a wrapper around `ComponentizeJS`. The `knitwit.json` is the configuration file used by [knitwit](https://github.com/fermyon/knitwit) to manage the WebAssembly dependencies of each package.
+The source for the component is present in `src/index.ts`. [Webpack](https://webpack.js.org) is used to bundle the component into a single `.js` file which will then be compiled to a `.wasm` module.
+
+{{ details "Going from JavaScript to Wasm" "The JS source is compiled to a `wasm` module using the `j2w` node executable provided by the `@fermyon/spin-sdk` which is a wrapper around `ComponentizeJS`. The `knitwit.json` is the configuration file used by [knitwit](https://github.com/fermyon/knitwit) to manage the WebAssembly dependencies of each package."}}
 
 ## Building and Running the Template
 
@@ -326,9 +328,9 @@ For more information about using relational databases from TypeScript/JavaScript
 
 For more information about using Serverless AI from JS/TS, see the [Serverless AI](serverless-ai-api-guide) API guide.
 
-## `Node.js` Compatibility
+## Node.js Compatibility
 
-The SDK does not support the full specification of `Node.js`. A limited set of APIs can be polyfilled using the [`@fermyon/wasi-ext`](https://github.com/fermyon/js-wasi-ext) library which provided a webpack plugin. It can be used by installing the  library first using:
+The SDK does not support the full specification of `Node.js`. A limited set of APIs can be polyfilled using the [`@fermyon/wasi-ext`](https://github.com/fermyon/js-wasi-ext) library which provides a webpack plugin. It can be used by installing the  library first using:
 
 <!-- @selectiveCpy -->
 

--- a/content/spin/v2/javascript-components.md
+++ b/content/spin/v2/javascript-components.md
@@ -9,7 +9,6 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/v2/javascript
 - [Installing Templates](#installing-templates)
 - [Structure of a JS/TS Component](#structure-of-a-jsts-component)
 - [Building and Running the Template](#building-and-running-the-template)
-  - [A Quick Note About the NPM Script and Windows](#a-quick-note-about-the-npm-script-and-windows)
 - [HTTP Components](#http-components)
 - [Sending Outbound HTTP Requests](#sending-outbound-http-requests)
 - [Storing Data in Redis From JS/TS Components](#storing-data-in-redis-from-jsts-components)
@@ -18,13 +17,14 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/v2/javascript
 - [Storing Data in SQLite](#storing-data-in-sqlite)
 - [Storing Data in MySQL and PostgreSQL Relational Databases](#storing-data-in-mysql-and-postgresql-relational-databases)
 - [AI Inferencing From JS/TS Components](#ai-inferencing-from-jsts-components)
+- [`Node.js` Compatibility](#nodejs-compatibility)
 - [Using External NPM Libraries](#using-external-npm-libraries)
   - [Suggested Libraries for Common Tasks](#suggested-libraries-for-common-tasks)
 - [Caveats](#caveats)
 
-With JavaScript being a very popular language, Spin provides support for building components with it using the experimental SDK. The development of the JavaScript SDK is continually being worked on to improve user experience and add features. 
+With JavaScript being a very popular language, Spin provides an SDK to support building components. The development of the JavaScript SDK is continually being worked on to improve user experience and add features. The SDK is based on [ComponentizeJS](https://github.com/bytecodealliance/ComponentizeJS).
 
-> This guide assumes you have Spin installed. If this is your first encounter with Spin, please see the [Quick Start](quickstart), which includes information about installing Spin with the JavaScript templates, installing required tools, and creating JavaScript and TypeScript applications.
+> This guide assumes you have Spin installed. If this is your first encounter with Spin, please see the [Quick Start](quickstart), which includes information about installing Spin with the JavaScript templates and creating JavaScript and TypeScript applications.
 
 > This guide assumes you are familiar with the JavaScript programming language,
 > but if you are just getting started, be sure to check [the MDN guide](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide).
@@ -32,15 +32,6 @@ With JavaScript being a very popular language, Spin provides support for buildin
 > All examples from this page can be found in [the JavaScript SDK repository on GitHub](https://github.com/fermyon/spin-js-sdk/tree/main/examples).
 
 [**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/)
-
-In order to compile JavaScript programs to Spin components, you also need to install a Spin plugin `js2wasm` using the following command:
-
-<!-- @selectiveCpy -->
-
-```bash
-$ spin plugin update
-$ spin plugin install js2wasm
-```
 
 ## Installing Templates
 
@@ -86,16 +77,17 @@ This creates a directory of the following structure:
 
 ```text
 hello-world/
+├── knitwit.json
 ├── package.json
-├── README.md
 ├── spin.toml
 ├── src
-│   └── index.ts
+│   ├── index.ts
+│   └── spin.ts
 ├── tsconfig.json
 └── webpack.config.js
 ```
 
-The source for the component is present in `src/index.ts`. [Webpack](https://webpack.js.org) is used to bundle the component into a single `.js` file which will then be compiled to a `.wasm` module using the `js2wasm` plugin.
+The source for the component is present in `src/index.ts`. [Webpack](https://webpack.js.org) is used to bundle the component into a single `.js` file which will then be compiled to a `.wasm` module using the `j2w` node executable provided by the `@fermyon/spin-sdk` which is a wrapper around `ComponentizeJS`. The `knitwit.json` is the configuration file used by [knitwit](https://github.com/fermyon/knitwit) to manage the WebAssembly dependencies of each package.
 
 ## Building and Running the Template
 
@@ -117,53 +109,15 @@ $ spin build
 $ spin up
 ```
 
-`spin build` will execute the command in the `command` key under the `[component.<component-name>.build]` section from `spin.toml` for each component in your application. In this case an `npx` command will be run.
-
----
-
-### A Quick Note About the NPM Script and Windows
-
-Please note that using pre-built NPM scripts can have different effects on different Operating Systems (OSs). Let's take a look at the `build` script in the `package.json` file as an example:
+`spin build` will execute the command in the `command` key under the `[component.<component-name>.build]` section from `spin.toml` for each component in your application. In this case an `npm` script will be run. The command in the `package.json` will looks something like:
 
 <!-- @nocpy -->
 
-```bash
+```json
 "scripts": {
-    "build": "npx webpack --mode=production && mkdir -p target && spin js2wasm -o target/spin-http-js.wasm dist/spin.js",
+    "build": "npx webpack --mode=production && npx mkdirp target && npx j2w -i dist.js -d combined-wit -n combined -o target/hello-world.wasm",
     "test": "echo \"Error: no test specified\" && exit 1"
   }
-```
-
-The `build` script will work on Linux and macOS. However, on Windows it will create both a `-p` directory and a `target` directory.
-
-On Linux/Unix systems, the `-p` option in the `mkdir` command is designed to prevent an error from occurring in the event that the `target` directory already exists. However, on Windows systems, npm (by default) uses cmd.exe which does not recognize the `-p` option, regarding its `mkdir` command.
-
-If you run the script on Windows (more than once) the following error will be encountered:
-
-<!-- @nocpy -->
-
-```bash
-A subdirectory or file -p already exists
-A Subdirectory or file target already exists
-```
-
-If any errors, as described above, occur please consider one of the two following options:
-
-a) Configure your instance of `npm` to use bash (by using the `script-shell` configuration setting): 
-
-<!-- @selectiveCpy -->
-
-```bash
-$ npm config set script-shell "C:\\Program Files\\git\\bin\\bash.exe"
-```
-
-b) Run the separate parts of the `build` manually, to suite your needs (OS syntax requirements):
-
-<!-- @selectiveCpy -->
-
-```bash
-$ npx webpack --mode=production
-$ spin js2wasm -o target/spin-http-js.wasm dist/spin.js
 ```
 
 ---
@@ -179,26 +133,23 @@ for writing Spin components with the Spin JS/TS SDK.
 > details about building HTTP applications.
 
 Building a Spin HTTP component using the JS/TS SDK means writing a single function
-that takes an HTTP request as a parameter, and returns an HTTP response — below
-is a complete implementation for such a component in TypeScript:
+that takes an HTTP request and a Response Builder which can be used to return an HTTP response as a parameter.
+
+Below is a complete implementation for such a component in TypeScript:
 
 ```javascript
-import { HandleRequest, HttpRequest, HttpResponse } from "@fermyon/spin-sdk"
+import { ResponseBuilder } from "@fermyon/spin-sdk";
 
-export const handleRequest: HandleRequest = async function (request: HttpRequest): Promise<HttpResponse> {
-    return {
-        status: 200,
-        headers: {"content-type": "text/plain"},
-        body: "Hello from TS-SDK"
-    }
+export async function handler(req: Request, res: ResponseBuilder) {
+    console.log(req);
+    res.send("hello universe");
 }
 ```
 
 The important things to note in the implementation above:
 
-- the `handleRequest` function is the entry point for the Spin component.
-- the component returns `Promise<HttpResponse>`.
-
+- The `handler` function is the entry point for the Spin component.
+- The execution of the function terminates once `res.send` or `res.end` is called. 
 
 ## Sending Outbound HTTP Requests
 
@@ -206,24 +157,21 @@ If allowed, Spin components can send outbound HTTP requests.
 Let's see an example of a component that makes a request to [an API that returns random animal facts](https://random-data-api.fermyon.app/animals/json)
 
 ```javascript
-import { HandleRequest, HttpRequest, HttpResponse } from "@fermyon/spin-sdk"
+import { ResponseBuilder } from "@fermyon/spin-sdk";
 
 interface AnimalFact {
    timestamp: number;
    fact: string;
 }
 
-export const handleRequest: HandleRequest = async function (request: HttpRequest): Promise<HttpResponse> {
+export async function handler(req: Request, res: ResponseBuilder) {
     const animalFactResponse = await fetch("https://random-data-api.fermyon.app/animals/json")
     const animalFact = await animalFactResponse.json() as AnimalFact
 
     const body = `Here's an animal fact: ${animalFact.fact}\n`
 
-    return {
-        status: 200,
-        headers: {"content-type": "text/plain"},
-        body: body
-    }
+    res.set({"content-type": "text/plain"})
+    res.send(body)
 }
 ```
 
@@ -288,38 +236,37 @@ proxies or URL shorteners.
 ## Storing Data in Redis From JS/TS Components
 
 > You can find a complete example for using outbound Redis from an HTTP component
-> in the [spin-js-sdk repository on GitHub](https://github.com/fermyon/spin-js-sdk/blob/main/examples/typescript/outbound_redis/src/index.ts).
+> in the [spin-js-sdk repository on GitHub](https://github.com/fermyon/spin-js-sdk/blob/main/examples/spin-host-apis/spin-redis).
 
 Using the Spin's JS SDK, you can use the Redis key/value store and to publish messages to Redis channels.
 
 Let's see how we can use the JS/TS SDK to connect to Redis:
 
 ```javascript
-import { HandleRequest, HttpRequest, HttpResponse, Redis } from "@fermyon/spin-sdk"
+import { ResponseBuilder, Redis } from '@fermyon/spin-sdk';
 
-const decoder = new TextDecoder()
-const encoder = new TextEncoder()
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+const redisAddress = 'redis://localhost:6379/';
 
-const redisAddress = "redis://localhost:6379/"
+export async function handler(_req: Request, res: ResponseBuilder) {
+  try {
+    let db = Redis.open(redisAddress);
+    db.set('test', encoder.encode('Hello world'));
+    let val = db.get('test');
 
-export const handleRequest: HandleRequest = async function (request: HttpRequest): Promise<HttpResponse> {
-
-    Redis.incr(redisAddress, "test")
-    Redis.incr(redisAddress, "test")
-
-    console.log(decoder.decode(new Uint8Array(Redis.get(redisAddress, "test"))))
-
-    Redis.set(redisAddress, "test-set", encoder.encode("This is a test").buffer)
-
-    console.log(decoder.decode(new Uint8Array(Redis.get(redisAddress, "test-set"))))
-
-    Redis.publish(redisAddress, "test", encoder.encode("This is a test").buffer)
-
-    return {
-        status: 200,
-        headers: { "content-type": "text/plain" },
-        body: "Your data is stored!"
+    if (!val) {
+      res.status(404);
+      res.send();
+      return;
     }
+    // publish to a channel names "message"
+    db.publish("message", val)
+    res.send(val);
+  } catch (e: any) {
+    res.status(500);
+    res.send(`Error: ${JSON.stringify(e.payload)}`);
+  }
 }
 ```
 
@@ -338,34 +285,28 @@ allowed_outbound_hosts = ["redis://localhost:6379"]
 
 ## Routing in a Component
 
-The JavaScript/TypeScript SDK provides a router that makes it easier to handle routing within a component. The router is based on [`itty-router`](https://www.npmjs.com/package/itty-router). An additional function `handleRequest` has been implemented in the router to allow passing in the Spin HTTP request directly. For a more complete documentation on the route, checkout the documentation at [itty-router](https://github.com/kwhitley/itty-router). An example usage of the router is given below:
+The JavaScript/TypeScript SDK provides a router that makes it easier to handle routing within a component. The router is based on [`itty-router`](https://www.npmjs.com/package/itty-router). An additional function `handleRequest` has been implemented in the router to allow passing in the Spin HTTP request directly. An example usage of the router is given below:
 
 ```javascript
-import { HandleRequest, HttpRequest, HttpResponse, Router} from "@fermyon/spin-sdk"
+import { ResponseBuilder, Router } from '@fermyon/spin-sdk';
 
-let router = Router()
+let router = Router();
 
-function handleDefaultRoute() {
-  return {
-    status: 200,
-    headers: { "content-type": "text/plain" },
-    body: "Hello from Default Route"
-  }
+router.get("/", (_, req, res) => { handleDefaultRoute(req, res) })
+router.get("/home/:id", (metadata, req, res) => { handleHomeRoute(req, res, metadata.params.id) })
+
+async function handleDefaultRoute(_req: Request, res: ResponseBuilder) {
+  res.set({ "content-type": "text/plain" });
+  res.send("Hello from default route");
 }
 
-function handleHomeRoute(id: string) {
-  return {
-    status: 200,
-    headers: { "content-type": "text/plain" },
-    body: "Hello from Home Route with id:" + id
-  }
+async function handleHomeRoute(_req: Request, res: ResponseBuilder, id: string) {
+  res.set({ "content-type": "text/plain" });
+  res.send(`Hello from home route with id: ${id}`);
 }
 
-router.get("/", handleDefaultRoute)
-router.get("/home/:id", ({params}) => handleHomeRoute(params.id))
-
-export const handleRequest: HandleRequest = async function(request: HttpRequest): Promise<HttpResponse> {
-    return await router.handleRequest(request)
+export async function handler(req: Request, res: ResponseBuilder) {
+  await router.handleRequest(req, res);
 }
 ```
 
@@ -385,11 +326,44 @@ For more information about using relational databases from TypeScript/JavaScript
 
 For more information about using Serverless AI from JS/TS, see the [Serverless AI](serverless-ai-api-guide) API guide.
 
+## `Node.js` Compatibility
+
+The SDK does not support the full specification of `Node.js`. A limited set of APIs can be polyfilled using the [`@fermyon/wasi-ext`](https://github.com/fermyon/js-wasi-ext) library which provided a webpack plugin. It can be used by installing the  library first using:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ npm install @fermyon/wasi-ext
+```
+
+Once installed, the plugin provided by it can be added to the webpack config: 
+
+```js
+const WasiExtPlugin = require("wasi-ext/plugin")
+
+module.exports = {
+    ...
+    plugins: [
+        new WasiExtPlugin()
+    ],
+    ...
+};
+```
+
+This library only currently supports the following polyfills:
+
+- `Node.js` buffers
+- `process` - certain methods are no-ops and few throw exceptions. For detailed list refer to the [upstream library](https://github.com/defunctzombie/node-process/blob/master/browser.js). **Note:** `process.env` is populated only inside the handler and returns an empty object outside the handler.
+- `fs` - only implements `readFileSync` and `readdirSync`.
+- `os` - Implements only `EOL` and `arch`.
+
+
 ## Using External NPM Libraries
 
 > Not all the NPM packages are guaranteed to work with the SDK as it is not fully compatible with the browser or `Node.js`. It implements only a subset of the API.
 
 Some NPM packages can be installed and used in the component. If a popular library does not work, please open an issue/feature request in the [spin-js-sdk repository](https://github.com/fermyon/spin-js-sdk/issues).
+
 
 ### Suggested Libraries for Common Tasks
 
@@ -405,6 +379,5 @@ These are some of the suggested libraries that have been tested and confirmed to
 
 ## Caveats
 
-- All `spin-sdk` related functions and methods (like `Config`, `Redis`, `Mysql`, `Pg`, `Kv` and `Sqlite`) can be called only inside the `handleRequest` function. This includes the usage of `fetch`. Any attempts to use it outside the function will lead to an error. This is due to Wizer using only Wasmtime to execute the script at build time, which does not include any Spin SDK support.
-- Only a subset of the browser and `Node.js` APIs are implemented.
-- The support for Crypto  module is limited. The methods currently supported are `crypto.getRandomValues`, `crypto.subtle.digest`, `crypto.createHash` and `crypto.createHmac`
+- All `spin-sdk` related functions and methods (like `Variables`, `Redis`, `Mysql`, `Pg`, `Kv` and `Sqlite`) can be called only inside the `handler` function. This includes `fetch`. Any attempts to use it outside the function will lead to an error. This is due to Wizer using only Wasmtime to execute the script at build time, which does not include any Spin SDK support.
+- No operation that involve handling private keys are suported. 

--- a/content/spin/v2/key-value-store-tutorial.md
+++ b/content/spin/v2/key-value-store-tutorial.md
@@ -76,7 +76,7 @@ $ spin new -t http-rust spin-key-value
 ```bash
 $ spin new -t http-ts spin-key-value
 
-# Reference: https://github.com/fermyon/spin-js-sdk/tree/feat/sdk-v2/examples/spin-host-apis/spin-kv
+# Reference: https://github.com/fermyon/spin-js-sdk/tree/main/examples/spin-host-apis/spin-kv
 ```
 
 {{ blockEnd }}
@@ -233,7 +233,7 @@ fn handle_request(req: Request) -> anyhow::Result<impl IntoResponse> {
 {{ startTab "TypeScript"}}
 
 ```typescript
-import { ResponseBuilder } from "@fermyon/spin-sdk";
+import { ResponseBuilder, Kv } from "@fermyon/spin-sdk";
 
 const encoder = new TextEncoder()
 const decoder = new TextDecoder()
@@ -269,7 +269,7 @@ export async function handler(req: Request, res: ResponseBuilder) {
         console.log(`Key ${req.uri} not found`);
         status = 404
       } else {
-      console.log(`Found Key ${req.uri}`);
+        console.log(`Found Key ${req.uri}`);
       }
       break;
     default:

--- a/content/spin/v2/key-value-store-tutorial.md
+++ b/content/spin/v2/key-value-store-tutorial.md
@@ -76,7 +76,7 @@ $ spin new -t http-rust spin-key-value
 ```bash
 $ spin new -t http-ts spin-key-value
 
-# Reference: https://github.com/fermyon/spin-js-sdk/tree/main/examples/typescript/spin_kv
+# Reference: https://github.com/fermyon/spin-js-sdk/tree/feat/sdk-v2/examples/spin-host-apis/spin-kv
 ```
 
 {{ blockEnd }}
@@ -233,52 +233,49 @@ fn handle_request(req: Request) -> anyhow::Result<impl IntoResponse> {
 {{ startTab "TypeScript"}}
 
 ```typescript
-import { HandleRequest, HttpRequest, HttpResponse, Kv } from "@fermyon/spin-sdk"
+import { ResponseBuilder } from "@fermyon/spin-sdk";
 
 const encoder = new TextEncoder()
 const decoder = new TextDecoder()
 
-export const handleRequest: HandleRequest = async function (request: HttpRequest): Promise<HttpResponse> {
+export async function handler(req: Request, res: ResponseBuilder) {
 
   let store = Kv.openDefault()
   let status = 200
   let body
 
-  switch (request.method) {
+  switch (req.method) {
     case "POST":
-      store.set(request.uri, request.body || (new Uint8Array()).buffer)
-      console.log(`Storing value in the KV store with ${request.uri} as the key`);
+      store.set(req.uri, await req.text() || (new Uint8Array()).buffer)
+      console.log(`Storing value in the KV store with ${req.uri} as the key`);
       break;
     case "GET":
       let val
       try {
-        val = store.get(request.uri)
+        val = store.get(req.uri)
         body = decoder.decode(val)
-      	console.log(`Found value for the key ${request.uri}`);
+      	console.log(`Found value for the key ${req.uri}`);
       } catch (error) {
-      	console.log(`Key ${request.uri} not found`);
+      	console.log(`Key ${req.uri} not found`);
         status = 404
       }
       break;
     case "DELETE":
-      store.delete(request.uri)
-      console.log(`Deleted Key ${request.uri}`);
+      store.delete(req.uri)
+      console.log(`Deleted Key ${req.uri}`);
       break;
     case "HEAD":
-      if (!store.exists(request.uri)) {
-        console.log(`Key ${request.uri} not found`);
+      if (!store.exists(req.uri)) {
+        console.log(`Key ${req.uri} not found`);
         status = 404
       } else {
-      console.log(`Found Key ${request.uri}`);
+      console.log(`Found Key ${req.uri}`);
       }
       break;
     default:
   }
-
-  return {
-    status: status,
-    body: body
-  }
+  res.status(status)
+  res.send(body)
 }
 ```
 

--- a/content/spin/v2/kv-store-api-guide.md
+++ b/content/spin/v2/kv-store-api-guide.md
@@ -102,14 +102,14 @@ export async function handler(req: Request, res: ResponseBuilder) {
 **General Notes**
 - The SDK doesn't surface the `close` operation. It automatically closes all stores at the end of the request; there's no way to close them early.
 
-[`get` **Operation**](https://fermyon.github.io/spin-js-sdk/interfaces/_internal_.KvStore.html#get)
+[`get` **Operation**](https://fermyon.github.io/spin-js-sdk/interfaces/Kv.Store.html#get)
 - The result is of the type `ArrayBuffer | null`
 - If the key does not exist, `get` returns `null`
 
-[`set` **Operation**](https://fermyon.github.io/spin-js-sdk/interfaces/_internal_.KvStore.html#set)
+[`set` **Operation**](https://fermyon.github.io/spin-js-sdk/interfaces/Kv.Store.html#set)
 - The value argument is of the type `Uint8Array | string | object`.
 
-[`setJson`](https://fermyon.github.io/spin-js-sdk/interfaces/_internal_.KvStore.html#setJson) and [`getJson` **Operation**](https://fermyon.github.io/spin-js-sdk/interfaces/_internal_.KvStore.html#getJson)
+[`setJson`](https://fermyon.github.io/spin-js-sdk/interfaces/Kv.Store.html#setJson) and [`getJson` **Operation**](https://fermyon.github.io/spin-js-sdk/interfaces/Kv.Store.html#getJson)
 - Applications can store JavaScript objects using `setJson`; these are serialized within the store as JSON. These serialized objects can be retrieved and deserialized using `getJson`. If you call `getJson` on a key that doesn't exist then it returns an empty object.
 
 {{ blockEnd }}

--- a/content/spin/v2/kv-store-api-guide.md
+++ b/content/spin/v2/kv-store-api-guide.md
@@ -85,38 +85,32 @@ fn handle_request(_req: Request) -> Result<impl IntoResponse> {
 
 > [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/)
 
-With Typescript, the key value functions can be accessed after opening a store using either [the `Kv.open` or the `Kv.openDefault` methods](https://fermyon.github.io/spin-js-sdk/variables/Kv.html) which returns a [handle to the store](https://fermyon.github.io/spin-js-sdk/interfaces/_internal_.KvStore.html). For example:
+With Typescript, the key value functions can be accessed after opening a store using either [the `Kv.open` or the `Kv.openDefault` methods](https://fermyon.github.io/spin-js-sdk/modules/Kv.html) which returns a [handle to the store](https://fermyon.github.io/spin-js-sdk/interfaces/Kv.Store.html). For example:
 
-```javascript
-import { HandleRequest, HttpRequest, HttpResponse, Kv } from "@fermyon/spin-sdk"
+```ts
+import { ResponseBuilder } from "@fermyon/spin-sdk";
 
-const encoder = new TextEncoder()
-
-export const handleRequest: HandleRequest = async function (request: HttpRequest): Promise<HttpResponse> {
+export async function handler(req: Request, res: ResponseBuilder) {
     let store = Kv.openDefault()
     store.set("mykey", "myvalue")
-    return {
-            status: 200,
-            headers: {"content-type":"text/plain"},
-            body: store.get("mykey") ?? encoder.encode("Key not found")
-    }
+    res.status(200)
+    res.set({"content-type":"text/plain"})
+    res.send(store.get("mykey") ?? "Key not found")
 }
-
 ```
 
 **General Notes**
-- The spinSdk object is always available at runtime. Code checking and completion are available in TypeScript at design time if the module imports anything from the @fermyon/spin-sdk package. For example: 
-- The JavaScript SDK doesn't surface the `close` operation. It automatically closes all stores at the end of the request; there's no way to close them early.
+- The SDK doesn't surface the `close` operation. It automatically closes all stores at the end of the request; there's no way to close them early.
 
 [`get` **Operation**](https://fermyon.github.io/spin-js-sdk/interfaces/_internal_.KvStore.html#get)
 - The result is of the type `ArrayBuffer | null`
 - If the key does not exist, `get` returns `null`
 
 [`set` **Operation**](https://fermyon.github.io/spin-js-sdk/interfaces/_internal_.KvStore.html#set)
-- The value argument is of the type `ArrayBuffer | string`.
+- The value argument is of the type `Uint8Array | string | object`.
 
 [`setJson`](https://fermyon.github.io/spin-js-sdk/interfaces/_internal_.KvStore.html#setJson) and [`getJson` **Operation**](https://fermyon.github.io/spin-js-sdk/interfaces/_internal_.KvStore.html#getJson)
-- JavaScript and TypeScript applications can store JavaScript objects using `setJson`; these are serialized within the store as JSON. These serialized objects can be retrieved and deserialized using `getJson`. If you call `getJson` on a key that doesn't exist then an error is thrown (note that this is different behavior from `get`).
+- Applications can store JavaScript objects using `setJson`; these are serialized within the store as JSON. These serialized objects can be retrieved and deserialized using `getJson`. If you call `getJson` on a key that doesn't exist then it returns an empty object.
 
 {{ blockEnd }}
 

--- a/content/spin/v2/kv-store-api-guide.md
+++ b/content/spin/v2/kv-store-api-guide.md
@@ -85,10 +85,10 @@ fn handle_request(_req: Request) -> Result<impl IntoResponse> {
 
 > [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/)
 
-With Typescript, the key value functions can be accessed after opening a store using either [the `Kv.open` or the `Kv.openDefault` methods](https://fermyon.github.io/spin-js-sdk/modules/Kv.html) which returns a [handle to the store](https://fermyon.github.io/spin-js-sdk/interfaces/Kv.Store.html). For example:
+The key value functions can be accessed after opening a store using either [the `Kv.open` or the `Kv.openDefault` methods](https://fermyon.github.io/spin-js-sdk/modules/Kv.html) which returns a [handle to the store](https://fermyon.github.io/spin-js-sdk/interfaces/Kv.Store.html). For example:
 
 ```ts
-import { ResponseBuilder } from "@fermyon/spin-sdk";
+import { ResponseBuilder , Kv} from "@fermyon/spin-sdk";
 
 export async function handler(req: Request, res: ResponseBuilder) {
     let store = Kv.openDefault()
@@ -103,7 +103,7 @@ export async function handler(req: Request, res: ResponseBuilder) {
 - The SDK doesn't surface the `close` operation. It automatically closes all stores at the end of the request; there's no way to close them early.
 
 [`get` **Operation**](https://fermyon.github.io/spin-js-sdk/interfaces/Kv.Store.html#get)
-- The result is of the type `ArrayBuffer | null`
+- The result is of the type `Uint8Array | null`
 - If the key does not exist, `get` returns `null`
 
 [`set` **Operation**](https://fermyon.github.io/spin-js-sdk/interfaces/Kv.Store.html#set)

--- a/content/spin/v2/language-support-overview.md
+++ b/content/spin/v2/language-support-overview.md
@@ -53,7 +53,7 @@ This page contains information about language support for Spin features:
 | [PostgreSQL](./rdbms-storage#using-mysql-and-postgresql-from-applications) | Supported |
 | [Outbound Redis](./javascript-components#storing-data-in-redis-from-jsts-components) | Supported |
 | [Serverless AI](./serverless-ai-api-guide) | Supported |
-| [MQTT Messaging](./mqtt-outbound) | Not Supported |
+| [MQTT Messaging](./mqtt-outbound) | Supported |
 | **Extensibility** |
 | Authoring Custom Triggers | Not Supported |
 

--- a/content/spin/v2/mqtt-outbound.md
+++ b/content/spin/v2/mqtt-outbound.md
@@ -57,7 +57,24 @@ You can find a complete Rust code example for using outbound MQTT from an HTTP c
 
 {{ startTab "TypeScript"}}
 
-MQTT is not available in the current version of the JavaScript/TypeScript SDK.
+> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/modules/Mqtt.html)
+
+To access an MQTT server, use the `Mqtt.open` function.
+
+```ts
+let connection = Mqtt.open(address, username, password, keepAliveSecs);
+```
+
+You can then call the `publish` method on the connection to send MQTT messages:
+
+```ts
+let catPicture = new Uint8Array(await req.arraybuffer());
+connection.publish("pets", catPicture, QoS::AtleastOnce);
+```
+
+For full details of the MQTT API, see the [Spin SDK reference documentation](https://fermyon.github.io/spin-js-sdk/modules/Mqtt.html)
+
+You can find a complete Rust code example for using outbound MQTT from an HTTP component in the [Spin Rust SDK repository on GitHub](https://github.com/fermyon/spin-js-sdk/tree/main/examples/spin-host-apis/spin-mqtt).
 
 {{ blockEnd }}
 

--- a/content/spin/v2/mqtt-outbound.md
+++ b/content/spin/v2/mqtt-outbound.md
@@ -69,7 +69,7 @@ You can then call the `publish` method on the connection to send MQTT messages:
 
 ```ts
 let catPicture = new Uint8Array(await req.arraybuffer());
-connection.publish("pets", catPicture, QoS::AtleastOnce);
+connection.publish("pets", catPicture, QoS.AtleastOnce);
 ```
 
 For full details of the MQTT API, see the [Spin SDK reference documentation](https://fermyon.github.io/spin-js-sdk/modules/Mqtt.html)

--- a/content/spin/v2/rdbms-storage.md
+++ b/content/spin/v2/rdbms-storage.md
@@ -72,8 +72,7 @@ For full information about the MySQL and PostgreSQL APIs, see [the Spin SDK refe
 
 > [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/)
 
-//TODO: Add example and point at it
-The code below is an [Outbound MySQL example](https://github.com/fermyon/spin-js-sdk/tree/main/examples/spin-host-apis/spin_mysql). There is also an outbound [PostgreSQL example](https://github.com/fermyon/spin-js-sdk/tree/main/examples/spin-host-apis/spin_postgres) available.
+The code below is an [Outbound MySQL example](https://github.com/fermyon/spin-js-sdk/tree/main/examples/spin-host-apis/spin-mysql). There is also an outbound [PostgreSQL example](https://github.com/fermyon/spin-js-sdk/tree/main/examples/spin-host-apis/spin-postgres) available.
 
 ```ts
 import { ResponseBuilder, Mysql } from '@fermyon/spin-sdk';

--- a/content/spin/v2/rdbms-storage.md
+++ b/content/spin/v2/rdbms-storage.md
@@ -93,7 +93,8 @@ export async function handler(_req: Request, res: ResponseBuilder) {
   conn.execute('delete from test where id=?', [4]);
   conn.execute('insert into test values (4,5)', []);
   let ret = conn.query('select * from test', []);
-
+  // return a object that looks like 
+  // { "columns": [{name: "id", dataType: "int32"}], "rows": [{ "id": 4, "val": 5 }] }
   res.send(JSON.stringify(ret, null, 2));
 }
 ```

--- a/content/spin/v2/rdbms-storage.md
+++ b/content/spin/v2/rdbms-storage.md
@@ -72,12 +72,11 @@ For full information about the MySQL and PostgreSQL APIs, see [the Spin SDK refe
 
 > [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/)
 
-The code below is an [Outbound MySQL example](https://github.com/fermyon/spin-js-sdk/tree/main/examples/typescript/outbound_mysql). There is also an outbound [PostgreSQL example](https://github.com/fermyon/spin-js-sdk/tree/main/examples/typescript/outbound_pg) available.
+//TODO: Add example and point at it
+The code below is an [Outbound MySQL example](https://github.com/fermyon/spin-js-sdk/tree/main/examples/spin-host-apis/spin_mysql). There is also an outbound [PostgreSQL example](https://github.com/fermyon/spin-js-sdk/tree/main/examples/spin-host-apis/spin_postgres) available.
 
 ```ts
-import { HandleRequest, HttpRequest, HttpResponse, Mysql } from "@fermyon/spin-sdk"
-
-const encoder = new TextEncoder()
+import { ResponseBuilder, Mysql } from '@fermyon/spin-sdk';
 
 // Connects as the root user without a password 
 const DB_URL = "mysql://root:@127.0.0.1/spin_dev"
@@ -90,22 +89,13 @@ const DB_URL = "mysql://root:@127.0.0.1/spin_dev"
  insert into test values (4,4);
 */
 
-export const handleRequest: HandleRequest = async function (request: HttpRequest): Promise<HttpResponse> {
+export async function handler(_req: Request, res: ResponseBuilder) {
+  let conn = Mysql.open(DB_URL);
+  conn.execute('delete from test where id=?', [4]);
+  conn.execute('insert into test values (4,5)', []);
+  let ret = conn.query('select * from test', []);
 
-    Mysql.execute(DB_URL, "delete from test where id=?", [4])
-    Mysql.execute(DB_URL, "insert into test values (4,5)", [])
-    let test = Mysql.query(DB_URL, "select * from test", [])
-
-    console.log(test.columns)
-    test.rows.map (k => {
-        console.log(k)
-    })
-
-    return {
-        status: 200,
-        headers: {"foo": "bar"},
-        body: encoder.encode("Hello from JS-SDK").buffer
-    }
+  res.send(JSON.stringify(ret, null, 2));
 }
 ```
 

--- a/content/spin/v2/redis-outbound.md
+++ b/content/spin/v2/redis-outbound.md
@@ -91,7 +91,7 @@ You can find a complete Rust code example for using outbound Redis from an HTTP 
 
 > [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/)
 
-Redis functions are available on [the `Redis` module](https://fermyon.github.io/spin-js-sdk/variables/Redis.html). The function names match the operations above. For example:
+Redis functions are available on [the `Redis` module](https://fermyon.github.io/spin-js-sdk/modules/Redis.html). The function names match the operations above. For example:
 
 ```javascript
 import { Redis } from "@fermyon/spin-sdk"

--- a/content/spin/v2/redis-outbound.md
+++ b/content/spin/v2/redis-outbound.md
@@ -97,11 +97,11 @@ Redis functions are available on [the `Redis` module](https://fermyon.github.io/
 import { Redis } from "@fermyon/spin-sdk"
 
 let db = Redis.open("redis://localhost:6379")
-const value = db.get(key);
+let value = db.get(key);
 ```
 
 **General Notes**
-* key parameters are strings.
+* Key parameters are strings.
 * Bytes parameters and return values are buffers (TypeScript `Uint8Array`).
 * Lists are passed and returned as arrays.
 
@@ -109,7 +109,7 @@ const value = db.get(key);
 
 * The arguments and results can be either numbers or buffers. (In TypeScript they are union types, e.g. `BigInt | Uint8Array`.)
 
-You can find a complete TypeScript example for using outbound Redis from an HTTP component in the [JavaScript SDK repository on GitHub](https://github.com/fermyon/spin-js-sdk/tree/main/examples/typescript/outbound_redis). Please also see this, related, [outbound Redis (using TypeScript) section](./javascript-components#storing-data-in-redis-from-jsts-components).
+You can find a complete TypeScript example for using outbound Redis from an HTTP component in the [JavaScript SDK repository on GitHub](https://github.com/fermyon/spin-js-sdk/tree/main/examples/spin-host-apis/spin-redis). Please also see this, related, [outbound Redis (using TypeScript) section](./javascript-components#storing-data-in-redis-from-jsts-components).
 
 {{ blockEnd }}
 

--- a/content/spin/v2/redis-outbound.md
+++ b/content/spin/v2/redis-outbound.md
@@ -8,6 +8,7 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/v2/redis-outb
 ---
 - [Using Redis From Applications](#using-redis-from-applications)
 - [Granting Network Permissions to Components](#granting-network-permissions-to-components)
+  - [Configuration-Based Permissions](#configuration-based-permissions)
 
 Spin provides an interface for you to read and write the Redis key/value store, and to publish Redis pub-sub messages.
 
@@ -90,25 +91,23 @@ You can find a complete Rust code example for using outbound Redis from an HTTP 
 
 > [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/)
 
-Redis functions are available on [the `Redis` object](https://fermyon.github.io/spin-js-sdk/variables/Redis.html). The function names match the operations above, but you must pass the Redis instance address to _each_ operation as its first parameter. For example:
+Redis functions are available on [the `Redis` module](https://fermyon.github.io/spin-js-sdk/variables/Redis.html). The function names match the operations above. For example:
 
 ```javascript
-import {Redis} from "@fermyon/spin-sdk"
+import { Redis } from "@fermyon/spin-sdk"
 
-const value = Redis.get(address, key);
+let db = Redis.open("redis://localhost:6379")
+const value = db.get(key);
 ```
 
 **General Notes**
-
-* The `spinSdk` object is always available at runtime. Code checking and completion are available in TypeScript at design time if the module imports anything from the `@fermyon/spin-sdk` package.
-* Address and key parameters are strings.
-* Bytes parameters and return values are buffers (TypeScript `ArrayBuffer`).
+* key parameters are strings.
+* Bytes parameters and return values are buffers (TypeScript `Uint8Array`).
 * Lists are passed and returned as arrays.
-* If a Spin SDK function fails, it throws an [Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error).
 
 **`execute` Operation**
 
-* The arguments and results can be either numbers or buffers. (In TypeScript they are union types, e.g. `BigInt | ArrayBuffer`.)
+* The arguments and results can be either numbers or buffers. (In TypeScript they are union types, e.g. `BigInt | Uint8Array`.)
 
 You can find a complete TypeScript example for using outbound Redis from an HTTP component in the [JavaScript SDK repository on GitHub](https://github.com/fermyon/spin-js-sdk/tree/main/examples/typescript/outbound_redis). Please also see this, related, [outbound Redis (using TypeScript) section](./javascript-components#storing-data-in-redis-from-jsts-components).
 

--- a/content/spin/v2/serverless-ai-api-guide.md
+++ b/content/spin/v2/serverless-ai-api-guide.md
@@ -112,22 +112,20 @@ The `infer_with_options` examples, operation:
 
 {{ startTab "Typescript"}}
 
-> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/variables/Llm.html)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/modules/Llm.html)
 
-To use Serverless AI functions, [the `Llm` module](https://fermyon.github.io/spin-js-sdk/variables/Llm.html) from the Spin SDK provides two methods: `infer` and `generateEmbeddings`. For example: 
+To use Serverless AI functions, [the `Llm` module](https://fermyon.github.io/spin-js-sdk/modules/Llm.html) from the Spin SDK provides two methods: `infer` and `generateEmbeddings`. For example: 
 
 ```javascript
-import { EmbeddingModels, HandleRequest, HttpRequest, HttpResponse, InferencingModels, Llm} from "@fermyon/spin-sdk"
+import { ResponseBuilder, Llm} from "@fermyon/spin-sdk"
 
-export const handleRequest: HandleRequest = async function (request: HttpRequest): Promise<HttpResponse> {
-    let embeddings = Llm.generateEmbeddings(EmbeddingModels.AllMiniLmL6V2, ["someString"])
+export async function handler(req: Request, res: ResponseBuilder) {
+    let embeddings = Llm.generateEmbeddings(Llm.EmbeddingModels.AllMiniLmL6V2, ["someString"])
     console.log(embeddings.embeddings)
-    let result = Llm.infer(InferencingModels.Llama2Chat, prompt)
-    return {
-        status: 200,
-        headers: {"content-type":"text/plain"},
-        body: result.text
-    }
+    let result = Llm.infer(Llm.InferencingModels.Llama2Chat, prompt)
+
+    res.set({"content-type":"text/plain"})
+    res.send(result.text)
 }
 ```
 
@@ -136,15 +134,15 @@ export const handleRequest: HandleRequest = async function (request: HttpRequest
 `infer` operation:
 
 - It takes in the following arguments - model name, prompt and a optional third parameter for inferencing options. 
-- The model name is a string. There are enums for the inbuilt models (llama2-chat and codellama) in [`InferencingModels`](https://fermyon.github.io/spin-js-sdk/enums/InferencingModels.html).
-- The optional third parameter which is an [InferencingOptions](https://fermyon.github.io/spin-js-sdk/interfaces/InferencingOptions.html) interface allows you to specify parameters such as `maxTokens`, `repeatPenalty`, `repeatPenaltyLastNTokenCount`, `temperature`, `topK`, `topP`.  
-- The return value is an [`InferenceResult`](https://fermyon.github.io/spin-js-sdk/interfaces/_internal_.InferenceResult.html).
+- The model name is a string. There are enums for the inbuilt models (llama2-chat and codellama) in [`InferencingModels`](https://fermyon.github.io/spin-js-sdk/enums/Llm.InferencingModels.html).
+- The optional third parameter which is an [InferencingOptions](https://fermyon.github.io/spin-js-sdk/interfaces/Llm.InferencingOptions.html) interface allows you to specify parameters such as `maxTokens`, `repeatPenalty`, `repeatPenaltyLastNTokenCount`, `temperature`, `topK`, `topP`.  
+- The return value is an [`InferenceResult`](https://fermyon.github.io/spin-js-sdk/interfaces/Llm.EmbeddingResult.html).
 
 `generateEmbeddings` operation:
 
 - It takes two arguments - model name and list of strings to generate the embeddings for. 
-- The model name is a string. There are enums for the inbuilt models (AllMiniLmL6V2) in [`EmbeddingModels`](https://fermyon.github.io/spin-js-sdk/enums/EmbeddingModels.html).
-- The return value is an [`EmbeddingResult`](https://fermyon.github.io/spin-js-sdk/interfaces/_internal_.EmbeddingResult.html)
+- The model name is a string. There are enums for the inbuilt models (AllMiniLmL6V2) in [`EmbeddingModels`](https://fermyon.github.io/spin-js-sdk/enums/Llm.EmbeddingModels.html).
+- The return value is an [`EmbeddingResult`](https://fermyon.github.io/spin-js-sdk/interfaces/Llm.EmbeddingResult.html)
 
 {{ blockEnd }}
 

--- a/content/spin/v2/sqlite-api-guide.md
+++ b/content/spin/v2/sqlite-api-guide.md
@@ -120,24 +120,24 @@ struct ToDo {
 
 {{ startTab "Typescript"}}
 
-> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/variables/Sqlite.html)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/modules/Sqlite.html)
 
-To use SQLite functions, use [the `Sqlite.open` or `Sqlite.openDefault` function](https://fermyon.github.io/spin-js-sdk/variables/Sqlite.html) to obtain [a `SqliteStore` object](https://fermyon.github.io/spin-js-sdk/interfaces/_internal_.SqliteStore.html). `SqliteStore` provides the `execute` method as described above. For example:
+To use SQLite functions, use [the `Sqlite.open` or `Sqlite.openDefault` function](https://fermyon.github.io/spin-js-sdk/modules/Sqlite.html) to obtain [a `SqliteConnection` object](https://fermyon.github.io/spin-js-sdk/interfaces/Sqlite.SqliteConnection.html). `SqliteConnection` provides the `execute` method as described above. For example:
 
 ```javascript
-import {Sqlite} from "@fermyon/spin-sdk"
+import { ResponseBuilder, Sqlite } from "@fermyon/spin-sdk";
 
-const conn = Sqlite.openDefault();
-const result = conn.execute("SELECT * FROM todos WHERE id > (?);", [1]);
-const json = JSON.stringify(result.rows);
+export async function handler(req: Request, res: ResponseBuilder) {
+    let conn = Sqlite.openDefault();
+    let result = conn.execute("SELECT * FROM todos WHERE id > (?);", [1]);
+
+    res.send(JSON.stringify(result));
+}
 ```
 
 **General Notes**
-* The `spinSdk` object is always available at runtime. Code checking and completion are available in TypeScript at design time if the module imports anything from the `@fermyon/spin-sdk` package.
-* Parameters are JavaScript values (numbers, strings, byte arrays, or nulls). Spin infers the underlying SQL type.
-* The `execute` function returns an object with `rows` and `columns` properties. `columns` is an array of strings representing column names. `rows` is an array of rows, each of which is an array of JavaScript values (as above) in the same order as `columns`.
-* The `SqliteStore` object doesn't surface the `close` function.
-* If a Spin SDK function fails, it throws an [Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error).
+* The `execute` function returns an object with `rows` and `columns` properties. `columns` is an array of strings representing column names. `rows` is an array of rows, each of which is an object containing Javascript Values keyed using the column names.
+* The `SqliteConnection` object doesn't surface the `close` function.
 
 {{ blockEnd }}
 

--- a/content/spin/v2/sqlite-api-guide.md
+++ b/content/spin/v2/sqlite-api-guide.md
@@ -136,7 +136,7 @@ export async function handler(req: Request, res: ResponseBuilder) {
 ```
 
 **General Notes**
-* The `execute` function returns an object with `rows` and `columns` properties. `columns` is an array of strings representing column names. `rows` is an array of rows, each of which is an object containing Javascript Values keyed using the column names.
+* The `execute` function returns an object with `rows` and `columns` properties. `columns` is an array of strings representing column names. `rows` is an array of rows, each of which is an object containing Javascript values keyed using the column names.
 * The `SqliteConnection` object doesn't surface the `close` function.
 
 {{ blockEnd }}

--- a/content/spin/v2/variables.md
+++ b/content/spin/v2/variables.md
@@ -117,29 +117,22 @@ fn handle_spin_example(req: Request) -> Result<impl IntoResponse> {
 
 {{ startTab "TypeScript"}}
 
-> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/variables/Config.html)
-
-> Note that the name is `Config` rather than `Variables`.
+> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/modules/Variables.html)
 
 ```ts
-import { HandleRequest, HttpRequest, HttpResponse, Config } from "@fermyon/spin-sdk"
+import { ResponseBuilder, Variables } from "@fermyon/spin-sdk";
 
-const decoder = new TextDecoder("utf-8")
-
-export const handleRequest: HandleRequest = async function (request: HttpRequest): Promise<HttpResponse> {
-  const expected = decoder.decode(request.body)
-  let password = Config.get("password")
+export async function handler(req: Request, res: ResponseBuilder) {
+  const expected = await req.text()
+  let password = Variables.get("password")
   let access = "denied"
   if (expected === password) {
       access = "accepted"
   }
   let responseJson = `{\"authentication\": \"${access}\"}`;
 
-  return {
-    status: 200,
-    headers: { "Content-Type": "application/json" },
-    body: responseJson
-  }
+  res.set({ "Content-Type": "application/json" })
+  res.send(responseJson)
 }
 ```
 


### PR DESCRIPTION
This PR updates the documentation to be based on the upcoming release of the v2 of the JS SDK.

Todo:
- [ ] Check the links once the new docs are up and SDK is moved to `main`.
- [ ] update `serverless-ai-hello-world` once the example repo is updated. 