### PR TITLE
Mention pluginify in plugin authoring docs

### DIFF
--- a/content/spin/v3/plugin-authoring.md
+++ b/content/spin/v3/plugin-authoring.md
@@ -134,6 +134,8 @@ $ spin plugin install --file practice.json
 $ spin practice
 ```
 
+> While developing a plugin, you can [use the `pluginify` plugin to automate packaging and installation](https://developer.fermyon.com/hub/preview/plugin_spin_pluginify) for testing in the Spin environment. This saves going through the package-manifest-install cycle every time you want to try an update!
+
 ### Contributing a Plugin
 
 If you think the community would benefit from your newly created plugin, create


### PR DESCRIPTION
Fixes #1386.  @michelleN I wasn't quite sure how to fit it into the explanation of the packaging flow and I think this might be too far into the "where no-one can find it" zone.  Although in practice I think most plugin devs will find out about it by copying other plugins rather than by reading the docs so 🤷.  What do you reckon?

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title`, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep $'\r' | wc -l` and expect 0 as a result)
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
