### PR TITLE
fix: question mark for placeholder does not work

### DIFF
--- a/content/spin/v3/rdbms-storage.md
+++ b/content/spin/v3/rdbms-storage.md
@@ -99,7 +99,7 @@ export async function handler(_req: Request, res: ResponseBuilder) {
     res.send(JSON.stringify(ret, null, 2));
   } catch (error) {
     console.log(error.payload);
-	res.send({});
+	res.send('{}');
   }
 }
 ```

--- a/content/spin/v3/rdbms-storage.md
+++ b/content/spin/v3/rdbms-storage.md
@@ -89,13 +89,18 @@ const DB_URL = "mysql://root:@127.0.0.1/spin_dev"
 */
 
 export async function handler(_req: Request, res: ResponseBuilder) {
-  let conn = Mysql.open(DB_URL);
-  conn.execute('delete from test where id=$1', [4]);
-  conn.execute('insert into test values (4,5)', []);
-  let ret = conn.query('select * from test', []);
-  // return a object that looks like 
-  // { "columns": [{name: "id", dataType: "int32"}], "rows": [{ "id": 4, "val": 5 }] }
-  res.send(JSON.stringify(ret, null, 2));
+  try {
+    let conn = Mysql.open(DB_URL);
+    conn.execute('delete from test where id=$1', [4]);
+    conn.execute('insert into test values (4,5)', []);
+    let ret = conn.query('select * from test', []);
+    // return a object that looks like 
+    // { "columns": [{name: "id", dataType: "int32"}], "rows": [{ "id": 4, "val": 5 }] }
+    res.send(JSON.stringify(ret, null, 2));
+  } catch (error) {
+    console.log(error.payload);
+	res.send({});
+  }
 }
 ```
 

--- a/content/spin/v3/rdbms-storage.md
+++ b/content/spin/v3/rdbms-storage.md
@@ -91,7 +91,7 @@ const DB_URL = "mysql://root:@127.0.0.1/spin_dev"
 export async function handler(_req: Request, res: ResponseBuilder) {
   try {
     let conn = Mysql.open(DB_URL);
-    conn.execute('delete from test where id=$1', [4]);
+    conn.execute('delete from test where id=?', [4]);
     conn.execute('insert into test values (4,5)', []);
     let ret = conn.query('select * from test', []);
     // return a object that looks like 

--- a/content/spin/v3/rdbms-storage.md
+++ b/content/spin/v3/rdbms-storage.md
@@ -90,7 +90,7 @@ const DB_URL = "mysql://root:@127.0.0.1/spin_dev"
 
 export async function handler(_req: Request, res: ResponseBuilder) {
   let conn = Mysql.open(DB_URL);
-  conn.execute('delete from test where id=?', [4]);
+  conn.execute('delete from test where id=$1', [4]);
   conn.execute('insert into test values (4,5)', []);
   let ret = conn.query('select * from test', []);
   // return a object that looks like 


### PR DESCRIPTION
# fix: question mark for placeholder does not work

If I follow the example with a question mark for a placeholder then this exception is thrown.

```ts
connection.execute("delete from tb_test where id=?", ['test3']);
```

```ts
"[object Object]" is not one of the cases of error
```

or this with a try-catch

error:
```ts
(new Error("[object Object] (see error.payload)", "dist.bindings.js", 157))
```
error.payload:
```ts
{ tag: "query-failed", val: "Error { kind: Db, cause: Some(DbError { severity: "ERROR", parsed_severity: Some(Error), code: SqlState(E42601), message: "syntax error at end of input", detail: None, hint: None, position: Some(Original(35)), where_: None, schema: None, table: None, column: None, datatype: None, constraint: None, file: Some("scan.l"), line: Some(1240), routine: Some("scanner_yyerror") }) }" }
```

## environment

- spin: 3.0.0
- macos
- postgresql 17
- target: wasm32-wasip1