### PR TITLE
Remove js2wasm from v3 docs

### DIFF
--- a/content/spin/v3/managing-plugins.md
+++ b/content/spin/v3/managing-plugins.md
@@ -20,7 +20,7 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/v3/managing-p
 - [Downgrading Plugins](#downgrading-plugins)
 - [Next Steps](#next-steps)
 
-Plugins are a way to extend the functionality of Spin. Spin provides commands for installing and removing them, so you don't need to use separate installation tools. When you have installed a plugin into Spin, you can call it as if it were a Spin subcommand. For example, the JavaScript SDK uses a tool called `js2wasm` to package JavaScript code into a Wasm module, and JavaScript applications run it via the `spin js2wasm` command.
+Plugins are a way to extend the functionality of Spin. Spin provides commands for installing and removing them, so you don't need to use separate installation tools. When you have installed a plugin into Spin, you can call it as if it were a Spin subcommand. For example, Fermyon Cloud can be accessed with a plugin called `cloud`, and you run it via the `spin cloud` command.
 
 ## Installing Plugins
 
@@ -33,7 +33,7 @@ The Spin maintainers curate a catalogue of "known" plugins. You can install plug
 <!-- @selectiveCpy -->
 
 ```bash
-$ spin plugins install js2wasm
+$ spin plugins install cloud
 ```
 
 Spin checks that the plugin is available for your version of Spin and your operating system, and prompts you to confirm the installation. To skip the prompt, pass the `--yes` flag.
@@ -47,7 +47,7 @@ To install a specific version of a plugin, pass the `--version` flag:
 <!-- @nocpy -->
 
 ```bash
-$ spin plugins install js2wasm --version 0.4.0
+$ spin plugins install cloud --version 0.9.1
 ```
 
 ### Installing a Plugin From a URL
@@ -77,7 +77,7 @@ You run plugins in the same way as built-in Spin subcommands. For example:
 <!-- @selectiveCpy -->
 
 ```bash
-$ spin js2wasm --help
+$ spin cloud --help
 ```
 
 ## Viewing Available Plugins
@@ -89,8 +89,8 @@ To see what plugins are available in the catalogue, run `spin plugins search`:
 ```bash
 $ spin plugins search
 befunge2wasm 1.4.0 [incompatible]
-js2wasm 0.3.0 [installed]
-js2wasm 0.4.0
+cloud 0.8.0 [installed]
+cloud 0.9.0
 trigger-sqs 0.1.0
 ```
 
@@ -130,13 +130,13 @@ The `spin plugins upgrade` command has the same options as the `spin plugins ins
 
 > The `upgrade` command uses your local cache of the catalogue. This might not include recently added plugins or versions. So always remember to run `spin plugins update` to refresh your local cache of the catalogue before performing the `spin plugins upgrade` command.
 
-The following example shows how to upgrade one plugin at a time (i.e. the `js2wasm` plugin):
+The following example shows how to upgrade one plugin at a time (i.e. the `cloud` plugin):
 
 <!-- @selectiveCpy -->
 
 ```bash
 $ spin plugins update
-$ spin plugins upgrade js2wasm
+$ spin plugins upgrade cloud
 ```
 
 The following example shows how to upgrade all installed plugins at once:
@@ -161,7 +161,7 @@ $ spin plugins upgrade --file ~/dev/spin-befunge-sdk/befunge2wasm.json
 
 ## Downgrading Plugins
 
-By default, Spin will only _upgrade_ plugins. Pass the `--downgrade` flag and specify the `--version` if you want Spin to roll back to an earlier version. The following abridged example (which doesn't list the full console output for simplicity) lists the versions of plugins, downgrades the `js2wasm` to an older version (`0.6.0`) and then lists the versions again to show the results:
+By default, Spin will only _upgrade_ plugins. Pass the `--downgrade` flag and specify the `--version` if you want Spin to roll back to an earlier version. The following abridged example (which doesn't list the full console output for simplicity) lists the versions of plugins, downgrades the `cloud` to an older version (`0.9.0`) and then lists the versions again to show the results:
 
 <!-- @nocpy -->
 
@@ -169,19 +169,17 @@ By default, Spin will only _upgrade_ plugins. Pass the `--downgrade` flag and sp
 $ spin plugins update
 $ spin plugins list
 // --snip--
-js2wasm 0.6.0
-js2wasm 0.6.1 [installed]
-$ spin plugins upgrade js2wasm --downgrade --version 0.6.0
+cloud 0.9.0
+cloud 0.9.1 [installed]
+$ spin plugins upgrade cloud --downgrade --version 0.9.0
 $ spin plugins list
 // --snip--
-js2wasm 0.6.0 [installed]
-js2wasm 0.6.1
+cloud 0.9.0 [installed]
+cloud 0.9.1
 ```
 
-After downgrading, the `[installed]` indicator is aligned with the `0.6.0` version of `js2wasm`, as intended in the example.
+After downgrading, the `[installed]` indicator is aligned with the `0.9.0` version of `cloud`, as intended in the example.
 
 ## Next Steps
 
-- [Install the JavaScript or Python plugins](quickstart)
-- [Use the JavaScript or Python plugins to build a Wasm module](build)
-- [Checkout the spin cloud plugin](https://github.com/fermyon/cloud-plugin)
+- [Check out the spin cloud plugin](https://github.com/fermyon/cloud-plugin)

--- a/content/spin/v3/plugin-authoring.md
+++ b/content/spin/v3/plugin-authoring.md
@@ -18,8 +18,8 @@ Spin plugins add new functionality or subcommands to Spin without modifying the
 Spin codebase. They make Spin easily extensible while keeping it lightweight.
 Spin plugins can add new triggers to Spin (such as the [example timer
 trigger](https://github.com/fermyon/spin/blob/main/examples/spin-timer/trigger-timer.json)),
-enable new language SDKs (such as
-[`js2wasm`](https://github.com/fermyon/spin-plugins/blob/main/manifests/js2wasm/js2wasm.json)),
+add deployment integrations (such as
+[`kube`](https://github.com/fermyon/spin-plugins/blob/main/manifests/kube/kube.json)),
 and more.
 
 This document will cover what Spin plugins are, how to use a plugin, and how to
@@ -46,19 +46,16 @@ and creates a local snapshot. To ensure that the local snapshot is up to date,
 it is best to run `spin plugins update` before installing any plugins. 
 
 To list available plugins, run `spin plugins search`. Now, decide which plugin to
-install. For example, the `js2wasm` plugin, which is needed in order to build
-JavaScript Spin applications, can be installed by running:
+install. For example, the `kube` plugin, which is needed in order to deploy
+applications to [SpinKube](https://www.spinkube.dev/), can be installed by running:
 
 <!-- @selectiveCpy -->
 
 ```bash
-$ spin plugins install js2wasm
+$ spin plugins install kube
 ```
 
-With the plugin installed, you can now call `spin js2wasm` to run it. In this
-case, for example, you might call it from your JavaScript application's npm
-build script. Learn more about building Spin components in JavaScript
-[here](./javascript-components.md).
+With the plugin installed, you can now call `spin kube` to run it.
 
 To upgrade installed plugins to newer versions, run `spin plugin update` to
 fetch the latest plugins to the local catalogue and `spin plugin upgrade` to perform the

--- a/content/spin/v3/quickstart.md
+++ b/content/spin/v3/quickstart.md
@@ -194,16 +194,7 @@ $ rustup target add wasm32-wasi
 
 {{ startTab "TypeScript" }}
 
-> If you used the installer script above, the `js2wasm` plugin is already installed, and you can skip this section!
-
-You'll need the Spin `js2wasm` plugin:
-
-<!-- @selectiveCpy -->
-
-```bash
-$ spin plugins update
-$ spin plugins install js2wasm --yes
-```
+You will need `npm` installed and on the path.  `npm` will install any additional build tools as part of building the application.
 
 [Learn more in the language guide.](javascript-components)
 
@@ -410,18 +401,15 @@ Now let's have a look at the code. Below is the complete source
 code for a Spin HTTP component written in TypeScript — a regular function named `handleRequest` that
 takes an HTTP request as a parameter and returns an HTTP response.  (The
 JavaScript version looks slightly different, but is still a function with
-the same signature.)  The Spin `js2wasm` plugin looks for the `handleRequest` function
+the same signature.)  The Spin integration looks for the `handler` function
 by name when building your application into a Wasm module:
 
 ```javascript
-import { HandleRequest, HttpRequest, HttpResponse } from "@fermyon/spin-sdk"
+import { ResponseBuilder } from "@fermyon/spin-sdk";
 
-export const handleRequest: HandleRequest = async function (request: HttpRequest): Promise<HttpResponse> {
-  return {
-    status: 200,
-    headers: { "content-type": "text/plain" },
-    body: "Hello from TS-SDK"
-  }
+export async function handler(req: Request, res: ResponseBuilder) {
+    console.log(req);
+    res.send("hello universe");
 }
 ```
 
@@ -743,7 +731,7 @@ $ spin build
 Executing the build command for component hello-typescript: npm run build
 
 > hello-typescript@1.0.0 build
-> npx webpack --mode=production && mkdir -p target && spin js2wasm -o target/spin-http-js.wasm dist/spin.js
+> npx webpack --mode=production && npx mkdirp target && npx j2w -i dist.js -d combined-wit -n combined -o target/hello-typescript.wasm
 
 asset spin.js 4.57 KiB [emitted] (name: main)
 runtime modules 670 bytes 3 modules
@@ -761,7 +749,6 @@ If the build fails, check:
 
 * Are you in the `hello_typescript` directory?
 * Did you run `npm install` before building`?
-* Did you install the `js2wasm` plugin?
 
 If you would like to know what build command Spin runs for a component, you can find it in the manifest, in the `component.(id).build` section:
 


### PR DESCRIPTION
Fixes #1409.

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title`, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep $'\r' | wc -l` and expect 0 as a result)
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
