### PR TITLE
docs(*): use fermyon/installer links

### DIFF
--- a/content/cloud/quickstart.md
+++ b/content/cloud/quickstart.md
@@ -96,7 +96,7 @@ Device authorized!
 
 This command will generate an authentication code for your current device to be authorized against the Fermyon Cloud. Follow the instructions in the prompt to complete the authorization process.
 
-{{ details "Learn more" "The default behavior of `spin login` is to authenticate with the Fermyon Cloud. The command can authenticate against any instance of the [Fermyon Platform](https://www.fermyon.dev)." }}
+{{ details "Learn more" "The default behavior of `spin login` is to authenticate with the Fermyon Cloud. The command can authenticate against any instance of the [Fermyon Platform](https://github.com/fermyon/installer)." }}
 
 ## Clone the Quickstart Repo
 

--- a/content/spin/v1/deploying-to-fermyon.md
+++ b/content/spin/v1/deploying-to-fermyon.md
@@ -12,16 +12,16 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/deploying-
 
 ## Deploying Microservices & Web Apps
 
-[Fermyon](https://www.fermyon.dev/) is the frictionless WebAssembly platform for deploying
+[Fermyon](https://github.com/fermyon/installer) is the frictionless WebAssembly platform for deploying
 microservices and web apps. With Fermyon, you can deploy your spin applications onto a server in
 moments.
 
 ## Running on Your Workstation
 
 For instructions guiding you through running the Fermyon platform on your development workstation,
-follow [this guide](https://www.fermyon.dev/quickstart-local).
+follow [this guide](https://github.com/fermyon/installer/tree/main/local/README.md).
 
 ## Running on AWS
 
 For instructions guiding you through running the Fermyon platform on AWS, follow
-[this guide](https://www.fermyon.dev/quickstart-aws).
+[this guide](https://github.com/fermyon/installer/tree/main/aws/README.md).

--- a/content/spin/v2/deploying-to-fermyon.md
+++ b/content/spin/v2/deploying-to-fermyon.md
@@ -16,16 +16,16 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/v2/deploying-
 
 ## Fermyon Platform
 
-[Fermyon Platform](https://www.fermyon.dev/) is a self-host platform for Spin applications. With Fermyon, you can deploy your spin applications onto a server in moments.
+[Fermyon Platform](https://github.com/fermyon/installer) is a self-hosted platform for Spin applications. With Fermyon, you can deploy your spin applications onto a server in moments.
 
 > Fermyon Platform does not currently support Spin 2.
 
 ### Running on Your Workstation
 
 For instructions guiding you through running the Fermyon platform on your development workstation,
-follow [this guide](https://www.fermyon.dev/quickstart-local).
+follow [this guide](https://github.com/fermyon/installer/tree/main/local/README.md).
 
 ### Running on AWS
 
 For instructions guiding you through running the Fermyon platform on AWS, follow
-[this guide](https://www.fermyon.dev/quickstart-aws).
+[this guide](https://github.com/fermyon/installer/tree/main/aws/README.md).


### PR DESCRIPTION
Use GitHub repo links for Fermyon Platform

Ref https://github.com/fermyon/installer/pull/137