### PR TITLE
Remove js2wasm from language guide

### DIFF
--- a/content/wasm-languages/javascript.md
+++ b/content/wasm-languages/javascript.md
@@ -35,14 +35,7 @@ The Spin SDK makes it very easy to build Javascript/TypeScript Wasm applications
 
 ### Prerequisites
 
-If you have not done so already, please [install Spin](/spin/v2/install). Having Spin installed will allow us to easily use js2wasm and Spin application templates.
-
-### Js2Wasm 
-
-```console
-$ spin plugin update
-$ spin plugin install js2wasm
-```
+If you have not done so already, please [install Spin](/spin/v3/install). Having Spin installed will allow us to easily use Spin application templates.
 
 ### The Spin JS/TS SDK Template
 
@@ -69,13 +62,11 @@ $ spin new -t http-js javascript-example --accept-defaults
 Take a look at the scaffolded program in `javascript-example/src/index.js`:
 
 ```javascript
-export async function handleRequest(request) {
+import { ResponseBuilder } from "@fermyon/spin-sdk";
 
-    return {
-        status: 200,
-        headers: { "content-type": "text/plain" },
-        body: "Hello from JS-SDK"
-    }
+export async function handler(req, res) {
+    console.log(req);
+    res.send("hello universe");
 }
 ```
 
@@ -96,7 +87,7 @@ Test it with `curl`:
 
 ```console
 $ curl localhost:3000/
-Hello from JS-SDK
+hello universe
 ```
 
 The Wasm binary can be found at `target/javascript-example.wasm`.


### PR DESCRIPTION
There is additional work to be done on the contextual material, which is very out of date, but that needs input from @karthik2804 and/or @tschneidereit, so I am deferring that to a separate PR.

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title`, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep $'\r' | wc -l` and expect 0 as a result)
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
