### PR TITLE
Update docs for Spin v2.7 version bump

### DIFF
--- a/content/spin/v2/cli-reference.md
+++ b/content/spin/v2/cli-reference.md
@@ -281,6 +281,48 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v2.7"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin add --help
+spin-add 
+Scaffold a new component into an existing application
+
+USAGE:
+    spin add [OPTIONS] [NAME]
+
+ARGS:
+    <NAME>    The name of the new application or component
+
+OPTIONS:
+    -a, --accept-defaults              An optional argument that allows to skip prompts for the
+                                       manifest file by accepting the defaults if available on the
+                                       template
+        --allow-overwrite              If the output directory already contains files, generate the
+                                       new files into it without confirming, overwriting any
+                                       existing files with the same names
+    -f, --file <APP_MANIFEST_FILE>     Path to spin.toml
+    -h, --help                         Print help information
+        --init                         Create the new application or component in the current
+                                       directory
+        --no-vcs                       An optional argument that allows to skip creating .gitignore
+    -o, --output <OUTPUT_PATH>         The directory in which to create the new application or
+                                       component. The default is the name argument
+    -t, --template <TEMPLATE_ID>       The template from which to create the new application or
+                                       component. Run `spin templates list` to see available options
+        --tag <TAGS>                   Filter templates to select by tags
+    -v, --value <VALUES>               Parameter values to be passed to the template (in name=value
+                                       format)
+        --values-file <VALUES_FILE>    A TOML file which contains parameter values in name = "value"
+                                       format. Parameters passed as CLI option overwrite parameters
+                                       specified in the file
+```
+
+{{ blockEnd }}
+
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -486,6 +528,40 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v2.7"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin build --help
+spin-build 
+Build the Spin application
+
+USAGE:
+    spin build [OPTIONS] [--] [UP_ARGS]...
+
+ARGS:
+    <UP_ARGS>...    
+
+OPTIONS:
+    -c, --component-id <COMPONENT_ID>...
+            Component ID to build. This can be specified multiple times. The default is all
+            components
+
+    -f, --from <APP_MANIFEST_FILE>
+            The application to build. This may be a manifest (spin.toml) file, or a directory
+            containing a spin.toml file. If omitted, it defaults to "spin.toml" [default: spin.toml]
+
+    -h, --help
+            Print help information
+
+    -u, --up
+            Run the application after building
+```
+
+{{ blockEnd }}
+
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -528,6 +604,13 @@ The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](/cloud/clo
 The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference).
 
 {{ blockEnd }}
+
+{{ startTab "v2.7"}}
+
+The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference).
+
+{{ blockEnd }}
+
 
 {{ blockEnd }}
 
@@ -572,6 +655,13 @@ The `spin cloud apps` command is implemented by the [Fermyon Cloud Plugin](/clou
 
 {{ blockEnd }}
 
+{{ startTab "v2.7"}}
+
+The `spin cloud apps` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-apps).
+
+{{ blockEnd }}
+
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -614,6 +704,13 @@ The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](/cl
 The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-deploy).
 
 {{ blockEnd }}
+
+{{ startTab "v2.7"}}
+
+The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-deploy).
+
+{{ blockEnd }}
+
 
 {{ blockEnd }}
 
@@ -658,6 +755,13 @@ The `spin cloud link` command is implemented by the [Fermyon Cloud Plugin](/clou
 
 {{ blockEnd }}
 
+{{ startTab "v2.7"}}
+
+The `spin cloud link` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-link).
+
+{{ blockEnd }}
+
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -700,6 +804,13 @@ The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](/clo
 The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-login).
 
 {{ blockEnd }}
+
+{{ startTab "v2.7"}}
+
+The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-login).
+
+{{ blockEnd }}
+
 
 {{ blockEnd }}
 
