### PR TITLE
Add Rust installation links and guidance to bart quickstart

### DIFF
--- a/content/bartholomew/quickstart.md
+++ b/content/bartholomew/quickstart.md
@@ -84,7 +84,7 @@ Creating content is made easy with the Bartholomew Command Line Interface (CLI) 
 
 For the `bart` CLI, there are two options:
 - download the latest `bart` binary [release](https://github.com/fermyon/bartholomew/releases/) and add it to your system path, or
-- clone and build `bart` from source (requires Rust), using the following commands:
+- clone and build `bart` from source (requires [Rust](https://www.rust-lang.org/tools/install)), using the following commands:
 
 <!-- @selectiveCpy -->
 
@@ -98,6 +98,8 @@ $ cd bartholomew
 # Build the Bartholomew CLI
 $ make bart
 ```
+
+> If `make bart` fails with `make: cargo: No such file or directory`, you need to [install Rust from this link](https://www.rust-lang.org/tools/install).
 
 > NOTE: The procedure in the example code block above will create the `bart` executable binary file inside the `~/bartholomew/target/release/` directory. Please ensure that this new binary executable is added to your system path.
 


### PR DESCRIPTION
Part of fix for https://github.com/fermyon/feedback/issues/57

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title`, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep $'\r' | wc -l` and expect 0 as a result)
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
