### PR TITLE
Fixed documentation Go example

### DIFF
--- a/content/spin/v3/key-value-store-tutorial.md
+++ b/content/spin/v3/key-value-store-tutorial.md
@@ -316,6 +316,7 @@ class IncomingHandler(http.IncomingHandler):
                     return Response(404, {"content-type": "text/plain"})
                 case default:
                     return Response(405, {"content-type": "text/plain"})
+```
 
 {{ blockEnd }}
 


### PR DESCRIPTION
Fixed documentation: Go example was missing because it was inside Python's one

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [x] The `title`, `template`, and `date` are all set
- [x] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [x] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep $'\r' | wc -l` and expect 0 as a result)
- [x] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [x] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [x] Headings are using Title Case
- [x] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [x] Have tested with `npm run test` and resolved all errors
- [x] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