@@ -744,6 +855,13 @@ The `spin cloud sqlite` command is implemented by the [Fermyon Cloud Plugin](/cl
 
 {{ blockEnd }}
 
+{{ startTab "v2.7"}}
+
+The `spin cloud sqlite` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-sqlite).
+
+{{ blockEnd }}
+
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -787,6 +905,13 @@ The `spin cloud unlink` command is implemented by the [Fermyon Cloud Plugin](/cl
 
 {{ blockEnd }}
 
+{{ startTab "v2.7"}}
+
+The `spin cloud unlink` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-unlink).
+
+{{ blockEnd }}
+
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -829,6 +954,13 @@ The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](
 The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-variables).
 
 {{ blockEnd }}
+
+{{ startTab "v2.7"}}
+
+The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-variables).
+
+{{ blockEnd }}
+
 
 {{ blockEnd }}
 
@@ -974,6 +1106,29 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v2.7"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin doctor --help
+
+spin-doctor 
+Detect and fix problems with Spin applications
+
+USAGE:
+    spin doctor [OPTIONS]
+
+OPTIONS:
+    -f, --from <APP_MANIFEST_FILE>    The application to check. This may be a manifest (spin.toml)
+                                      file, or a directory containing a spin.toml file. If omitted,
+                                      it defaults to "spin.toml" [default: spin.toml]
+    -h, --help                        Print help information
+```
+
+{{ blockEnd }}
+
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -1017,6 +1172,13 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v2.7"}}
+
+> Please note: Spin `help` is a convenient way to access help using a subcommand, instead of using the `--help` option. For example, `spin help cloud` will give you the same output as `spin cloud --help`. Similarly, `spin help build` will give you the same output as `spin build --help` and so forth.
+
+{{ blockEnd }}
+
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -1035,6 +1197,13 @@ The `spin kube` command is implemented by the [`spin-kube` plugin](https://www.s
 The `spin kube` command is implemented by the [`spin-kube` plugin](https://www.spinkube.dev/docs/reference/cli-reference/).
 
 {{ blockEnd }}
+
+{{ startTab "v2.7"}}
+
+The `spin kube` command is implemented by the [`spin-kube` plugin](https://www.spinkube.dev/docs/reference/cli-reference/).
+
+{{ blockEnd }}
+
 
 {{ blockEnd }}
 
@@ -1055,6 +1224,13 @@ The `spin kube completion` command is implemented by the [`spin-kube` plugin](ht
 
 {{ blockEnd }}
 
+{{ startTab "v2.7"}}
+
+The `spin kube completion` command is implemented by the [`spin-kube` plugin](https://www.spinkube.dev/docs/reference/cli-reference/#spin-kube-completion).
+
+{{ blockEnd }}
+
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -1073,6 +1249,13 @@ The `spin kube scaffold` command is implemented by the [`spin-kube` plugin](http
 The `spin kube scaffold` command is implemented by the [`spin-kube` plugin](https://www.spinkube.dev/docs/reference/cli-reference/#spin-kube-scaffold).
 
 {{ blockEnd }}
+
+{{ startTab "v2.7"}}
+
+The `spin kube scaffold` command is implemented by the [`spin-kube` plugin](https://www.spinkube.dev/docs/reference/cli-reference/#spin-kube-scaffold).
+
+{{ blockEnd }}
+
 
 {{ blockEnd }}
 
@@ -1311,6 +1494,48 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v2.7"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin new --help  
+
+spin-new 
+Scaffold a new application based on a template
+
+USAGE:
+    spin new [OPTIONS] [NAME]
+
+ARGS:
+    <NAME>    The name of the new application or component
+
+OPTIONS:
+    -a, --accept-defaults              An optional argument that allows to skip prompts for the
+                                       manifest file by accepting the defaults if available on the
+                                       template
+        --allow-overwrite              If the output directory already contains files, generate the
+                                       new files into it without confirming, overwriting any
+                                       existing files with the same names
+    -h, --help                         Print help information
+        --init                         Create the new application or component in the current
+                                       directory
+        --no-vcs                       An optional argument that allows to skip creating .gitignore
+    -o, --output <OUTPUT_PATH>         The directory in which to create the new application or
+                                       component. The default is the name argument
+    -t, --template <TEMPLATE_ID>       The template from which to create the new application or
+                                       component. Run `spin templates list` to see available options
+        --tag <TAGS>                   Filter templates to select by tags
+    -v, --value <VALUES>               Parameter values to be passed to the template (in name=value
+                                       format)
+        --values-file <VALUES_FILE>    A TOML file which contains parameter values in name = "value"
+                                       format. Parameters passed as CLI option overwrite parameters
+                                       specified in the file
+```
+
+{{ blockEnd }}
+
+
 {{ blockEnd }}
 
 **Please note: `spin new` vs `spin add`**.  These commands are similar except that:
