### PR TITLE
Remove `wasm.builders` links

### DIFF
--- a/content/wasm-languages/javascript.md
+++ b/content/wasm-languages/javascript.md
@@ -106,7 +106,6 @@ The Wasm binary can be found at `target/javascript-example.wasm`.
 Here are some great resources:
 
 - Shopify has created an easy-to-use builder that uses QuickJS. It is called [Javy](https://github.com/Shopify/javy)
-- A short article on Wasm.Builders covers [JavaScript, MessagePack, and Javy](https://www.wasm.builders/deepanshu1484/javascript-and-wasi-24k8)
 - Bytecode Alliance's [builder for Spidermonkey](https://github.com/bytecodealliance/spidermonkey-wasm-build) provides binary releases
 - [QuickJS](https://bellard.org/quickjs/) is a tiny JavaScript runtime that can be compiled to Wasm.
 - [Making JavaScript Run Fast on WebAssembly](https://bytecodealliance.org/articles/making-javascript-run-fast-on-webassembly) from Bytecode Alliance explains how SpiderMonkey and Wasm work together.

--- a/content/wasm-languages/python.md
+++ b/content/wasm-languages/python.md
@@ -175,7 +175,6 @@ Joel's video on Spin, Python, and Components (Recorded at WasmCon on Sep 12, 202
 
 Here are some great resources:
 - A tutorial for building [Python Wasm apps with Spin](https://dev.to/technosophos/building-a-serverless-webassembly-app-with-spin-5dh9)
-- A tutorial doing [AI inferencing with Python and Spin](https://www.wasm.builders/technosophos/serverless-ai-inferencing-with-python-and-wasm-3lkd)
 - The [Spin Python SDK](https://github.com/fermyon/spin-python-sdk)
 - The [Spin Developer Docs](../spin) fully document the Python SDKs
 - [Python Wasm examples](../../hub/index) at Spin Hub


### PR DESCRIPTION
The site appears defunct, giving invalid SSL certificate errors and triggering ad blockers willy nilly.  We should avoid linking to it unless it reactivates.

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title`, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep $'\r' | wc -l` and expect 0 as a result)
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
