### PR TITLE
Remove references to HTTP application base

### DIFF
--- a/content/spin/v3/manifest-reference-v1.md
+++ b/content/spin/v3/manifest-reference-v1.md
@@ -34,7 +34,7 @@ The manifest is a TOML file, and follows standard TOML syntax.  See the [TOML do
 | `version`               | Required   | String      | The version of the application. The must be a string of the form `major.minor.patch`, where each element is a number. | `"1.0.5"` |
 | `description`           | Optional   | String      | A human-readable description of the application. | `"The best app for all your world-greeting needs"` |
 | `authors`               | Optional   | Array of strings | The authors of the applications. If present, this must ba an array, even if it has only one entry. | `["Jane Q Hacker (<dev@example.com>)"]` |
-| `trigger`               | Required   | Table       | The trigger for the application - that is, the kind of event that the application responds to. The table must contain the `type` field, and may contain others depending on the value of `type`. See [The `trigger` Table](#the-trigger-table) for details. | `{ type = "http", base = "/" }` |
+| `trigger`               | Required   | Table       | The trigger for the application - that is, the kind of event that the application responds to. The table must contain the `type` field, and may contain others depending on the value of `type`. See [The `trigger` Table](#the-trigger-table) for details. | `{ type = "http" }` |
 | `variables`             | Optional   | Table       | Dynamic configuration variables which the user can set when they run the application. See [The `variables` Table](#the-variables-table) below. | `[variables]`<br />`message = { default = "hello" }` |
 | `component`             | Required   | Table array | A manifest must contain at least one `component` table. `component` is always an array, even if there is only one component, so always use double square brackets.  See [The `component` Tables](#the-component-tables) below. | `[[component]]`<br />`id = "hello"` |
 
@@ -45,7 +45,7 @@ The `trigger` table specifies the events that the application responds to.  The 
 > Because the `trigger` table usually contains only a few simple fields, you will usually see it written inline using brace notation, rather than written out using square-brackets table syntax.  For example:
 >
 > ```toml
-> trigger = { type = "http", base = "/" }
+> trigger = { type = "http" }
 > ```
 
 ### The `trigger` Table for HTTP Applications
@@ -53,7 +53,6 @@ The `trigger` table specifies the events that the application responds to.  The 
 | Name                    | Required?  | Type        | Value    | Example   |
 |-------------------------|------------|-------------|----------|-----------|
 | `type`                  | Required   | String      | Always `"http"` for HTTP applications. | `"http"` |
-| `base`                  | Required   | String      | The base path of the application. All component routes are relative to this. It allows multiple applications to be mounted under the same host. | `"/"` |
 
 ### The `trigger` Table for Redis Applications
 

--- a/content/spin/v3/manifest-reference.md
+++ b/content/spin/v3/manifest-reference.md
@@ -10,7 +10,6 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/v3/manifest-r
 - [Manifest Fields](#manifest-fields)
 - [The `application` Table](#the-application-table)
 - [The `application.trigger` Table](#the-applicationtrigger-table)
-  - [The `application.trigger.http` Table](#the-applicationtriggerhttp-table)
   - [The `application.trigger.redis` Table](#the-applicationtriggerredis-table)
 - [The `variables` Table](#the-variables-table)
 - [The `trigger` Table](#the-trigger-table)
@@ -85,21 +84,13 @@ The only variables permitted in manifest expressions are application variables.
 | `version`               | Optional   | String      | The version of the application. The must be a string of the form `major.minor.patch`, where each element is a number. | `"1.0.5"` |
 | `description`           | Optional   | String      | A human-readable description of the application. | `"The best app for all your world-greeting needs"` |
 | `authors`               | Optional   | Array of strings | The authors of the applications. If present, this must ba an array, even if it has only one entry. | `["Jane Q Hacker (<dev@example.com>)"]` |
-| `trigger`               | Optional   | Table       | Application-global trigger settings. See [The `application.trigger` Table](#the-applicationtrigger-table) below. | `[application.trigger.http]`<br />`base = "/"` |
+| `trigger`               | Optional   | Table       | Application-global trigger settings. See [The `application.trigger` Table](#the-applicationtrigger-table) below. | `[application.trigger.redis]`<br />`address = "redis.example.com"` |
 
 ## The `application.trigger` Table
 
-The `application.trigger` should contain only one key, the trigger type whose settings you want to override. This is usually written inline as part of the TOML table header, e.g. `[application.trigger.http]`.
+The `application.trigger` should contain only one key, the trigger type whose settings you want to override. This is usually written inline as part of the TOML table header, e.g. `[application.trigger.redis]`.
 
 > In many cases, your trigger will have no settings, or the default ones will suffice. In this case, you can omit the `application.trigger` table.
-
-> If you're familiar with manifest version 1, note that this is now optional. The trigger type to which the application responds is determined by the top-level `trigger` mappings; you only need to provide an `application.trigger` if you want to override the default global settings for the trigger type.
-
-### The `application.trigger.http` Table
-
-| Name                    | Required?  | Type        | Value    | Example   |
-|-------------------------|------------|-------------|----------|-----------|
-| `base`                  | Optional   | String      | The base path of the application. All component routes are relative to this. It allows multiple applications to be mounted under the same host. | `"/"` |
 
 ### The `application.trigger.redis` Table
 

--- a/content/spin/v3/quickstart.md
+++ b/content/spin/v3/quickstart.md
@@ -598,7 +598,6 @@ Pick a template to start your application with:
   http-rust (HTTP request handler using Rust)
 Enter a name for your new application: hello_go
 Description: My first Go Spin application
-HTTP base: /
 HTTP path: /...
 ```
 

--- a/content/spin/v3/template-authoring.md
+++ b/content/spin/v3/template-authoring.md
@@ -120,7 +120,7 @@ add a few items to your metadata.
 |-----------------|-----------------|
 | `snippets`      | A subtable with an entry named `component`, whose value is the name of the file containing the component manifest template. (Don't include the `snippets` directory prefix - Spin knows to look in the `snippets` directory.) |
 | `skip_files`    | Optional array of content files that should _not_ be copied when running in "add component" mode. For example, if your template contains a `spin.toml` file, you should use this setting to exclude that, because you want to add a new entry to the existing file, not overwrite it. |
-| `skip_parameters` | Optional array of parameters that Spin should _not_ prompt for when running in "add component" mode. For example, the HTTP templates don't prompt for the base path, because that's defined at the application level, not set on an individual component. |
+| `skip_parameters` | Optional array of parameters that Spin should _not_ prompt for when running in "add component" mode. |
 
 Here is an example `add_component` table from a HTTP template:
 
@@ -129,7 +129,7 @@ Here is an example `add_component` table from a HTTP template:
 ```toml
 [add_component]
 skip_files = ["spin.toml"]
-skip_parameters = ["http-base"]
+skip_parameters = ["shared-prefix"]
 [add_component.snippets]
 component = "component.txt"
 ```

--- a/content/spin/v3/writing-apps.md
+++ b/content/spin/v3/writing-apps.md
@@ -93,9 +93,7 @@ Another trigger type is `redis`, which is triggered by Redis pub-sub messages. F
 
 Multiple triggers may refer to the same component. For example, you could have another trigger on `/dober-dan` which also invokes the `greeter` component.
 
-Some triggers have additional application-level configuration options.  For example, the HTTP trigger allows you to provide a `base` field, which tells Spin the "root" route to which all component routes are relative.  See the [HTTP trigger](http-trigger) and [Redis trigger](redis-trigger) documentation for more details.
-
-> If you're familiar with Spin 1.x, note that triggers are now distinct entries in the manifest, and _refer_ to components, instead of being specified _inside_ components.
+Some triggers have additional application-level configuration options.  For example, the Redis trigger allows you to provide an `address` field, which tells Spin the default server for components that do not specify servers.  See the [Redis trigger](redis-trigger) documentation for more details.
 
 ### The Component Name
 


### PR DESCRIPTION
Fixes #1371.

I think I got all of them but egad it's not the easiest string to search for.  In future can we name our settings "elephant" or "dodecahedron" kthxbai

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title`, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep $'\r' | wc -l` and expect 0 as a result)
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
