### PR TITLE
Install templates from tarball

### DIFF
--- a/content/spin/v3/managing-templates.md
+++ b/content/spin/v3/managing-templates.md
@@ -10,6 +10,7 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/v3/managing-t
   - [Installing From the Spin Git Repository](#installing-from-the-spin-git-repository)
   - [Installing From a Specific Branch](#installing-from-a-specific-branch)
   - [Installing From a Local Directory](#installing-from-a-local-directory)
+  - [Installing From a Remote Tarball](#installing-from-a-remote-tarball)
 - [Viewing Your Installed Templates](#viewing-your-installed-templates)
 - [Uninstalling Templates](#uninstalling-templates)
 - [Upgrading Templates](#upgrading-templates)
@@ -70,6 +71,18 @@ $ spin templates install --dir ~/dev/spin-befunge-sdk
 ```
 
 See [Template Authoring](template-authoring) for more details on this layout.
+
+### Installing From a Remote Tarball
+
+To install templates from a remote tarball, run `spin templates install --tar`.
+
+> The tarball must have a `/templates` directory at its root, _or_ have a single root directory and have a `templates` directory within that. This slightly complicated rule is so that it works correctly with a GitHub release tarball, which always has a root directory named after the release.
+
+<!-- @selectiveCpy -->
+
+```bash
+$ spin templates install --tar https://github.com/fermyon/spin/archive/refs/tags/v9.8.7.tar.gz
+```
 
 ## Viewing Your Installed Templates
 


### PR DESCRIPTION
Late breaking 3.1 feature!

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title`, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep $'\r' | wc -l` and expect 0 as a result)
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
