### PR TITLE
Fix statement that all triggers must be same type

### DIFF
--- a/content/spin/v2/writing-apps.md
+++ b/content/spin/v2/writing-apps.md
@@ -74,7 +74,7 @@ You can look up the various fields in the [Manifest Reference](manifest-referenc
 
 An application contains one or more _triggers_.  Each trigger specifies a type, an event of that type that the application responds to, and a component to handle that event.
 
-> In current versions of Spin, all triggers in the application must be of the same type. You can't listen for Redis messages and HTTP requests in the same application.
+> In Spin 2.2 and below, all triggers in the application must be of the same type. You can't listen for Redis messages and HTTP requests in the same application. This restriction was removed in Spin 2.3.
 
 The description above might sound a bit abstract. Let's clarify it with a concrete example. The most common trigger type is `http`, for which events are distinguished by the route. So an HTTP trigger might look like this:
 

--- a/content/spin/v3/writing-apps.md
+++ b/content/spin/v3/writing-apps.md
@@ -82,8 +82,6 @@ You can look up the various fields in the [Manifest Reference](manifest-referenc
 
 An application contains one or more _triggers_.  Each trigger specifies a type, an event of that type that the application responds to, and a component to handle that event.
 
-> In current versions of Spin, all triggers in the application must be of the same type. You can't listen for Redis messages and HTTP requests in the same application.
-
 The description above might sound a bit abstract. Let's clarify it with a concrete example. The most common trigger type is `http`, for which events are distinguished by the route. So an HTTP trigger might look like this:
 
 ```toml


### PR DESCRIPTION
Fixes #1418.

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title`, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep $'\r' | wc -l` and expect 0 as a result)
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
