### PR TITLE
Mention `spin watch` in quickstart

### DIFF
--- a/content/spin/v3/quickstart.md
+++ b/content/spin/v3/quickstart.md
@@ -867,6 +867,8 @@ Available Routes:
   hello-typescript: http://127.0.0.1:3000 (wildcard)
 ```
 
+> You can also run a Spin application using `spin watch`. This automatically rebuilds code and reloads content whenever they change. [Learn more.](./running-apps.md#monitoring-applications-for-changes)
+
 Spin instantiates all components from the application manifest, and
 creates the router configuration for the HTTP trigger according to the routes in the manifest. The
 component can now be invoked by making requests to `http://localhost:3000/`


### PR DESCRIPTION
Fixes #1458 

I'm not ecstatic about the flow here - I kinda want the quick start to focus on giving users a clear and unambuguous route to success, rather than on suggesting other ways to do things.  On the other hand, we bought ourselves a butt-ton of complexity budget by getting rid of the stuff about `RUST_LOG` so may as well spend it on something useful.

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title`, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep $'\r' | wc -l` and expect 0 as a result)
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