@@ -1490,6 +1715,35 @@ SUBCOMMANDS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.7"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins --help
+
+spin-plugins 
+Install/uninstall Spin plugins
+
+USAGE:
+    spin plugins <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    help         Print this message or the help of the given subcommand(s)
+    install      Install plugin from a manifest
+    list         List available or installed plugins
+    search       Search for plugins by name
+    uninstall    Remove a plugin from your installation
+    update       Fetch the latest Spin plugins from the spin-plugins repository
+    upgrade      Upgrade one or all plugins
+```
+
+{{ blockEnd }}
+
 
 {{ blockEnd }}
 
@@ -1744,6 +1998,48 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v2.7"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins install --help
+
+spin-plugins-install 
+Install plugin from a manifest.
+
+The binary file and manifest of the plugin is copied to the local Spin plugins directory.
+
+USAGE:
+    spin plugins install [OPTIONS] [PLUGIN_NAME]
+
+ARGS:
+    <PLUGIN_NAME>
+            Name of Spin plugin
+
+OPTIONS:
+    -f, --file <LOCAL_PLUGIN_MANIFEST>
+            Path to local plugin manifest
+
+    -h, --help
+            Print help information
+
+        --override-compatibility-check
+            Overrides a failed compatibility check of the plugin with the current version of Spin
+
+    -u, --url <REMOTE_PLUGIN_MANIFEST>
+            URL of remote plugin manifest to install
+
+    -v, --version <VERSION>
+            Specific version of a plugin to be install from the centralized plugins repository
+
+    -y, --yes
+            Skips prompt to accept the installation of the plugin
+```
+
+{{ blockEnd }}
+
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -1877,6 +2173,29 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v2.7"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins list --help   
+
+spin-plugins-list 
+List available or installed plugins
+
+USAGE:
+    spin plugins list [OPTIONS]
+
+OPTIONS:
+        --all                List all versions of plugins. This is the default behaviour
+        --filter <FILTER>    Filter the list to plugins containing this string
+    -h, --help               Print help information
+        --installed          List only installed plugins
+        --summary            List latest and installed versions of plugins
+```
+{{ blockEnd }}
+
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -2009,6 +2328,28 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.7"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins search --help
+spin-plugins-search 
+Search for plugins by name
+
+USAGE:
+    spin plugins search [FILTER]
+
+ARGS:
+    <FILTER>    The text to search for. If omitted, all plugins are returned
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+{{ blockEnd }}
+
 
 {{ blockEnd }}
 
@@ -2149,6 +2490,29 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v2.7"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins uninstall --help
+
+spin-plugins-uninstall 
+Remove a plugin from your installation
+
+USAGE:
+    spin plugins uninstall <NAME>
+
+ARGS:
+    <NAME>    Name of Spin plugin
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+{{ blockEnd }}
+
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -2269,6 +2633,26 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.7"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins update --help
+
+spin-plugins-update 
+Fetch the latest Spin plugins from the spin-plugins repository
+
+USAGE:
+    spin plugins update
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+{{ blockEnd }}
+
 
 {{ blockEnd }}
 
@@ -2541,6 +2925,51 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v2.7"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin plugins upgrade --help
+
+spin-plugins-upgrade 
+Upgrade one or all plugins
+
+USAGE:
+    spin plugins upgrade [OPTIONS] [PLUGIN_NAME]
+
+ARGS:
+    <PLUGIN_NAME>    Name of Spin plugin to upgrade
+
+OPTIONS:
+    -a, --all
+            Upgrade all plugins
+
+    -d, --downgrade
+            Allow downgrading a plugin's version
+
+    -f, --file <LOCAL_PLUGIN_MANIFEST>
+            Path to local plugin manifest
+
+    -h, --help
+            Print help information
+
+        --override-compatibility-check
+            Overrides a failed compatibility check of the plugin with the current version of Spin
+
+    -u, --url <REMOTE_PLUGIN_MANIFEST>
+            Path to remote plugin manifest
+
+    -v, --version <VERSION>
+            Specific version of a plugin to be install from the centralized plugins repository
+
+    -y, --yes
+            Skips prompt to accept the installation of the plugin[s]
+```
+
+{{ blockEnd }}
+
+
 {{ blockEnd }}
 
 **Note:** For additional information, please see the [Managing Plugins](/spin/managing-plugins) and/or [Creating Plugins](/spin/plugin-authoring) sections of the documentation.
