### PR TITLE
Fix wildcard service chaining host string

### DIFF
--- a/content/spin/v2/http-outbound.md
+++ b/content/spin/v2/http-outbound.md
@@ -219,7 +219,7 @@ allowed_outbound_hosts = ["http://authz.spin.internal", "https://reporting.spin.
 To allow local chaining to _any_ component in your application, use a subdomain wildcard:
 
 ```toml
-allowed_outbound_hosts = ["*://*.spin.internal"]
+allowed_outbound_hosts = ["http://*.spin.internal"]
 ```
 
 > Local service chaining is not currently supported on Fermyon Cloud.


### PR DESCRIPTION
Fixes #1364.

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title`, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep $'\r' | wc -l` and expect 0 as a result)
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
