### PR TITLE
Update Dart webassembly-language-support.md

### DIFF
--- a/content/wasm-languages/webassembly-language-support.md
+++ b/content/wasm-languages/webassembly-language-support.md
@@ -1,4 +1,4 @@
-date = "2024-02-18T01:01:01Z"
+date = "2024-09-14T01:01:01Z"
 title = "WebAssembly Language Support Matrix"
 description = "Tracking the programming languages that compile to WebAssembly (Wasm). This page stays up to date with information about which languages can compile to Wasm, and what their language characteristics are."
 template = "page"
@@ -39,7 +39,7 @@ Some languages, like CSS, PowerShell, and "Shell", don't really have a meaningfu
 | [Kotlin (JVM)][Kotlin]    | ✅    | ✅      | ✅   | ⏳       |
 | [Kotlin (Wasm)][Kotlin]   | ⏳    | ✅      | ✅   | ❌       |
 | [Rust][Rust]              | ✅    | ✅      | ✅   | ✅       |
-| [Dart][Dart]              | ❌    | ⏳      | ❌   | ❌       |
+| [Dart][Dart]              | ✅    | ✅      | ⏳   | ❌       |
 
 * _Core_ means there is an implementation of WebAssembly 1.0
 * _Browser_ means there is at least one browser implementation


### PR DESCRIPTION
Update language matrix to be aligned with @kevmoo's https://github.com/fermyon/developer/commit/6cb4c1e4481c423dca3bc7d3c1fc7f4b952d2949

- Dart (and Flutter) have core and browser support: https://dart.dev/web/wasm
- WASI support is tracked in https://github.com/dart-lang/sdk/issues/56366

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title`, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep $'\r' | wc -l` and expect 0 as a result)
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
