### PR TITLE
Exclude coreutils page from link checking

### DIFF
--- a/.build/check-broken-links.sh
+++ b/.build/check-broken-links.sh
@@ -84,6 +84,7 @@ blc --recursive http://127.0.0.1:3000                                           
     --exclude 'https://linux.die.net/man/1/which'                                                                                                                                           \
                                                                                                                                                                                             \
     `## false positives`                                                                                                                                                                    \
+    --exclude 'https://www.gnu.org/software/coreutils/'                                                                                                                                     \
     --exclude 'https://events.hashicorp.com/hashitalksdeploy'                                                                                                                               \
     --exclude 'https://dotnet.microsoft.com/en-us/download/dotnet/8.0'                                                                                                                      \
     --exclude 'https://www.developerweek.com/'                                                                                                                                              \


### PR DESCRIPTION
I don't know why it fails.  curl from local machine shows a 200.  Onto the list of shame it goes.

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title`, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep $'\r' | wc -l` and expect 0 as a result)
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