@@ -2693,6 +3122,31 @@ SUBCOMMANDS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.7"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry --help
+spin-registry 
+Commands for working with OCI registries to distribute applications
+
+USAGE:
+    spin registry <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    help     Print this message or the help of the given subcommand(s)
+    login    Log in to a registry
+    pull     Pull a Spin application from a registry
+    push     Push a Spin application to a registry
+```
+
+{{ blockEnd }}
+
 
 {{ blockEnd }}
 
@@ -2850,6 +3304,32 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.7"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry login --help
+
+spin-registry-login 
+Log in to a registry
+
+USAGE:
+    spin registry login [OPTIONS] <SERVER>
+
+ARGS:
+    <SERVER>    OCI registry server (e.g. ghcr.io)
+
+OPTIONS:
+    -h, --help                   Print help information
+    -p, --password <PASSWORD>    Password for the registry
+        --password-stdin         Take the password from stdin
+    -u, --username <USERNAME>    Username for the registry
+```
+
+{{ blockEnd }}
+
 
 {{ blockEnd }}
 
@@ -3012,6 +3492,34 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.7"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry pull --help
+
+spin-registry-pull 
+Pull a Spin application from a registry
+
+USAGE:
+    spin registry pull [OPTIONS] <REFERENCE>
+
+ARGS:
+    <REFERENCE>    Reference in the registry of the published Spin application. This is a string
+                   whose format is defined by the registry standard, and generally consists of
+                   <registry>/<username>/<application-name>:<version>. E.g.
+                   ghcr.io/ogghead/spin-test-app:0.1.0
+
+OPTIONS:
+        --cache-dir <CACHE_DIR>    Cache directory for downloaded registry data
+    -h, --help                     Print help information
+    -k, --insecure                 Ignore server certificate errors
+```
+
+{{ blockEnd }}
+
 
 {{ blockEnd }}
 
@@ -3211,6 +3719,42 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v2.7"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin registry push --help 
+
+spin-registry-push 
+Push a Spin application to a registry
+
+USAGE:
+    spin registry push [OPTIONS] <REFERENCE>
+
+ARGS:
+    <REFERENCE>    Reference in the registry of the Spin application. This is a string whose
+                   format is defined by the registry standard, and generally consists of
+                   <registry>/<username>/<application-name>:<version>. E.g.
+                   ghcr.io/ogghead/spin-test-app:0.1.0
+
+OPTIONS:
+        --annotation <ANNOTATIONS>    Specifies the OCI image manifest annotations (in key=value
+                                      format). Any existing value will be overwritten. Can be used
+                                      multiple times
+        --build                       Specifies to perform `spin build` before pushing the
+                                      application [env: SPIN_ALWAYS_BUILD=]
+        --cache-dir <CACHE_DIR>       Cache directory for downloaded registry data
+    -f, --from <APP_MANIFEST_FILE>    The application to push. This may be a manifest (spin.toml)
+                                      file, or a directory containing a spin.toml file. If omitted,
+                                      it defaults to "spin.toml" [default: spin.toml]
+    -h, --help                        Print help information
+    -k, --insecure                    Ignore server certificate errors
+```
+
+{{ blockEnd }}
+
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -3399,6 +3943,33 @@ SUBCOMMANDS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.7"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates --help    
+
+spin-templates 
+Commands for working with WebAssembly component templates
+
+USAGE:
+    spin templates <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    help         Print this message or the help of the given subcommand(s)
+    install      Install templates from a Git repository or local directory
+    list         List the installed templates
+    uninstall    Remove a template from your installation
+    upgrade      Upgrade templates to match your current version of Spin
+```
+
+{{ blockEnd }}
+
 
 {{ blockEnd }}
 
@@ -3623,6 +4194,43 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v2.7"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates install --help
+
+spin-templates-install 
+Install templates from a Git repository or local directory.
+
+The files of the templates are copied to the local template store: a directory in your data or home
+directory.
+
+USAGE:
+    spin templates install [OPTIONS]
+
+OPTIONS:
+        --branch <BRANCH>
+            The optional branch of the git repository
+
+        --dir <FROM_DIR>
+            Local directory containing the template(s) to install
+
+        --git <FROM_GIT>
+            The URL of the templates git repository. The templates must be in a git repository in a
+            "templates" directory
+
+    -h, --help
+            Print help information
+
+        --upgrade
+            If present, updates existing templates instead of skipping
+```
+
+{{ blockEnd }}
+
+
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -3755,6 +4363,28 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.7"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates list --help   
+
+spin-templates-list 
+List the installed templates
+
+USAGE:
+    spin templates list [OPTIONS]
+
+OPTIONS:
+    -h, --help          Print help information
+        --tag <TAGS>    Filter templates matching all provided tags
+        --verbose       Whether to show additional template details in the list
+```
+
+{{ blockEnd }}
+
 
 {{ blockEnd }}
 
@@ -3896,6 +4526,29 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.7"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates uninstall --help
+
+spin-templates-uninstall 
+Remove a template from your installation
+
+USAGE:
+    spin templates uninstall <TEMPLATE_ID>
+
+ARGS:
+    <TEMPLATE_ID>    The template to uninstall
+
+OPTIONS:
+    -h, --help    Print help information
+```
+
+{{ blockEnd }}
+
 
 {{ blockEnd }}
 
