### PR TITLE
Remove stuff about Spin debug logs from quickstart

### DIFF
--- a/content/spin/v3/quickstart.md
+++ b/content/spin/v3/quickstart.md
@@ -867,16 +867,6 @@ Available Routes:
   hello-typescript: http://127.0.0.1:3000 (wildcard)
 ```
 
-If you would like to see what Spin is doing under the hood, set the RUST_LOG environment variable for detailed logs, before running `spin up`:
-
-<!-- @selectiveCpy -->
-
-```bash
-$ export RUST_LOG=spin=trace
-```
-
-> The variable is `RUST_LOG` no matter what language your application is written in, because this is setting the log level for Spin itself.
-
 Spin instantiates all components from the application manifest, and
 creates the router configuration for the HTTP trigger according to the routes in the manifest. The
 component can now be invoked by making requests to `http://localhost:3000/`
@@ -895,6 +885,8 @@ Hello, Fermyon
 ```
 
 > The `curl` output may vary based on which language SDK you use. 
+
+You'll also see any logging (stdout/stderr) from the generated code printed to the console where Spin is running. For more details, see the [page about running Spin applications](./running-apps.md).
 
 Congratulations! You just created, built and ran your first Spin application!
 

--- a/content/spin/v3/troubleshooting-application-dev.md
+++ b/content/spin/v3/troubleshooting-application-dev.md
@@ -44,3 +44,15 @@ If `spin doctor` detects a problem it can fix, you can choose to accept the fix,
 ## Spin Test
 
 The [spin test plugin](https://github.com/fermyon/spin-test) allows you to write test scenarios for your application's business logic. For more information, see [testing applications](./testing-apps.md).
+
+## Viewing Spin Debug Logs
+
+If you need to follow what Spin is doing internally, set the RUST_LOG environment variable for detailed logs, before running `spin up`:
+
+<!-- @selectiveCpy -->
+
+```bash
+$ export RUST_LOG=spin=trace
+```
+
+> The variable is `RUST_LOG` no matter what language your application is written in, because this is setting the log level for Spin itself.


### PR DESCRIPTION
Fixes #1459 

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title`, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep $'\r' | wc -l` and expect 0 as a result)
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
