### PR TITLE
Document the self.alt pseudo-host for self-requests

### DIFF
--- a/content/spin/v3/http-outbound.md
+++ b/content/spin/v3/http-outbound.md
@@ -7,6 +7,7 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/v3/http-outbo
 
 ---
 - [Using HTTP From Applications](#using-http-from-applications)
+- [Restrictions](#restrictions)
 - [Granting HTTP Permissions to Components](#granting-http-permissions-to-components)
   - [Configuration-Based Permissions](#configuration-based-permissions)
 - [Making HTTP Requests Within an Application](#making-http-requests-within-an-application)
@@ -232,10 +233,14 @@ However, the wildcard implies that the component requires _all other_ components
 
 To make an HTTP request to another route with your application, you can pass just the route as the URL. For example, if you make an outbound HTTP request to `/api/customers/`, Spin prepends the route with whatever host the application is running on. It also replaces the URL scheme (`http` or `https`) with the scheme of the current HTTP request. For example, if the application is running in the cloud, Spin changes `/api` to `https://.../api`.
 
+> You can also use the special host `self.alt` to perform self-requests by route. This is important for the JavaScript `fetch` wrapper, which handles relative requests in a way that doesn't work with `allowed_outbound_hosts`. For example, you would write `fetch('http://self.alt/api')`.
+
 In this way of doing self-requests, the request undergoes normal HTTP processing once Spin has prepended the host. For example, in a cloud deployment, the request passes through the network, and potentially back in through a load balancer or other gateway. The benefit of this is that it allows load to be distributed across the environment, but it may count against your use of bandwidth.
 
-You must still grant permission by including `self` in `allowed_outbound_hosts`:
+You must still grant permission by including `self` or `self.alt` in `allowed_outbound_hosts`:
 
 ```toml
-allowed_outbound_hosts = ["http://self", "https://self"]
+allowed_outbound_hosts = ["http://self", "https://self.alt"]
 ```
+
+> It doesn't matter which you use - either 'allow' form enables both relative and `self.alt` URLs.

--- a/content/spin/v3/javascript-components.md
+++ b/content/spin/v3/javascript-components.md
@@ -11,6 +11,7 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/v3/javascript
 - [Building and Running the Template](#building-and-running-the-template)
 - [HTTP Components](#http-components)
 - [Sending Outbound HTTP Requests](#sending-outbound-http-requests)
+  - [Intra-Application Requests in JavaScript](#intra-application-requests-in-javascript)
 - [Storing Data in Redis From JS/TS Components](#storing-data-in-redis-from-jsts-components)
 - [Routing in a Component](#routing-in-a-component)
 - [Storing Data in the Spin Key-Value Store](#storing-data-in-the-spin-key-value-store)
@@ -155,7 +156,7 @@ The important things to note in the implementation above:
 
 ## Sending Outbound HTTP Requests
 
-If allowed, Spin components can send outbound HTTP requests.
+If allowed, Spin components can send outbound HTTP requests using the `fetch` function.
 Let's see an example of a component that makes a request to [an API that returns random animal facts](https://random-data-api.fermyon.app/animals/json)
 
 ```javascript
@@ -232,6 +233,19 @@ service, manipulates that result, then responds to the original request.
 This can be the basis for building components that communicate with external
 databases or storage accounts, or even more specialized components like HTTP
 proxies or URL shorteners.
+
+### Intra-Application Requests in JavaScript
+
+JavaScript's `fetch` function handles relative URLs in a way that doesn't work well with Spin's fine-grained outbound HTTP permissions.
+Therefore, when [making a request to another route within the same application](./http-outbound#intra-application-http-requests-by-route),
+you must use the special pseudo-host `self.alt` rather than a relative route.  For example:
+
+```javascript
+await fetch('/api');  // Avoid!
+await fetch('http://self.alt/api');  // Prefer!
+```
+
+You must [add `http://self` or `http://self.alt` to the component's `allowed_outbound_hosts`](./http-outbound#intra-application-http-requests-by-route).
 
 ---
 


### PR DESCRIPTION
This will ship in 3.2 - do not merge until then.

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title`, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep $'\r' | wc -l` and expect 0 as a result)
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