@@ -4108,6 +4761,41 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v2.7"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin templates upgrade --help
+spin-templates-upgrade 
+Upgrade templates to match your current version of Spin.
+
+The files of the templates are copied to the local template store: a directory in your data or home
+directory.
+
+USAGE:
+    spin templates upgrade [OPTIONS]
+
+OPTIONS:
+        --all
+            By default, Spin displays the list of installed repositories and prompts you to choose
+            which to upgrade.  Pass this flag to upgrade all repositories without prompting
+
+        --branch <BRANCH>
+            The optional branch of the git repository, if a specific repository is given
+
+    -h, --help
+            Print help information
+
+        --repo <GIT_URL>
+            By default, Spin displays the list of installed repositories and prompts you to choose
+            which to upgrade.  Pass this flag to upgrade only the specified repository without
+            prompting
+```
+
+{{ blockEnd }}
+
+
 {{ blockEnd }}
 
 **Note:** For additional information, please see the [Managing Templates](/spin/managing-templates) and/or [Creating Templates](/spin/template-authoring) sections of the documentation.
@@ -4142,8 +4830,6 @@ Options:
 
 {{ blockEnd }}
 
-**Note:** For additional information, please see the [Managing Templates](/spin/managing-templates) and/or [Creating Templates](/spin/template-authoring) sections of the documentation.
-
 {{ startTab "v2.6"}}
 
 <!-- @selectiveCpy -->
@@ -4168,6 +4854,32 @@ Options:
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.7"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin test --help
+
+By default `spin-test` will invoke the `run` subcommand.
+
+Usage: test [COMMAND]
+
+Commands:
+  run   Run a test suite against a Spin application
+  help  Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
+```
+
+{{ blockEnd }}
+
 
 {{ blockEnd }}
 
