### PR TITLE
You can't use selective deployment with wildcard service chaining

### DIFF
--- a/content/spin/v3/http-outbound.md
+++ b/content/spin/v3/http-outbound.md
@@ -218,11 +218,13 @@ You must still grant permission by including the relevant `spin.internal` hosts 
 allowed_outbound_hosts = ["http://authz.spin.internal", "https://reporting.spin.internal"]
 ```
 
-To allow local chaining to _any_ component in your application, use a subdomain wildcard:
+To allow local chaining to _any_ component in your application, you can use a subdomain wildcard:
 
 ```toml
 allowed_outbound_hosts = ["http://*.spin.internal"]
 ```
+
+However, the wildcard implies that the component requires _all other_ components to be local to it. You will therefore not be able to use [selective deployment](./running-apps#splitting-an-application-across-environments) for an application that uses wildcard service chaining.
 
 > Local service chaining is not currently supported on Fermyon Cloud.
 

--- a/content/spin/v3/running-apps.md
+++ b/content/spin/v3/running-apps.md
@@ -188,7 +188,7 @@ $ spin up -f registry.example.com/app:1.1.0 -c chat-engine -c sentiment-analyzer
 
 > In practice you'd set these commands up in a scheduler or orchestrator rather than typing them interactively - or, more likely, use a selection-aware scheduler such as [SpinKube](https://www.spinkube.dev/) rather than running `spin up` directly.
 
-If you run a subset which includes a component that uses [local service chaining](./http-outbound#local-service-chaining), then you must also include all chaining targets in the subset - Spin checks this at load time.  [Self-requests](./http-outbound#making-http-requests-within-an-application) will work only if the target route maps to a component in the subset, but this is not checked at load time - instead, self-requests to unselected components will fail at request time with 404 Not Found.
+If you run a subset which includes a component that uses [local service chaining](./http-outbound#local-service-chaining), then you must also include all chaining targets in the subset - Spin checks this at load time. (Wildcard service chaining - the `*.spin.internal` host - means that _all_ components are potential chaining targets, so you will not be able to use selective deployment if any component uses wildcard service chaining.) [Self-requests](./http-outbound#making-http-requests-within-an-application) will work only if the target route maps to a component in the subset, but this is not checked at load time - instead, self-requests to unselected components will fail at request time with 404 Not Found.
 
 ## The Always Build Option
 


### PR DESCRIPTION
And here's why.

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title`, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep $'\r' | wc -l` and expect 0 as a result)
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
