### PR TITLE
Update the version of the WASI-SDK in the C language guide

### DIFF
--- a/content/wasm-languages/c-lang.md
+++ b/content/wasm-languages/c-lang.md
@@ -72,11 +72,12 @@ Since it supports the WASI specification, C can be used on the Fermyon Platform 
 The first step is to install the WASI SDK. If you use this broadly, it may be a good idea to install it in a common location. For our example, though, we will create a project and install the SDK inside of that project.
 
 You can download the latest version from the [WASI releases page](https://github.com/WebAssembly/wasi-sdk/releases).
-At the time of this writing, the latest version is `20.0`:
+At the time of this writing, the latest version is `24.0`. For Linux on Intel/AMD devices, you can download and extract it with the following commands (for other platforms, adjust the URL and file name accordingly):
 
 ```console
-$ curl -O -sSL https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sdk-20.0-linux.tar.gz
-$ tar -xzf wasi-sdk-20.0-linux.tar.gz
+$ curl -O -sSL https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-24/wasi-sdk-24.0-x86_64-linux.tar.gz
+$ tar -xzf wasi-sdk-24.0-x86_64-linux.tar.gz
+$ mv wasi-sdk-24.0-x86_64-linux wasi-sdk-24.0
 ```
 
 Now we can write a simple C program using WASI. Here is the text of our `hello.c` file:
@@ -94,10 +95,10 @@ int main() {
 To compile this, we will use the `clang` that comes with the WASI SDK.
 
 ```console
-$ ./wasi-sdk-20.0/bin/clang --sysroot wasi-sdk-20.0/share/wasi-sysroot/ hello.c -o hello.wasm
+$ ./wasi-sdk-24.0/bin/clang --sysroot wasi-sdk-24.0/share/wasi-sysroot/ hello.c -o hello.wasm
 ```
 
->> Newer versions of Clang may only need the command `clang --target=wasm32-wasi --sysroot=wasi-sdk-20.0/share/wasi-sysroot/  hello.c -o hello.wasm`
+>> Newer versions of Clang may only need the command `clang --target=wasm32-wasi --sysroot=wasi-sdk-24.0/share/wasi-sysroot/  hello.c -o hello.wasm`
 
 The above should produce a file named `hello.wasm`. We can execute that with Wasmtime:
 


### PR DESCRIPTION
Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title`, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep $'\r' | wc -l` and expect 0 as a result)
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)

<details>
<summary>Details</summary>



</details>

- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors
- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
