### PR TITLE
Add spin kinesis trigger plugin info

### DIFF
--- a/content/api/hub/plugin_spin_kinesis_trigger.md
+++ b/content/api/hub/plugin_spin_kinesis_trigger.md
@@ -1,0 +1,77 @@
+title = "Kinesis Trigger"
+template = "render_hub_content_body"
+date = "2024-10-04T00:22:56Z"
+content-type = "text/plain"
+tags = ["trigger", "rust", "plugins"]
+
+[extra]
+author = "ogghead"
+type = "hub_document"
+category = "Plugin"
+language = "Rust"
+created_at = "2024-08-31T00:22:56Z"
+last_updated = "2024-10-04T00:22:56Z"
+spin_version = ">=v2.6.0"
+summary = "An experimental Kinesis trigger for Spin apps"
+url = "https://github.com/ogghead/spin-trigger-kinesis"
+keywords = "trigger, kinesis"
+
+---
+
+An experimental plugin that enables AWS Kinesis trigger for Spin applications.
+
+## Installing Plugin
+
+You can install the plugin using the following command:
+
+```sh
+spin plugins install --url https://github.com/ogghead/spin-trigger-kinesis/releases/download/canary/trigger-kinesis.json
+```
+
+## Installing Template
+
+You can install the template using the following command:
+
+```sh
+spin templates install --git https://github.com/ogghead/spin-trigger-kinesis
+```
+
+Once the template is installed, you can create a new application using:
+
+```sh
+spin new -t kinesis-rust hello_kinesis --accept-defaults
+```
+
+Note that you will need to provide a valid ARN (Amazon Resource Name) for your stream.
+
+To run the newly created app:
+
+```bash
+cd hello_kinesis
+spin build --up
+```
+
+### Configuring the Kinesis Trigger
+
+The trigger type is `kinesis` and there are no application-level configuration options.
+
+The following options are available to set in the [[trigger.kinesis]] section:
+
+| Name                        | Type             | Required? | Description |
+|-----------------------------|------------------|-----------|-------------|
+| `stream_arn`                | string           | required  | The stream to which this trigger listens and responds. |
+| `batch_size`                | number           | optional  | The maximum number of records to fetch per Kinesis shard on each poll. The default is 10. This directly affects the amount of records that your component is invoked with. |
+| `shard_idle_wait_millis`    | number           | optional  | How long (in milliseconds) to wait between checks when the stream is idle (i.e. when no messages were received on the last check). The default is 1000. If the stream is _not_ idle, there is no wait between checks. The idle wait is also applied if an error occurs. Note that this number should _not_ exceed 300,000 milliseconds (5 minutes), as shard iterators time out after this period |
+| `detector_poll_millis`      | number           | optional  | How long (in milliseconds) to wait between checks for new shards. The default is 30,000 (30 seconds). |
+| `shard_iterator_type`       | enum             | optional  | See <https://docs.aws.amazon.com/cli/latest/reference/kinesis/get-shard-iterator.html#options> for possible options. Defaults to LATEST. |
+| `component`                 | string or table  | required  | The component to run when a stream record is received. This is the standard Spin trigger component field. |
+
+```toml
+[[trigger.kinesis]]
+component = "test"
+stream_arn = "arn:aws:kinesis:us-east-1:1234567890:stream/TestStream"
+batch_size = 1000
+shard_idle_wait_millis = 250
+detector_poll_millis = 30000
+shard_iterator_type = "TRIM_HORIZON"
+```

--- a/content/api/hub/plugin_spin_kinesis_trigger.md
+++ b/content/api/hub/plugin_spin_kinesis_trigger.md
@@ -33,7 +33,7 @@ spin plugins install --url https://github.com/ogghead/spin-trigger-kinesis/relea
 You can install the template using the following command:
 
 ```sh
-spin templates install --git https://github.com/ogghead/spin-trigger-kinesis
+spin templates install --update --git https://github.com/ogghead/spin-trigger-kinesis
 ```
 
 Once the template is installed, you can create a new application using:


### PR DESCRIPTION
Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title`, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
  - No new menu item
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep $'\r' | wc -l` and expect 0 as a result)
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
  - Ran: `bart check content/api/hub/plugin_spin_kinesis_trigger.md`
  - Output: `✅ content/api/hub/plugin_spin_kinesis_trigger.md`
- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors
  - `All the errors were transient. The links are valid!`
- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
  - Blog has not yet been published, but I will add a link soon!
