### PR TITLE
Remove broken link to swift package manager

### DIFF
--- a/content/wasm-languages/swift.md
+++ b/content/wasm-languages/swift.md
@@ -118,7 +118,7 @@ Note that we use the `wagi` executor.
 And then, in the same directory, run `spin up`. Once the server is running, you can use either `curl` or a web browser to test it.
 
 ```console
-$ curl localhost:3000                                       
+$ curl localhost:3000
 
 Hello, World!
 ```
@@ -129,7 +129,6 @@ Hello, World!
 
 Here are some great resources:
 
-- It is possible to use the [Swift Package Manager with Wasm](https://book.swiftwasm.org/getting-started/swift-package.html)
 - There is a [Swift Spin SDK](https://github.com/endocrimes/swiftwasm-test) in development.
 - The [SwiftWasm Book](https://book.swiftwasm.org/) has examples and info about compiling to Wasm32+WASI
 - [yo-wasm](https://github.com/deislabs/yo-wasm) supports Swift


### PR DESCRIPTION
The page was removed upstream and merged into the samples.

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title`, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep $'\r' | wc -l` and expect 0 as a result)
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
