### PR TITLE
Show how to use a different port in the quickstart

### DIFF
--- a/content/spin/v3/quickstart.md
+++ b/content/spin/v3/quickstart.md
@@ -867,6 +867,8 @@ Available Routes:
   hello-typescript: http://127.0.0.1:3000 (wildcard)
 ```
 
+> If another program is using port 3000, add the `--listen` flag. E.g. `spin up --listen 127.0.0.1:12345`.
+
 > You can also run a Spin application using `spin watch`. This automatically rebuilds code and reloads content whenever they change. [Learn more.](./running-apps.md#monitoring-applications-for-changes)
 
 Spin instantiates all components from the application manifest, and


### PR DESCRIPTION
We had feedback that the quickstart was useless if another program was using port 3000 (we gave the user the impression that port 3000 was hardwired rather than a default).  I'm wary of trying to cover every option in the quickstart (I'd like it to remain focused on the "quick" and "start", and we're already jimmying in `spin watch` in this section), but let's see how this feels...

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title`, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep $'\r' | wc -l` and expect 0 as a result)
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
