### PR TITLE
update spin v2 docs to point at sdk-v2 branch for JS

### DIFF
--- a/content/spin/v2/ai-sentiment-analysis-api-tutorial.md
+++ b/content/spin/v2/ai-sentiment-analysis-api-tutorial.md
@@ -60,7 +60,7 @@ The above installation script automatically installs the latest SDKs for Rust (w
 <!-- @selectiveCpy -->
 
 ```bash
-$ spin templates install --git https://github.com/fermyon/spin-js-sdk --upgrade
+$ spin templates install --git https://github.com/fermyon/spin-js-sdk --upgrade --branch sdk-v2
 ```
 
 **Python**

--- a/content/spin/v2/http-outbound.md
+++ b/content/spin/v2/http-outbound.md
@@ -102,7 +102,7 @@ const response = await fetch("https://example.com/users");
 
 **Notes**
 
-You can find a complete example of using outbound HTTP in the JavaScript SDK repository on [GitHub](https://github.com/fermyon/spin-js-sdk/tree/main/examples/common-patterns/outbound-http)
+You can find a complete example of using outbound HTTP in the JavaScript SDK repository on [GitHub](https://github.com/fermyon/spin-js-sdk/tree/sdk-v2/examples/common-patterns/outbound-http)
 
 **Note**: `fetch` currently only works when building for the HTTP trigger.  
 

--- a/content/spin/v2/install.md
+++ b/content/spin/v2/install.md
@@ -263,7 +263,7 @@ Spin JS SDK:
 <!-- @selectiveCpy -->
 
 ```bash
-$ spin templates install --git https://github.com/fermyon/spin-js-sdk --upgrade
+$ spin templates install --git https://github.com/fermyon/spin-js-sdk --upgrade --branch sdk-v2
 ```
 
 To list installed templates, run:

--- a/content/spin/v2/javascript-components.md
+++ b/content/spin/v2/javascript-components.md
@@ -29,18 +29,18 @@ With JavaScript being a very popular language, Spin provides an SDK to support b
 > This guide assumes you are familiar with the JavaScript programming language,
 > but if you are just getting started, be sure to check [the MDN guide](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide).
 
-> All examples from this page can be found in [the JavaScript SDK repository on GitHub](https://github.com/fermyon/spin-js-sdk/tree/main/examples).
+> All examples from this page can be found in [the JavaScript SDK repository on GitHub](https://github.com/fermyon/spin-js-sdk/tree/sdk-v2/examples).
 
 [**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/)
 
 ## Installing Templates
 
-The JavaScript/TypeScript templates can be installed from [spin-js-sdk repository](https://github.com/fermyon/spin-js-sdk/tree/main/) using the following command:
+The JavaScript/TypeScript templates can be installed from [spin-js-sdk repository](https://github.com/fermyon/spin-js-sdk/tree/sdk-v2/) using the following command:
 
 <!-- @selectiveCpy -->
 
 ```bash
-$ spin templates install --git https://github.com/fermyon/spin-js-sdk --update
+$ spin templates install --git https://github.com/fermyon/spin-js-sdk --update --branch sdk-v2
 ```
 
 which will install the `http-js` and `http-ts` templates:
@@ -238,7 +238,7 @@ proxies or URL shorteners.
 ## Storing Data in Redis From JS/TS Components
 
 > You can find a complete example for using outbound Redis from an HTTP component
-> in the [spin-js-sdk repository on GitHub](https://github.com/fermyon/spin-js-sdk/blob/main/examples/spin-host-apis/spin-redis).
+> in the [spin-js-sdk repository on GitHub](https://github.com/fermyon/spin-js-sdk/blob/sdk-v2/examples/spin-host-apis/spin-redis).
 
 Using the Spin's JS SDK, you can use the Redis key/value store and to publish messages to Redis channels.
 

--- a/content/spin/v2/key-value-store-tutorial.md
+++ b/content/spin/v2/key-value-store-tutorial.md
@@ -76,7 +76,7 @@ $ spin new -t http-rust spin-key-value
 ```bash
 $ spin new -t http-ts spin-key-value
 
-# Reference: https://github.com/fermyon/spin-js-sdk/tree/main/examples/spin-host-apis/spin-kv
+# Reference: https://github.com/fermyon/spin-js-sdk/tree/sdk-v2/examples/spin-host-apis/spin-kv
 ```
 
 {{ blockEnd }}

--- a/content/spin/v2/mqtt-outbound.md
+++ b/content/spin/v2/mqtt-outbound.md
@@ -74,7 +74,7 @@ connection.publish("pets", catPicture, QoS.AtleastOnce);
 
 For full details of the MQTT API, see the [Spin SDK reference documentation](https://fermyon.github.io/spin-js-sdk/modules/Mqtt.html)
 
-You can find a complete Rust code example for using outbound MQTT from an HTTP component in the [Spin Rust SDK repository on GitHub](https://github.com/fermyon/spin-js-sdk/tree/main/examples/spin-host-apis/spin-mqtt).
+You can find a complete Rust code example for using outbound MQTT from an HTTP component in the [Spin Rust SDK repository on GitHub](https://github.com/fermyon/spin-js-sdk/tree/sdk-v2/examples/spin-host-apis/spin-mqtt).
 
 {{ blockEnd }}
 

--- a/content/spin/v2/quickstart.md
+++ b/content/spin/v2/quickstart.md
@@ -116,7 +116,7 @@ Note: The Rust templates are in a repo that contains several other languages; th
 <!-- @selectiveCpy -->
 
 ```bash
-$ spin templates install --git https://github.com/fermyon/spin-js-sdk --update
+$ spin templates install --git https://github.com/fermyon/spin-js-sdk --update --branch sdk-v2
 Copying remote template source
 Installing template http-js...
 Installing template http-ts...

--- a/content/spin/v2/rdbms-storage.md
+++ b/content/spin/v2/rdbms-storage.md
@@ -8,6 +8,7 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/v2/rdbms-stor
 ---
 - [Using MySQL and PostgreSQL From Applications](#using-mysql-and-postgresql-from-applications)
 - [Granting Network Permissions to Components](#granting-network-permissions-to-components)
+	- [Configuration-Based Permissions](#configuration-based-permissions)
 
 Spin provides two interfaces for relational (SQL) databases:
 
@@ -72,7 +73,7 @@ For full information about the MySQL and PostgreSQL APIs, see [the Spin SDK refe
 
 > [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/)
 
-The code below is an [Outbound MySQL example](https://github.com/fermyon/spin-js-sdk/tree/main/examples/spin-host-apis/spin-mysql). There is also an outbound [PostgreSQL example](https://github.com/fermyon/spin-js-sdk/tree/main/examples/spin-host-apis/spin-postgres) available.
+The code below is an [Outbound MySQL example](https://github.com/fermyon/spin-js-sdk/tree/sdk-v2/examples/spin-host-apis/spin-mysql). There is also an outbound [PostgreSQL example](https://github.com/fermyon/spin-js-sdk/tree/sdk-v2/examples/spin-host-apis/spin-postgres) available.
 
 ```ts
 import { ResponseBuilder, Mysql } from '@fermyon/spin-sdk';

--- a/content/spin/v2/redis-outbound.md
+++ b/content/spin/v2/redis-outbound.md
@@ -109,7 +109,7 @@ let value = db.get(key);
 
 * The arguments and results can be either numbers or buffers. (In TypeScript they are union types, e.g. `BigInt | Uint8Array`.)
 
-You can find a complete TypeScript example for using outbound Redis from an HTTP component in the [JavaScript SDK repository on GitHub](https://github.com/fermyon/spin-js-sdk/tree/main/examples/spin-host-apis/spin-redis). Please also see this, related, [outbound Redis (using TypeScript) section](./javascript-components#storing-data-in-redis-from-jsts-components).
+You can find a complete TypeScript example for using outbound Redis from an HTTP component in the [JavaScript SDK repository on GitHub](https://github.com/fermyon/spin-js-sdk/tree/sdk-v2/examples/spin-host-apis/spin-redis). Please also see this, related, [outbound Redis (using TypeScript) section](./javascript-components#storing-data-in-redis-from-jsts-components).
 
 {{ blockEnd }}
 

--- a/content/spin/v2/serverless-ai-hello-world.md
+++ b/content/spin/v2/serverless-ai-hello-world.md
@@ -50,7 +50,7 @@ To enable Serverless AI functionality via TypeScript/Javascript, please ensure y
 <!-- @selectiveCpy -->
  
 ```bash
-$ spin templates install --git https://github.com/fermyon/spin-js-sdk --upgrade
+$ spin templates install --git https://github.com/fermyon/spin-js-sdk --upgrade --branch sdk-v2
 ```
  
 **Python**


### PR DESCRIPTION
Points at sdk-v2 branch for Links to github.com/fermyon/spin-js-sdk as we are preparing for a 3.0.0 release.