### PR TITLE
rename spin up hub to spin hub

### DIFF
--- a/content/api/hub/contributing.md
+++ b/content/api/hub/contributing.md
@@ -1,4 +1,4 @@
-title = "Contributing to Spin Up Hub"
+title = "Contributing to the Spin Hub"
 template = "render_hub_content_body"
 date = "2023-07-20T12:00:00Z"
 enable_shortcodes = true
@@ -22,7 +22,7 @@ url = "https://github.com/fermyon/developer/blob/main/content/api/hub/contributi
   - [Push Changes](#push-changes)
   - [Create a Pull Request](#create-a-pull-request)
 
-We are delighted that you are interested in making Spin Up Hub better! Thank you! This
+We are delighted that you are interested in making Spin Hub better! Thank you! This
 document will guide you through making your first contribution to the project.
 
 First, any contribution and interaction on any Fermyon project MUST follow our
@@ -134,7 +134,7 @@ Will be shown in the modal. |
 
 ### Valid Content Types
 
-The following is a list of the types of content that a user can submit to the Spin Up Hub.
+The following is a list of the types of content that a user can submit to the Spin Hub.
 
 - **Examples**
     - Spin Application examples
@@ -199,7 +199,7 @@ Type the following commit command to ensure that you sign off (--signoff), sign 
 <!-- @nocpy -->
 
 ```bash
-$ git commit -S --signoff -m "Updating Spin Up Hub"
+$ git commit -S --signoff -m "Updating Spin Hub"
 ```
 
 > Note: the `--signoff` option will only add a Signed-off-by trailer by the committer at the end of the commit log message. In addition to this, it is recommended that you use the `-S` option which will GPG-sign your commits. For more information about using GPG in GitHub see [this GitHub documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/adding-a-gpg-key-to-your-github-account).

--- a/content/spin/v1/ai-sentiment-analysis-api-tutorial.md
+++ b/content/spin/v1/ai-sentiment-analysis-api-tutorial.md
@@ -951,5 +951,5 @@ We want to get feedback on the Serverless AI API. We are curious about what mode
 ## Next Steps
 
 - Try the numerous Serverless AI examples in our GitHub repository called [ai-examples](https://github.com/fermyon/ai-examples).
-- [Contribute](/hub/contributing) your Serverless AI app to our [Spin Up Hub](/hub).
+- [Contribute](/hub/contributing) your Serverless AI app to our [Spin Hub](/hub).
 - Ask questions and share your thoughts in [our Discord community](https://discord.gg/AAFNfS7NGf).

--- a/content/spin/v1/serverless-ai-hello-world.md
+++ b/content/spin/v1/serverless-ai-hello-world.md
@@ -381,6 +381,6 @@ This was just a small example of what Serverless AI Inferencing can do. To check
 - Read [our in-depth tutorial](../../spin/ai-sentiment-analysis-api-tutorial) on building a Sentiment Analysis API with Serverless AI
 - Look at the [Serverless AI API Guide](../../spin/serverless-ai-api-guide)
 - Try the numerous Serverless AI examples in our GitHub repository called [ai-examples](https://github.com/fermyon/ai-examples).
-- [Contribute](../../hub/contributing) your Serverless AI app to our [Spin Up Hub](../../hub/index).
+- [Contribute](../../hub/contributing) your Serverless AI app to our [Spin Hub](../../hub/index).
 - Ask questions and share your thoughts in [our Discord community](https://discord.gg/AAFNfS7NGf).
 ---

--- a/content/spin/v2/ai-sentiment-analysis-api-tutorial.md
+++ b/content/spin/v2/ai-sentiment-analysis-api-tutorial.md
@@ -1112,5 +1112,5 @@ We want to get feedback on the Serverless AI API. We are curious about what mode
 ## Next Steps
 
 - Try the numerous Serverless AI examples in our GitHub repository called [ai-examples](https://github.com/fermyon/ai-examples).
-- [Contribute](/hub/contributing) your Serverless AI app to our [Spin Up Hub](/hub).
+- [Contribute](/hub/contributing) your Serverless AI app to our [Spin Hub](/hub).
 - Ask questions and share your thoughts in [our Discord community](https://discord.gg/AAFNfS7NGf).

--- a/content/spin/v2/serverless-ai-hello-world.md
+++ b/content/spin/v2/serverless-ai-hello-world.md
@@ -446,6 +446,6 @@ This was just a small example of what Serverless AI Inferencing can do. To check
 - Read [our in-depth tutorial](ai-sentiment-analysis-api-tutorial) on building a Sentiment Analysis API with Serverless AI
 - Look at the [Serverless AI API Guide](serverless-ai-api-guide)
 - Try the numerous Serverless AI examples in our GitHub repository called [ai-examples](https://github.com/fermyon/ai-examples).
-- [Contribute](../../hub/contributing) your Serverless AI app to our [Spin Up Hub](../../hub/index).
+- [Contribute](../../hub/contributing) your Serverless AI app to our [Spin Hub](../../hub/index).
 - Ask questions and share your thoughts in [our Discord community](https://discord.gg/AAFNfS7NGf).
 ---

--- a/content/wasm-languages/python.md
+++ b/content/wasm-languages/python.md
@@ -178,7 +178,7 @@ Here are some great resources:
 - A tutorial doing [AI inferencing with Python and Spin](https://www.wasm.builders/technosophos/serverless-ai-inferencing-with-python-and-wasm-3lkd)
 - The [Spin Python SDK](https://github.com/fermyon/spin-python-sdk)
 - The [Spin Developer Docs](../spin) fully document the Python SDKs
-- [Python Wasm examples](../../hub/index) at Spin Up Hub
+- [Python Wasm examples](../../hub/index) at Spin Hub
 - The [Componentize-Py](https://pypi.org/project/componentize-py/) tooling
 - VMware has a [distribution of CPython as Wasm](https://github.com/vmware-labs/webassembly-language-runtimes/tree/main/python) based on the official CPython
 - A detailed document about  [the (once) current state and features of Wasm](https://pythondev.readthedocs.io/wasm.html) in the latest CPython version (Now outdated)

--- a/spin-up-hub/index.html
+++ b/spin-up-hub/index.html
@@ -15,7 +15,7 @@
     <link
       rel="alternate"
       type="application/rss+xml"
-      title="Spin Up Hub"
+      title="Spin Hub"
       href="/atom.xml"
     />
 
@@ -39,7 +39,7 @@
       rel="stylesheet"
     />
 
-    <title>Spin Up Hub</title>
+    <title>Spin Hub</title>
 
     <!-- Google Tag Manager -->
     <script>
@@ -213,7 +213,7 @@
           </div>
           <div class="overlay"></div>
 
-          <a class="navbar-item is-active" href="./">Spin Up Hub</a>
+          <a class="navbar-item is-active" href="./">Spin Hub</a>
         </div>
 
         <div class="navbar-end">

--- a/spin-up-hub/src/store.js
+++ b/spin-up-hub/src/store.js
@@ -36,7 +36,7 @@ const store = createStore({
         state.modalData.description = ""
         state.modalData.isloaded = false
         document.body.classList.add("modal-open")
-        document.title = `Spin Up Hub | ${state.modalData.title} `
+        document.title = `Spin Hub | ${state.modalData.title} `
       }
     },
     openPreview(state, payload) {
@@ -50,7 +50,7 @@ const store = createStore({
       if (shouldUpdateHistory) {
         router.push("/hub")
       }
-      document.title = "Spin Up Hub"
+      document.title = "Spin Hub"
     },
     updateModalDescription(state, payload) {
       state.modalData.description = payload.description

--- a/spin-up-hub/src/view/Contributing.vue
+++ b/spin-up-hub/src/view/Contributing.vue
@@ -9,7 +9,7 @@ export default {
     },
     async mounted() {
         let res = await fetch(import.meta.env.VITE_API_HOST + "/api/hub/contributing")
-        this.contributionGuide = "<h1>Spin Up Hub Contribution Guide</h1>" + unescapeHTML(await res.text())
+        this.contributionGuide = "<h1>Spin Hub Contribution Guide</h1>" + unescapeHTML(await res.text())
         nextTick(() => {
             document.querySelectorAll("pre > code").forEach((codeblock) => {
                 console.log(codeblock)

--- a/templates/content_navbar.hbs
+++ b/templates/content_navbar.hbs
@@ -93,8 +93,8 @@
             </div>
             <div class="overlay"></div>
             {{!-- quicklinks can be added to the topbar here --}}
-            <a class="navbar-item plausible-event-name=docs-nav-hub" href="/hub" title="Sample apps, plugins and templates in Spin Up Hub">
-                Spin Up Hub
+            <a class="navbar-item plausible-event-name=docs-nav-hub" href="/hub" title="Sample apps, plugins and templates in Spin Hub">
+                Spin Hub
             </a>
 
             {{#if (active_project request.spin-path-info "/cloud/" )}}

--- a/templates/home.hbs
+++ b/templates/home.hbs
@@ -24,7 +24,7 @@ read_pages_glob = ["events/*.md"]
                     <li><a href="/bartholomew/index" {{#if (active_project request.spin-path-info "/cloud/" )}}
                             class="is-active" {{/if}}>Bartholomew</a></li>
                     <li><a href="/hub" {{#if (active_project request.spin-path-info "/cloud/" )}} class="is-active"
-                            {{/if}}>Spin Up Hub</a></li>
+                            {{/if}}>Spin Hub</a></li>
                 </ul>
 
                 <a class="navbar-item button is-primary is-rounded is-small" href="https://cloud.fermyon.com/"


### PR DESCRIPTION
Small terminology change for the name of the `/hub` section, to align with CLI work.

```
Spin Up Hub -> Spin Hub
```