### PR TITLE
Update Rust guide to `wasm32-wasip1` target

### DIFF
--- a/content/spin/v3/ai-sentiment-analysis-api-tutorial.md
+++ b/content/spin/v3/ai-sentiment-analysis-api-tutorial.md
@@ -1003,12 +1003,12 @@ route = "/api/..."
 component = "sentiment-analysis-rust"
 
 [component.sentiment-analysis-rust]
-source = "target/wasm32-wasi/release/sentiment_analysis_rust.wasm"
+source = "target/wasm32-wasip1/release/sentiment_analysis_rust.wasm"
 allow_outbound_hosts = []
 ai_models = ["llama2-chat"]
 key_value_stores = ["default"]
 [component.sentiment-analysis-rust.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"
 watch = ["src/**/*.rs", "Cargo.toml"]
 
 [[trigger.http]]

--- a/content/spin/v3/build.md
+++ b/content/spin/v3/build.md
@@ -45,22 +45,24 @@ If you generated the component from a Fermyon-supplied template, the `build` sec
 
 {{ startTab "Rust"}}
 
-For Rust applications, you must have the `wasm32-wasi` target installed:
+For Rust applications, you must have the `wasm32-wasip1` target installed:
 
 <!-- @selectiveCpy -->
 
 ```bash
-$ rustup target add wasm32-wasi
+$ rustup target add wasm32-wasip1
 ```
 
-The build command typically runs `cargo build` with the `wasm32-wasi` target and the `--release` option:
+The build command typically runs `cargo build` with the `wasm32-wasip1` target and the `--release` option:
 
 <!-- @nocpy -->
 
 ```toml
 [component.hello.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"
 ```
+
+> If you are on Rust 1.77 or earlier, use `wasm32-wasi` (without the `p1`). We recommend upgrading to Rust 1.78 or above. Future versions of Rust will not support `wasm32-wasi` (without the `p1`).
 
 {{ blockEnd }}
 
@@ -151,7 +153,7 @@ Once the build commands are set up, running `spin build` will execute, sequentia
 
 ```bash
 $ spin build
-Building component hello with `cargo build --target wasm32-wasi --release`
+Building component hello with `cargo build --target wasm32-wasip1 --release`
     Updating crates.io index
     Updating git repository `https://github.com/fermyon/spin`
 
@@ -194,7 +196,7 @@ To have the Rust build `command` run in directory `deep`, we can set the compone
 ```toml
 [component.deep.build]
 # `command` is the normal build command for this language
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"
 # This tells Spin to run it in the directory of the build file (in this case Cargo.toml)
 workdir = "deep"
 ```

--- a/content/spin/v3/contributing-spin.md
+++ b/content/spin/v3/contributing-spin.md
@@ -49,11 +49,11 @@ soon as possible. First, make sure you have Rust installed.
 
 ![Rust Version](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2Ffermyon%2Fspin%2Fmain%2FCargo.toml&query=$[%27workspace%27][%27package%27][%27rust-version%27]&label=Rust%20Version&logo=Rust&color=orange)
 
-After [installing Rust](https://www.rust-lang.org/tools/install) please ensure the `wasm32-wasi` and
+After [installing Rust](https://www.rust-lang.org/tools/install) please ensure the `wasm32-wasip1` and
   `wasm32-unknown-unknown` targets are configured. For example:
   
 ```bash
-rustup target add wasm32-wasi && rustup target add wasm32-unknown-unknown
+rustup target add wasm32-wasip1 && rustup target add wasm32-unknown-unknown
 ```
 
 In addition, make sure you have the following prerequisites configured:

--- a/content/spin/v3/http-trigger.md
+++ b/content/spin/v3/http-trigger.md
@@ -419,7 +419,7 @@ Wagi supports non-default entry points, and allows you to pass an arguments stri
 ### Request Handling in Wagi
 
 Building a Wagi component in a particular programming language that can compile
-to `wasm32-wasi` does not require any special libraries — instead,
+to `wasm32-wasip1` does not require any special libraries — instead,
 [building Wagi components](https://github.com/deislabs/wagi/tree/main/docs) can
 be done by reading the HTTP request from the standard input and environment
 variables, and sending the HTTP response to the module's standard output.

--- a/content/spin/v3/install.md
+++ b/content/spin/v3/install.md
@@ -218,7 +218,7 @@ $ git clone https://github.com/fermyon/spin
 $ cd spin
 $ # Check out the latest tagged release
 $ # git checkout <latest release>
-$ rustup target add wasm32-wasi
+$ rustup target add wasm32-wasip1
 $ rustup target add wasm32-unknown-unknown
 $ cargo install --locked --path .
 $ spin --help

--- a/content/spin/v3/manifest-reference-v1.md
+++ b/content/spin/v3/manifest-reference-v1.md
@@ -131,7 +131,7 @@ Each table in the `component` array contains the following fields:
 
 | Name                    | Required?  | Type        | Value    | Example   |
 |-------------------------|------------|-------------|----------|-----------|
-| `command`               | Required   | String      | The command to execute on `spin build`. | `"cargo build --target wasm32-wasi --release"` |
+| `command`               | Required   | String      | The command to execute on `spin build`. | `"cargo build --target wasm32-wasip1 --release"` |
 | `workdir`               | Optional   | String      | The directory in which to execute `command`, relative to the manifest file. The default is the directory containing the manifest file. An example of where this is needed is a multi-component application where each component is its own source tree in its own directory. | `"my-project"` |
 | `watch`                 | Optional   | Array of strings | The files or glob patterns which `spin watch` should monitor to determine if the component Wasm file needs to be rebuilt. These are relative to `workdir`, or to the directory containing the manifest file if `workdir` is not present. | `["src/**/*.rs", "Cargo.toml"]` |
 

--- a/content/spin/v3/manifest-reference.md
+++ b/content/spin/v3/manifest-reference.md
@@ -42,10 +42,10 @@ route = "/..."
 component = "spin-manifest-example-in-rust"
 
 [component.spin-manifest-example-in-rust]
-source = "target/wasm32-wasi/release/spin_manifest_example_in_rust.wasm"
+source = "target/wasm32-wasip1/release/spin_manifest_example_in_rust.wasm"
 allowed_outbound_hosts = []
 [component.spin-manifest-example-in-rust.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"
 watch = ["src/**/*.rs", "Cargo.toml"]
 ```
 
@@ -193,7 +193,7 @@ The value of each key is a table with the following fields.
 
 | Name                    | Required?  | Type        | Value    | Example   |
 |-------------------------|------------|-------------|----------|-----------|
-| `command`               | Required   | String      | The command to execute on `spin build`. | `"cargo build --target wasm32-wasi --release"` |
+| `command`               | Required   | String      | The command to execute on `spin build`. | `"cargo build --target wasm32-wasip1 --release"` |
 | `workdir`               | Optional   | String      | The directory in which to execute `command`, relative to the manifest file. The default is the directory containing the manifest file. An example of where this is needed is a multi-component application where each component is its own source tree in its own directory. | `"my-project"` |
 | `watch`                 | Optional   | Array of strings | The files or glob patterns which `spin watch` should monitor to determine if the component Wasm file needs to be rebuilt. These are relative to `workdir`, or to the directory containing the manifest file if `workdir` is not present. | `["src/**/*.rs", "Cargo.toml"]` |
 

--- a/content/spin/v3/quickstart.md
+++ b/content/spin/v3/quickstart.md
@@ -180,12 +180,12 @@ Some languages require additional tool support for Wasm:
 
 {{ startTab "Rust"}}
 
-You'll need the `wasm32-wasi` target for Rust:
+You'll need the `wasm32-wasip1` target for Rust:
 
 <!-- @selectiveCpy -->
 
 ```bash
-$ rustup target add wasm32-wasi
+$ rustup target add wasm32-wasip1
 ```
 
 [Learn more in the language guide.](rust-components)
@@ -295,10 +295,10 @@ route = "/..."
 component = "hello-rust"
 
 [component.hello-rust]
-source = "target/wasm32-wasi/release/hello_rust.wasm"
+source = "target/wasm32-wasip1/release/hello_rust.wasm"
 allowed_outbound_hosts = []
 [component.hello-rust.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"
 watch = ["src/**/*.rs", "Cargo.toml"]
 ```
 
@@ -675,7 +675,7 @@ The Spin template creates starter source code.  Now you need to turn that into a
 
 ```bash
 $ spin build
-Executing the build command for component hello-rust: cargo build --target wasm32-wasi --release
+Executing the build command for component hello-rust: cargo build --target wasm32-wasip1 --release
     Updating crates.io index
     Updating git repository `https://github.com/fermyon/spin`
     Updating git repository `https://github.com/bytecodealliance/wit-bindgen`
@@ -691,14 +691,16 @@ Finished building all Spin components
 If the build fails, check:
 
 * Are you in the `hello_rust` directory?
-* Did you successfully [install the `wasm32-wasi` target](#install-the-tools)?
-* Is your version of Rust up to date (`cargo --version`)?  The Spin SDK needs Rust 1.64 or above.
+* Did you successfully [install the `wasm32-wasip1` target](#install-the-tools)?
+* Is your version of Rust up to date (`cargo --version`)?  The Spin SDK needs Rust 1.78 or above.
+
+> The Rust target used to be called `wasm32-wasi` (without the `p1`). Even if you already installed the old target, you'll need to install the new one!
 
 If you would like to know what build command Spin runs for a component, you can find it in the manifest, in the `component.(id).build` section:
 
 ```toml
 [component.hello-rust.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"
 ```
 
 You can always run this command manually; `spin build` is a shortcut to save you having to remember it.

--- a/content/spin/v3/running-apps.md
+++ b/content/spin/v3/running-apps.md
@@ -118,7 +118,7 @@ If any of these change, Spin will rebuild the application if necessary, then res
 
 > Spin watch does not consider changes to a file's metadata (file permissions or when it was last modified) as a change.
 
-The following `spin.toml` configuration (belonging to a Spin `http-rust` application) is configured to ensure that the application is both **rebuilt** (via `cargo build --target wasm32-wasi --release`) and **rerun** whenever changes occur in any Rust source (`.rs`) files, the `Cargo.toml` file or the `spin.toml` file, itself. When changes occur in either the Wasm binary file (`target/wasm32-wasi/release/test.wasm`) or the text file (`my-files/changing-file.txt`) the application is only **rerun** using the initial `spin up` command:
+The following `spin.toml` configuration (belonging to a Spin `http-rust` application) is configured to ensure that the application is both **rebuilt** (via `cargo build --target wasm32-wasip1 --release`) and **rerun** whenever changes occur in any Rust source (`.rs`) files, the `Cargo.toml` file or the `spin.toml` file, itself. When changes occur in either the Wasm binary file (`target/wasm32-wasip1/release/test.wasm`) or the text file (`my-files/changing-file.txt`) the application is only **rerun** using the initial `spin up` command:
 
 <!-- @nocpy -->
 

--- a/content/spin/v3/rust-components.md
+++ b/content/spin/v3/rust-components.md
@@ -65,15 +65,30 @@ Note: The Rust templates are in a repo that contains several other languages; th
 
 ### Install the Tools
 
-To build Spin components, you'll need the `wasm32-wasi` target for Rust.
+To build Spin components, you'll need the `wasm32-wasip1` target for Rust.
 
 <!-- @selectiveCpy -->
 
 ```bash
-$ rustup target add wasm32-wasi
+$ rustup target add wasm32-wasip1
 ```
 
-> If you get a lot of strange errors when you try to build your first Rust component, check that you have this target installed by running `rustup target list --installed`. This is the most common source of problems when starting out with Rust in Spin!
+> If you originally installed your Wasm target in an older version of Rust, it may be called `wasm32-wasi` (without the `p1`). This target is being withdrawn. Upgrade to Rust 1.78 or above, and install the `wasm32-wasip1` target.
+
+If you don't have the target installed, then when you try to build a Spin component, you'll see an error similar to this:
+
+```
+error[E0463]: can't find crate for `core`
+  |
+  = note: the `wasm32-wasip1` target may not be installed
+  = help: consider downloading the target with `rustup target add wasm32-wasip1`
+
+For more information about this error, try `rustc --explain E0463`.
+```
+
+Check that you have the WASI target installed by running `rustup target list --installed`, or follow the instructions in the message and run `rustup target add wasm32-wasip1`. This is the most common source of problems when starting out with Rust in Spin!
+
+> If you have an existing project with the `wasm32-wasi` target and migrate it to `wasm32-wasip1`, be sure to update each component path (`source`) at the same time as you change the build command. If you're rebuilding but your changes aren't showing up at runtime, check your `source` isn't pointing to the old path!
 
 ## HTTP Components
 
@@ -148,7 +163,7 @@ The component can be built with Cargo by executing:
 <!-- @selectiveCpy -->
 
 ```bash
-$ cargo build --target wasm32-wasi --release
+$ cargo build --target wasm32-wasip1 --release
 ```
 
 The manifest for a Redis application must contain the address of the Redis
@@ -166,7 +181,7 @@ address = "redis://localhost:6379"
 
 [[trigger.redis]]
 channel = "messages"
-component = { source = "target/wasm32-wasi/release/spinredis.wasm" }
+component = { source = "target/wasm32-wasip1/release/spinredis.wasm" }
 ```
 
 This application will connect to `redis://localhost:6379`, and for every new
@@ -254,7 +269,7 @@ route = "/..."
 component = "get-animal-fact"
 
 [component.get-animal-fact]
-source = "get-animal-fact/target/wasm32-wasi/release/get_animal_fact.wasm"
+source = "get-animal-fact/target/wasm32-wasip1/release/get_animal_fact.wasm"
 allowed_outbound_hosts = ["https://random-data-api.fermyon.app"]
 ```
 
@@ -504,8 +519,8 @@ Spin provides clients for MySQL and PostgreSQL. For information about using them
 ## Using External Crates in Rust Components
 
 In Rust, Spin components are regular libraries that contain a function
-annotated using the `http_component` macro, compiled to the `wasm32-wasi` target.
-This means that any [crate](https://crates.io) that compiles to `wasm32-wasi` can
+annotated using the `http_component` macro, compiled to the `wasm32-wasip1` target.
+This means that any [crate](https://crates.io) that compiles to `wasm32-wasip1` can
 be used when implementing the component.
 
 ### Using the `http` crate
@@ -551,13 +566,14 @@ If you bump into issues building and running your Rust component, here are some 
 
   - To check: run  `cargo --version`.  
   - To update: run `rustup update`.
-- Make sure the `wasm32-wasi` compiler target is installed.
-  - To check: run `rustup target list --installed` and check that `wasm32-wasi` is on the list.
-  - To install: run `rustup target add wasm32-wasi`.
+- Make sure the `wasm32-wasip1` compiler target is installed.
+  - To check: run `rustup target list --installed` and check that `wasm32-wasip1` is on the list.
+  - To install: run `rustup target add wasm32-wasip1`.
 - Make sure you are building in `release` mode.  Spin manifests refer to your Wasm file by a path, and the default path corresponds to `release` builds.
-  - To build manually: run `cargo build --release --target wasm32-wasi`.
+  - To build manually: run `cargo build --release --target wasm32-wasip1`.
   - If you're using `spin build` and the templates, this should be set up correctly for you.
-- Make sure that the `source` field in the component manifest match the path and name of the Wasm file in `target/wasm32-wasi/release`. These could get out of sync if you renamed the Rust package in its `Cargo.toml`.
+- Make sure that the `source` field in the component manifest match the path and name of the Wasm file in `target/wasm32-wasip1/release`. These could get out of sync if you renamed the Rust package in its `Cargo.toml`.
+  - They can also get out of sync if you switched an existing project from the old `wasm32-wasi` target to the new `wasm32-wasip1` target.
 
 ## Manually Creating New Projects With Cargo
 

--- a/content/spin/v3/serverless-ai-hello-world.md
+++ b/content/spin/v3/serverless-ai-hello-world.md
@@ -213,11 +213,11 @@ route = "/..."
 component = "hello-world"
 
 [component.hello-world]
-source = "target/wasm32-wasi/release/hello_world.wasm"
+source = "target/wasm32-wasip1/release/hello_world.wasm"
 allowed_outbound_hosts = []
 ai_models = ["llama2-chat"]
 [component.hello-world.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"
 watch = ["src/**/*.rs", "Cargo.toml"]
 ```
  

--- a/content/spin/v3/spin-application-structure.md
+++ b/content/spin/v3/spin-application-structure.md
@@ -150,10 +150,10 @@ route = "/first/..."
 component = "first-http-rust-component"
 
 [component.first-http-rust-component]
-source = "first-http-rust-component/target/wasm32-wasi/release/first_http_rust_component.wasm"
+source = "first-http-rust-component/target/wasm32-wasip1/release/first_http_rust_component.wasm"
 allowed_outbound_hosts = []
 [component.first-http-rust-component.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"
 workdir = "first-http-rust-component"
 watch = ["src/**/*.rs", "Cargo.toml"]
 
@@ -162,10 +162,10 @@ route = "/second/..."
 component = "second-http-rust-component"
 
 [component.second-http-rust-component]
-source = "second-http-rust-component/target/wasm32-wasi/release/second_http_rust_component.wasm"
+source = "second-http-rust-component/target/wasm32-wasip1/release/second_http_rust_component.wasm"
 allowed_outbound_hosts = []
 [component.second-http-rust-component.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"
 workdir = "second-http-rust-component"
 watch = ["src/**/*.rs", "Cargo.toml"]
 

--- a/content/spin/v3/testing-apps.md
+++ b/content/spin/v3/testing-apps.md
@@ -208,7 +208,7 @@ Then we edit the `my-app` application's manifest (the `spin.toml` file) by addin
 
 ```toml
 [component.my-component.tool.spin-test]
-source = "tests/target/wasm32-wasi/release/tests.wasm"
+source = "tests/target/wasm32-wasip1/release/tests.wasm"
 build = "cargo component build --release"
 dir = "tests"
 ```
@@ -248,16 +248,16 @@ route = "/..."
 component = "my-component"
 
 [component.my-component]
-source = "my-component/target/wasm32-wasi/release/my_component.wasm"
+source = "my-component/target/wasm32-wasip1/release/my_component.wasm"
 allowed_outbound_hosts = []
 key_value_stores = ["default"]
 [component.my-component.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"
 workdir = "my-component"
 watch = ["src/**/*.rs", "Cargo.toml"]
 
 [component.my-component.tool.spin-test]
-source = "tests/target/wasm32-wasi/release/tests.wasm"
+source = "tests/target/wasm32-wasip1/release/tests.wasm"
 build = "cargo component build --release"
 dir = "tests"
 ```

--- a/content/spin/v3/triggers.md
+++ b/content/spin/v3/triggers.md
@@ -39,11 +39,11 @@ An application manifest can define _named_ components in the `component` section
 
 ```toml
 [component.checkout]  # The component's name is "checkout"
-source = "target/wasm32-wasi/release/checkout.wasm"
+source = "target/wasm32-wasip1/release/checkout.wasm"
 allowed_outbound_hosts = ["https://payment-processing.example.com"]
 key_value_stores = ["default"]
 [component.checkout.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"
 ```
 
 To map a trigger to a named component, specify its name in the trigger's `component` field:
@@ -68,7 +68,7 @@ component = { source = "dist/cart.wasm" }
 [[trigger.http]]
 route = "/cart/..."
 [trigger.http.component]
-source = "target/wasm32-wasi/release/checkout.wasm"
+source = "target/wasm32-wasip1/release/checkout.wasm"
 allowed_outbound_hosts = ["payment-processing.example.com"]
 ```
 
@@ -133,10 +133,10 @@ route = "/..."
 component = "rust-http-trigger-example"
 
 [component.rust-http-trigger-example]
-source = "rust-http-trigger-example/target/wasm32-wasi/release/rust_http_trigger_example.wasm"
+source = "rust-http-trigger-example/target/wasm32-wasip1/release/rust_http_trigger_example.wasm"
 allowed_outbound_hosts = []
 [component.rust-http-trigger-example.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"
 workdir = "rust-http-trigger-example"
 watch = ["src/**/*.rs", "Cargo.toml"]
 
@@ -148,10 +148,10 @@ channel = "one"
 component = "rust-redis-trigger-example"
 
 [component.rust-redis-trigger-example]
-source = "rust-redis-trigger-example/target/wasm32-wasi/release/rust_redis_trigger_example.wasm"
+source = "rust-redis-trigger-example/target/wasm32-wasip1/release/rust_redis_trigger_example.wasm"
 allowed_outbound_hosts = []
 [component.rust-redis-trigger-example.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"
 workdir = "rust-redis-trigger-example"
 watch = ["src/**/*.rs", "Cargo.toml"]                             
 ```
@@ -246,7 +246,7 @@ We can immediately run this pre-written (template) application and observe the t
 cd hello_cron
 spin build --up
 
-Building component hello-cron with `cargo build --target wasm32-wasi --release`
+Building component hello-cron with `cargo build --target wasm32-wasip1 --release`
 
 ...
 

--- a/content/spin/v3/writing-apps.md
+++ b/content/spin/v3/writing-apps.md
@@ -70,10 +70,10 @@ component = "hello"
 [component.hello]
 description = "A simple component that returns hello world."
 # The Wasm module to run for the component
-source = "target/wasm32-wasi/release/helloworld.wasm"
+source = "target/wasm32-wasip1/release/helloworld.wasm"
 # How to build the Wasm module from source
 [component.hello.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"
 ```
 
 You can look up the various fields in the [Manifest Reference](manifest-reference), but let's look at the key fields in more detail.


### PR DESCRIPTION
The docs side of https://github.com/fermyon/spin/issues/2925

There's a lot of clutter in this PR due to updating tutorials, examples, etc.  Sorry.  The meat of it is the quickstart, build page, and language guide.

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title`, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep $'\r' | wc -l` and expect 0 as a result)
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
