### PR TITLE
Update variables documentation with latest APIs and better example

### DIFF
--- a/content/spin/v2/variables.md
+++ b/content/spin/v2/variables.md
@@ -11,7 +11,7 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/v2/variables.
 
 Spin supports dynamic application variables. Instead of being static, their values can be updated without modifying the application, creating a simpler experience for rotating secrets, updating API endpoints, and more. 
 
-These variables are defined in a Spin application manifest (in the `[variables]` section), and their values can be set or overridden at runtime by an [application variables provider](./dynamic-configuration.md#application-variables-runtime-configuration). When running Spin locally, the variables provider can be [Hashicorp Vault](./dynamic-configuration.md#vault-application-variable-provider) for secrets, [Azure Key Vault](https://azure.microsoft.com/en-us/products/key-vault), or host environment variables.
+These variables are defined in a Spin application manifest (in the `[variables]` section), and their values can be set or overridden at runtime by an [application variables provider](./dynamic-configuration.md#application-variables-runtime-configuration). When running Spin locally, the variables provider can be [Hashicorp Vault](./dynamic-configuration.md#vault-application-variable-provider) for secrets, or host environment variables.
 
 For information about configuring application variables providers, refer to the [dynamic configuration documentation](./dynamic-configuration.md#application-variables-runtime-configuration).
 
@@ -19,29 +19,39 @@ For information about configuring application variables providers, refer to the 
 
 Variables are added to an application under the top-level `[variables]` section of an application manifest (`spin.toml`). Each entry must either have a default value or be marked as `required = true`. “Required” entries must be [provided](./dynamic-configuration#application-variables-runtime-configuration) with a value.
 
-For example, say an application needs to access a secret. A `[variables]` section could be added to an application's manifest with one entry for a variable named `secret`. Since there is no reasonable default value for a secret, the variable is set as required with `required = true`:
+For example, say an application needs to access a bearer token for an outbound API call. A `[variables]` section could be added to an application's manifest with one entry for a variable named `token`. Since there is no reasonable default value for a secret, the variable is set as required with `required = true`. On the other hand, say the the API endpoint is known but should be configurable for A/B testing, another v`api_uri` variable could be added with a default that can be overridden. This scenario could be configured in the application manifest as follows:
 
 <!-- @nocpy -->
 
 ```toml
-# Add this above the [component.<id>] section
 [variables]
-secret = { required = true }
+api_token = { required = true }
+api_uri = { default = "http://my-api.com" }
 ```
 
-Variables are surfaced to a specific component by adding a `[component.(name).variables]` section to the component and referencing them within it. The `[component.(name).variables]` section contains a mapping of component variables and values. Entries can be static (like `api_host` below) or reference an updatable application variable (like `password` below) using [mustache](https://mustache.github.io/)-inspired string templates. Only components that explicitly use variables in their configuration section will get access to them. This enables only exposing variables (such as secrets) to the desired components of an application.
+Variables are surfaced to a specific component by adding a `[component.(name).variables]` section to the component and referencing them within it. The `[component.(name).variables]` section contains a mapping of component variables and values. Entries can be static (like `api_version` below) or reference an updatable application variable (like `token` below) using [mustache](https://mustache.github.io/)-inspired string templates. Only components that explicitly use variables in their configuration section will get access to them. This enables only exposing variables (such as secrets) to the desired components of an application.
 
 <!-- @nocpy -->
 
 ```toml
-[component.cart.variables]
-password = "\{{ secret }}"
-api_host = "https://my-api.com"
+[component.(name).variables]
+token = "\{{ api_token }}"
+api_uri = "\{{ api_uri }}"
+api_version = "v1"
 ```
 
-When a component variable references an application variable, its value will dynamically update as the application variable changes. For example, if the `secret` variable is provided using the [Spin Vault provider](./dynamic-configuration.md#vault-application-variable-provider), it can be updated by changing the value in HashiCorp Vault. The next time the component gets the value of `password`, the latest value of `secret` will be returned by the provider. See the [next section](#using-variables-from-applications) to learn how to use Spin's configuration SDKs to get configuration variables within applications.
+Variables can also be surfaced to other sections of the application manifest that benefit from dynamic configuration. For example, the `allowed_outbound_hosts` can be dynamically configured using variables as follows:
 
-An application manifest with a `secret` variable and a component that uses it would look similar to the following:
+<!-- @nocpy -->
+
+```toml
+[component.(name)]
+allowed_outbound_hosts = [ "\{{ api_uri }}" ]
+```
+
+When a component variable references an application variable, its value will dynamically update as the application variable changes. For example, if the `api_token` variable is provided using the [Spin Vault provider](./dynamic-configuration.md#vault-application-variable-provider), it can be updated by changing the value in HashiCorp Vault. The next time the component gets the value of `token`, the latest value of `api_token` will be returned by the provider. See the [next section](#using-variables-from-applications) to learn how to use Spin's configuration SDKs to get configuration variables within applications.
+
+An application manifest with a `api_token` variable and a component that uses it would look similar to the following:
 
 <!-- @nocpy -->
 
@@ -49,22 +59,24 @@ An application manifest with a `secret` variable and a component that uses it wo
 spin_manifest_version = 2
 
 [application]
-name = "password-checker"
+name = "api-consumer"
 version = "0.1.0"
-description = "A Spin app with a dynamically updatable secret"
+description = "A Spin app that makes API requests"
 
 [variables]
-secret = { required = true }
+api_token = { required = true }
+api_uri = { default = "http://my-api.com" }
 
 [[trigger.http]]
 route = "/..."
-component = "password-checker"
+component = "api-consumer"
 
-[component.password-checker]
+[component.api-consumer]
 source = "app.wasm"
-[component.password-checker.variables]
-password = "\{{ secret }}"
-api_host = "https://my-api.com"
+[component.api-consumer.variables]
+token = "\{{ api_token }}"
+api_uri = "\{{ api_uri }}
+api_version = "v1"
 ```
 
 ## Using Variables From Applications
@@ -75,7 +87,7 @@ The Spin SDK surfaces the Spin configuration interface to your language. The [in
 |------------|--------------------|---------------------|----------|
 | `get`      | Variable name      | Variable value      | Gets the value of the variable from the configured provider |
 
-To illustrate the variables API, each of the following examples receives a password via the HTTP request body, compares it to the value stored in the application variable, and returns a JSON response indicating whether the submitted password matched or not. The application manifest associated with the examples would look similar to the one described [in the previous section](#adding-variables-to-your-applications). 
+To illustrate the variables API, each of the following examples makes a request to some API with a bearer token. The API URI, version, and token are all passed as application variables. The application manifest associated with the examples would look similar to the one described [in the previous section](#adding-variables-to-your-applications). 
 
 The exact details of calling the config SDK from a Spin application depends on the language:
 
@@ -88,27 +100,26 @@ The exact details of calling the config SDK from a Spin application depends on t
 The interface is available in the `spin_sdk::variables` module and is named `get`.
 
 ```rust
-use anyhow::Result;
 use spin_sdk::{
-    http::{IntoResponse, Request, Response},
-    http_component,
-    variables,
+    http::{IntoResponse, Method, Request, Response},
+    http_component, variables,
 };
 
 #[http_component]
-fn handle_spin_example(req: Request) -> Result<impl IntoResponse> {
-    let password = std::str::from_utf8(req.body().as_ref()).unwrap();
-    let expected = variables::get("password").expect("could not get variable");
-    let response = if expected == password {
-        "accepted"
-    } else {
-        "denied"
-    };
-    let response_json = format!("\{{\"authentication\": \"{}\"}}", response);
+async fn handle_api_call_with_token(_req: Request) -> anyhow::Result<impl IntoResponse> {
+    let token = variables::get("token")?;
+    let api_uri = variables::get("api_uri")?;
+    let version = variables::get("version")?;
+    let versioned_api_uri = format!("{}/{}", api_uri, version);
+    let request = Request::builder()
+        .method(Method::Get)
+        .uri(versioned_api_uri)
+        .header("Authorization", format!("Bearer {}", token))
+        .build();
+    let response: Response = spin_sdk::http::send(request).await?;
+    // Do something with the response ...
     Ok(Response::builder()
         .status(200)
-        .header("content-type", "application/json")
-        .body(response_json)
         .build())
 }
 ```
@@ -123,16 +134,21 @@ fn handle_spin_example(req: Request) -> Result<impl IntoResponse> {
 import { ResponseBuilder, Variables } from "@fermyon/spin-sdk";
 
 export async function handler(req: Request, res: ResponseBuilder) {
-  const expected = await req.text()
-  let password = Variables.get("password")
-  let access = "denied"
-  if (expected === password) {
-      access = "accepted"
-  }
-  let responseJson = `{\"authentication\": \"${access}\"}`;
-
-  res.set({ "Content-Type": "application/json" })
-  res.send(responseJson)
+  let token = Variables.get("token")
+  let apiUri = Variables.get("api_uri")
+  let version = Variables.get("version")
+  let versionedAPIUri = `${apiUri}/${version}`
+  let response = await fetch(
+    versionedAPIUri,
+    {
+      headers: {
+        'Authorization': 'Bearer ' + token
+      }
+    }
+  );
+  // Do something with the response ...
+  res.set({ "Content-Type": "text/plain" })
+  res.send("Used an API")
 }
 ```
 
@@ -142,22 +158,28 @@ export async function handler(req: Request, res: ResponseBuilder) {
 
 > [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-python-sdk/variables.html)
 
-The `variables` module has a function called `get`(https://fermyon.github.io/spin-python-sdk/variables.get).
+The `variables` module has a function called `get`(https://fermyon.github.io/spin-python-sdk/variables.html#spin_sdk.variables.get).
 
 ```py
-from spin_http import Response
-from spin_config import config_get
+from spin_sdk.http import IncomingHandler, Request, Response, send
+from spin_sdk import variables
 
-def handle_request(request):
-    password = request.body.decode("utf-8")
-    expected = config_get("password")
-    access = "denied"
-    if expected == password:
-        access = "accepted"
-    response = f'\{{"authentication": "{access}"}}'
-    return Response(200,
-                    {"content-type": "application/json"},
-                    bytes(response, "utf-8"))
+class IncomingHandler(IncomingHandler):
+    def handle_request(self, request: Request) -> Response:
+        token = variables.get("token")
+        api_uri = variables.get("api_uri")
+        version = variables.get("version")
+        versioned_api_uri = f"{api_uri}/{version}"
+        headers = {
+            "Authorization": f"Bearer {token}"
+        }
+        response = send(Request("GET", versioned_api_uri, headers, None))
+        # Do something with the response ...
+        return Response(
+            200,
+            {"content-type": "text/plain"},
+            bytes("Used an API", "utf-8")
+        )
 ```
 
 {{ blockEnd }}
@@ -170,31 +192,43 @@ The function is available in the `github.com/fermyon/spin/sdk/go/v2/variables` p
 
 ```go
 import (
+	"bytes"
 	"fmt"
-	"io"
 	"net/http"
 
-	"github.com/fermyon/spin/sdk/go/v2/variables"
 	spinhttp "github.com/fermyon/spin/sdk/go/v2/http"
+	"github.com/fermyon/spin/sdk/go/v2/variables"
 )
 
-spinhttp.Handle(func(w http.ResponseWriter, r *http.Request) {
-    access := "denied"
-    password, err := io.ReadAll(r.Body)
-    if err == nil {
-        expected, err := variables.Get("password")
-        if err != nil {
-            http.Error(w, err.Error(), http.StatusInternalServerError)
-            return
-        }
-        if expected == string(password) {
-            access = "accepted"
-        }
-    }
-    response := fmt.Sprintf("{\"authentication\": \"%s\"}", access)
-    w.Header().Set("Content-Type", "application/json")
-    fmt.Fprintln(w, response)
-})
+func init() {
+	spinhttp.Handle(func(w http.ResponseWriter, r *http.Request) {
+		token, err := variables.Get("token")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		apiUri, err := variables.Get("api_uri")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		version, err := variables.Get("version")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		versionedApiUri := fmt.Sprintf("%s/%s", apiUri, version)
+
+		request, err := http.NewRequest("GET", versionedApiUri, bytes.NewBuffer([]byte("")))
+		request.Header.Add("Authorization", "Bearer "+token)
+		response, err := spinhttp.Send(request)
+		// Do something with the response ...
+		w.Header().Set("Content-Type", "text/plain")
+		fmt.Fprintln(w, "Used an API")
+	})
+}
+
+func main() {}
 ```
 
 {{ blockEnd }}
@@ -208,22 +242,22 @@ To build and run the application, we issue the following commands:
 ```bash
 # Build the application
 $ spin build
-# Export the value of the secret, using the `SPIN_VARIABLE` prefix (upper case is necessary as shown here)
-$ export SPIN_VARIABLE_SECRET="your-password-here"
-# Run the application
-$ spin up
+# Run the application, setting the values of the API token and URI via the environment variable provider
+# using the `SPIN_VARIABLE` prefix (upper case is necessary as shown here)
+$ SPIN_VARIABLE_API_TOKEN="your-token-here" SPIN_VARIABLE_API_URI="http://my-best-api.com spin up
 ```
 
-To test the application, we use pass in the password in the body of the request:
+Assuming you have configured you application to use an API, to test the application, simply query
+the app endpoint:
 
 <!-- @selectiveCpy -->
 
 ```bash
-$ curl -i localhost:3000 -d "your-password-here"  
+$ curl -i localhost:3000
 HTTP/1.1 200 OK
-content-type: application/json
-content-length: 30
-date: Tue, 07 May 2024 02:33:10 GMT
+content-type: text/plain
+content-length: 11
+date: Wed, 31 Jul 2024 22:03:35 GMT
 
-{"authentication": "accepted"}
+Used an API
 ```


### PR DESCRIPTION
Our variables example showed a bad example of checking passwords -- it does not at minimum do a constant time comparison. While it is an example, we cannot assume that folks will not use it. Instead, this updates the example to be a more realistic one that calls an API with a token. 

This also updates the examples to use the latest SDKs -- Python was out of date -- and talks about templating within the manifest.

I've run all examples locally -- here is a repo with the examples for if we need to test them for future sdk changes: https://github.com/kate-goldenring/spin-variables-examples
## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title`, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep $'\r' | wc -l` and expect 0 as a result)
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