@@ -4651,6 +5363,87 @@ HTTP TRIGGER OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v2.7"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin up --help
+
+spin-up 
+Start the Spin application
+
+USAGE:
+    spin up [OPTIONS]
+
+OPTIONS:
+        --build                    For local apps, specifies to perform `spin build` before running
+                                   the application [env: SPIN_ALWAYS_BUILD=]
+        --cache-dir <CACHE_DIR>    Cache directory for downloaded components and assets
+        --direct-mounts            For local apps with directory mounts and no excluded files, mount
+                                   them directly instead of using a temporary directory
+    -e, --env <ENV>                Pass an environment variable (key=value) to all components of the
+                                   application
+    -f, --from <APPLICATION>       The application to run. This may be a manifest (spin.toml) file,
+                                   a directory containing a spin.toml file, or a remote registry
+                                   reference. If omitted, it defaults to "spin.toml"
+    -h, --help                     
+    -k, --insecure                 Ignore server certificate errors from a registry
+        --temp <TMP>               Temporary directory for the static assets of the components
+
+HTTP TRIGGER OPTIONS:
+        --allow-transient-write
+            Set the static assets of the components in the temporary directory as writable
+
+        --cache <WASMTIME_CACHE_FILE>
+            Wasmtime cache configuration file
+            
+            [env: WASMTIME_CACHE_FILE=]
+
+        --disable-cache
+            Disable Wasmtime cache
+            
+            [env: DISABLE_WASMTIME_CACHE=]
+
+        --disable-pooling
+            Disable Wasmtime's pooling instance allocator
+
+        --follow <FOLLOW_ID>
+            Print output to stdout/stderr only for given component(s)
+
+        --key-value <KEY_VALUES>
+            Set a key/value pair (key=value) in the application's default store. Any existing value
+            will be overwritten. Can be used multiple times
+
+    -L, --log-dir <APP_LOG_DIR>
+            Log directory for the stdout and stderr of components. Setting to the empty string
+            disables logging to disk
+            
+            [env: SPIN_LOG_DIR=]
+
+    -q, --quiet
+            Silence all component output to stdout/stderr
+
+        --runtime-config-file <RUNTIME_CONFIG_FILE>
+            Configuration file for config providers and wasmtime config
+            
+            [env: RUNTIME_CONFIG_FILE=]
+
+        --sqlite <SQLITE_STATEMENTS>
+            Run a SQLite statement such as a migration against the default database. To run from a
+            file, prefix the filename with @ e.g. spin up --sqlite @migration.sql
+
+        --state-dir <STATE_DIR>
+            Set the application state directory path. This is used in the default locations for
+            logs, key value stores, etc.
+            
+            For local apps, this defaults to `.spin/` relative to the `spin.toml` file. For remote
+            apps, this has no default (unset). Passing an empty value forces the value to be unset.
+```
+
+{{ blockEnd }}
+
+
 {{ blockEnd }}
 
 > **Please note:** If the `-f` or `--from` options do not accurately infer the intended registry or `.toml` file for your application, then you can explicitly specify either the `--from-registry` or  `--from-file` options to clarify this.
@@ -4812,6 +5605,33 @@ The following additional trigger options are available for the [spin up](#spin-u
 ```
 
 {{ blockEnd }}
+
+{{ startTab "v2.7"}}
+
+<!-- @selectiveCpy -->
+
+```console
+--listen <ADDRESS>
+    IP address and port to listen on
+
+    [env: SPIN_HTTP_LISTEN_ADDR=]
+    [default: 127.0.0.1:3000]
+
+--tls-cert <TLS_CERT>
+    The path to the certificate to use for https, if this is not set, normal http will be
+    used. The cert should be in PEM format
+    
+    [env: SPIN_TLS_CERT=]
+
+--tls-key <TLS_KEY>
+    The path to the certificate key to use for https, if this is not set, normal http will
+    be used. The key should be in PKCS#8 format
+    
+    [env: SPIN_TLS_KEY=]
+```
+
+{{ blockEnd }}
+
 
 {{ blockEnd }}
 
