### PR TITLE
Fix some broken links

### DIFF
--- a/content/spin/v2/variables.md
+++ b/content/spin/v2/variables.md
@@ -86,7 +86,7 @@ api_version = "v1"
 
 ## Using Variables From Applications
 
-The Spin SDK surfaces the Spin configuration interface to your language. The [interface](https://github.com/fermyon/spin/blob/main/wit/variables.wit) consists of one operation:
+The Spin SDK surfaces the Spin configuration interface to your language. The [interface](https://github.com/fermyon/spin/blob/main/wit/deps/spin@2.0.0/variables.wit) consists of one operation:
 
 | Operation  | Parameters         | Returns             | Behavior |
 |------------|--------------------|---------------------|----------|

--- a/content/spin/v3/contributing-docs.md
+++ b/content/spin/v3/contributing-docs.md
@@ -54,7 +54,7 @@ How-to guides are oriented towards showing a user how to solve a problem, which 
 
 ### 3. Reference
 
-Reference resources are merely a dry description; describing the feature in its simplest form. A great example of a reference resource is the [Spin CLI Reference page](./cli-reference). You will notice that the CLI Reference page simply lists all of the commands and available options.
+Reference resources are merely a dry description; describing the feature in its simplest form. An example of a reference resource is the [Spin application manifest reference](./manifest-reference). You will notice that the Manifest Reference page simply lists all of the manifest entries and available options.
 
 ### 4. Explanation
 

--- a/content/spin/v3/http-trigger.md
+++ b/content/spin/v3/http-trigger.md
@@ -509,7 +509,7 @@ The `spin up` command's `--tls-cert` and `--tls-key` trigger options provide a w
 
 The `--tls-cert` option specifies the path to the TLS certificate to use for HTTPS, if this is not set, normal HTTP will be used. The certificate should be in PEM format. 
 
-The `--tls-key` option specifies the path to the private key to use for HTTPS, if this is not set, normal HTTP will be used. The key should be in PKCS#8 format. For more information, please see the [Spin CLI Reference](./cli-reference#trigger-options).
+The `--tls-key` option specifies the path to the private key to use for HTTPS, if this is not set, normal HTTP will be used. The key should be in PKCS#8 format.
 
 ### Environment Variables
 

--- a/content/spin/v3/managing-plugins.md
+++ b/content/spin/v3/managing-plugins.md
@@ -126,7 +126,7 @@ To update your local cache of the catalogue, run `spin plugins update`.
 
 To upgrade a plugin to the latest version, first run `spin plugins update` (to refresh the catalogue), then `spin plugins upgrade`. 
 
-The `spin plugins upgrade` command has the same options as the `spin plugins install` command (according to whether the plugin comes from the catalogue, a URL, or a file). For more information, see the plugins section of the [Spin CLI Reference documentation](cli-reference#spin-plugins). 
+The `spin plugins upgrade` command has the same options as the `spin plugins install` command (according to whether the plugin comes from the catalogue, a URL, or a file). For more information, see the command help by running `spin plugins upgrade --help`.
 
 > The `upgrade` command uses your local cache of the catalogue. This might not include recently added plugins or versions. So always remember to run `spin plugins update` to refresh your local cache of the catalogue before performing the `spin plugins upgrade` command.
 

--- a/content/spin/v3/python-components.md
+++ b/content/spin/v3/python-components.md
@@ -83,7 +83,7 @@ Installed 1 template(s)
 +---------------------------------------------+
 ```
 
-**Please note:** For more information about managing `spin templates`, see the [templates section](./cli-reference#templates) in the Spin Command Line Interface (CLI) documentation.
+**Please note:** For more information about managing Spin templates, see the [templates guide](./managing-templates).
 
 ## Creating a New Python Component
 

--- a/content/spin/v3/quickstart.md
+++ b/content/spin/v3/quickstart.md
@@ -453,7 +453,7 @@ Installed 1 template(s)
 +---------------------------------------------+
 ```
 
-**Please note:** For more information about managing `spin templates`, see the [templates section](./cli-reference#templates) in the Spin Command Line Interface (CLI) documentation.
+**Please note:** For more information about managing Spin templates, see the [templates guide](./managing-templates).
 
 This command created a directory with the necessary files needed to build and run a Python Spin application.  Change to that directory, and look at the files.  It contains a minimal Python application:
 

--- a/content/spin/v3/registry-tutorial.md
+++ b/content/spin/v3/registry-tutorial.md
@@ -78,7 +78,7 @@ Now we're ready to push the application. Run the `spin registry push` command to
 $ spin registry push ghcr.io/USERNAME/spin-react-fullstack:v1
 ```
 
-> **Note:** You can find more information on `spin registry` options and subcommands in the [Spin CLI Reference documentation](./cli-reference#oci-registry).
+> **Note:** You can find more information on `spin registry` options and subcommands by using the `--help` option.
 
 You now have a Spin application stored in your registry. You can see the artifact under packages in the [GitHub UI](https://docs.github.com/en/packages/learn-github-packages/viewing-packages#viewing-a-repositorys-packages).
 

--- a/content/spin/v3/running-apps.md
+++ b/content/spin/v3/running-apps.md
@@ -101,9 +101,9 @@ Some trigger types support additional `spin up` flags.  For example, HTTP applic
 
 ## Monitoring Applications for Changes
 
-Spin's `watch` command rebuilds and restarts Spin applications whenever files change. You can use the `spin watch` [command](./cli-reference#watch) in place of the `spin build` and `spin up` commands, to build, run and then keep your Spin application running without manual intervention while staying on the latest code and files.
+Spin's `watch` command rebuilds and restarts Spin applications whenever files change. You can use the `spin watch` command in place of the `spin build` and `spin up` commands, to build, run and then keep your Spin application running without manual intervention while staying on the latest code and files.
 
-> The `watch` command accepts valid Spin [up](./cli-reference#up) options and passes them through to `spin up` for you when running/rerunning the Spin application.
+> The `watch` command accepts valid `spin up` options and passes them through to `spin up` for you when running/rerunning the Spin application.
 E.g. `spin watch --listen 127.0.0.1:3001`
 
 By default, Spin watch monitors:

--- a/content/spin/v3/variables.md
+++ b/content/spin/v3/variables.md
@@ -86,7 +86,7 @@ api_version = "v1"
 
 ## Using Variables From Applications
 
-The Spin SDK surfaces the Spin configuration interface to your language. The [interface](https://github.com/fermyon/spin/blob/main/wit/variables.wit) consists of one operation:
+The Spin SDK surfaces the Spin configuration interface to your language. The [interface](https://github.com/fermyon/spin/blob/main/wit/deps/spin@2.0.0/variables.wit) consists of one operation:
 
 | Operation  | Parameters         | Returns             | Behavior |
 |------------|--------------------|---------------------|----------|

--- a/content/wasm-languages/standards.md
+++ b/content/wasm-languages/standards.md
@@ -28,7 +28,7 @@ WebAssembly is standardized by W3C, the same group that standardizes CSS, HTML, 
 - The [WASI site](https://wasi.dev) is the main page
 - The [WASI repo](https://github.com/WebAssembly/WASI)
 - The working group [charter](https://github.com/WebAssembly/WASI/blob/main/Charter.md)
-- Most of the WASI proposed standards are [in the WebAssembly GitHub](https://github.com/search?q=org%3AWebAssembly+wasi)
+- Most of the WASI proposed standards are [in the WebAssembly GitHub](https://github.com/orgs/WebAssembly/repositories?q=wasi)
 - The [WASI libc library](https://github.com/WebAssembly/wasi-libc) is the C library for core WASI
 
 ### The Component Model


### PR DESCRIPTION
Mostly related to v3 removing the CLI reference but also general background churn of outbound links.

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title`, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep $'\r' | wc -l` and expect 0 as a result)
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