@@ -4994,6 +5814,36 @@ OPTIONS:
 
 {{ blockEnd }}
 
+{{ startTab "v2.7"}}
+
+<!-- @selectiveCpy -->
+
+```console
+$ spin watch --help
+spin-watch 
+Build and run the Spin application, rebuilding and restarting it when files change
+
+USAGE:
+    spin watch [OPTIONS] [UP_ARGS]...
+
+ARGS:
+    <UP_ARGS>...    Arguments to be passed through to spin up
+
+OPTIONS:
+    -c, --clear                       Clear the screen before each run
+    -d, --debounce <DEBOUNCE>         Set the timeout between detected change and re-execution, in
+                                      milliseconds [default: 100]
+    -f, --from <APP_MANIFEST_FILE>    The application to watch. This may be a manifest (spin.toml)
+                                      file, or a directory containing a spin.toml file. If omitted,
+                                      it defaults to "spin.toml" [default: spin.toml]
+    -h, --help                        Print help information
+        --skip-build                  Only run the Spin application, restarting it when build
+                                      artifacts change
+```
+
+{{ blockEnd }}
+
+
 {{ blockEnd }}
 
 ## Stability Table
@@ -5108,5 +5958,23 @@ CLI commands have four phases that indicate levels of stability:
 | <code>spin watch</code>                                                               | Experimental |
 | <code>spin test</code>                                                                | Experimental |
 {{ blockEnd }}
+
+{{ startTab "v2.7"}}
+
+| Command                                                                               | Stability    |
+| ------------------------------------------------------------------------------------- | ------------ |
+| <code>spin add</code>                                                                 | Stable       |
+| <code>spin build</code>                                                               | Stable       |
+| <code>spin new</code>                                                                 | Stable       |
+| <code>spin plugins</code>                                                             | Stable       |
+| <code>spin templates</code>                                                           | Stable       |
+| <code>spin up</code>                                                                  | Stable       |
+| <code>spin cloud</code>                                                               | Stabilizing  |
+| <code>spin registry</code>                                                            | Stabilizing  |
+| <code>spin doctor</code>                                                              | Experimental |
+| <code>spin watch</code>                                                               | Experimental |
+| <code>spin test</code>                                                                | Experimental |
+{{ blockEnd }}
+
 
 {{ blockEnd }}


### PR DESCRIPTION
Updated spin v2.7 cli reference docs as [per toolkit output](https://github.com/fermyon/developer/tree/main/toolkit) 

The changes between two different Spin versions(v2.6 and v2.7) script output. A quick necessary information for a new Spin CLI Reference PR.

```
< Output: spin 2.6.0 (a4ddd39 2024-06-20)
---
> Output: spin 2.7.0 (a111517 2024-07-30)
47a48,50
>         --allow-overwrite              If the output directory already contains files, generate the
>                                        new files into it without confirming, overwriting any
>                                        existing files with the same names
890a894,896
>         --allow-overwrite              If the output directory already contains files, generate the
>                                        new files into it without confirming, overwriting any
>                                        existing files with the same names
974a981
>         --all                List all versions of plugins. This is the default behaviour
977a985
>         --summary            List latest and installed versions of plugins
1273,1274c1281,1283
<                                    a directory containing a spin.toml file, or a remote registry
<                                    reference. If omitted, it defaults to "spin.toml"
---
>                                    a directory containing a spin.toml file, a remote registry
>                                    reference, or a Wasm module (a .wasm file). If omitted, it
>                                    defaults to "spin.toml"
```

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title`, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep $'\r' | wc -l` and expect 0 as a result)
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
