### PR TITLE
Update Homebrew installation to use spinframework tap

### DIFF
--- a/content/spin/v1/install.md
+++ b/content/spin/v1/install.md
@@ -34,7 +34,7 @@ Install the Fermyon tap, which Homebrew tracks, updates, and installs Spin from:
 <!-- @selectiveCpy -->
 
 ```bash
-$ brew tap fermyon/tap
+$ brew tap spinframework/tap
 ```
 
 Install Spin:
@@ -42,7 +42,7 @@ Install Spin:
 <!-- @selectiveCpy -->
 
 ```bash
-$ brew install fermyon/tap/spin
+$ brew install spinframework/tap/spin
 ```
 
 > Note: `brew install spin` will **not** install Fermyon's Spin framework. Fermyon Spin is accessed from the `fermyon` tap, as shown above.
@@ -96,7 +96,7 @@ Install the Fermyon tap, which Homebrew tracks, updates, and installs Spin from:
 <!-- @selectiveCpy -->
 
 ```bash
-$ brew tap fermyon/tap
+$ brew tap spinframework/tap
 ```
 
 Install Spin:
@@ -104,7 +104,7 @@ Install Spin:
 <!-- @selectiveCpy -->
 
 ```bash
-$ brew install fermyon/tap/spin
+$ brew install spinframework/tap/spin
 ```
 
 > Note: `brew install spin` will **not** install Fermyon's Spin framework. Fermyon Spin is accessed from the `fermyon` tap, as shown above.

--- a/content/spin/v1/upgrade.md
+++ b/content/spin/v1/upgrade.md
@@ -109,7 +109,7 @@ If you installed Spin using [Homebrew](https://brew.sh/) please use the followin
 
 ```bash
 $ brew update
-$ brew upgrade fermyon/tap/spin
+$ brew upgrade spinframework/tap/spin
 ```
 
 ## Troubleshooting

--- a/content/spin/v2/install.md
+++ b/content/spin/v2/install.md
@@ -33,7 +33,7 @@ Install the Fermyon tap, which Homebrew tracks, updates, and installs Spin from:
 <!-- @selectiveCpy -->
 
 ```bash
-$ brew tap fermyon/tap
+$ brew tap spinframework/tap
 ```
 
 Install Spin:
@@ -41,7 +41,7 @@ Install Spin:
 <!-- @selectiveCpy -->
 
 ```bash
-$ brew install fermyon/tap/spin
+$ brew install spinframework/tap/spin
 ```
 
 > Note: `brew install spin` will **not** install Fermyon's Spin framework. Fermyon Spin is accessed from the `fermyon` tap, as shown above.
@@ -95,7 +95,7 @@ Install the Fermyon tap, which Homebrew tracks, updates, and installs Spin from:
 <!-- @selectiveCpy -->
 
 ```bash
-$ brew tap fermyon/tap
+$ brew tap spinframework/tap
 ```
 
 Install Spin:
@@ -103,7 +103,7 @@ Install Spin:
 <!-- @selectiveCpy -->
 
 ```bash
-$ brew install fermyon/tap/spin
+$ brew install spinframework/tap/spin
 ```
 
 > Note: `brew install spin` will **not** install Fermyon's Spin framework. Fermyon Spin is accessed from the `fermyon` tap, as shown above.

--- a/content/spin/v2/upgrade.md
+++ b/content/spin/v2/upgrade.md
@@ -87,7 +87,7 @@ If you installed Spin using [Homebrew](https://brew.sh/) please use the followin
 
 ```bash
 $ brew update
-$ brew upgrade fermyon/tap/spin
+$ brew upgrade spinframework/tap/spin
 ```
 
 ### Cargo

--- a/content/spin/v3/install.md
+++ b/content/spin/v3/install.md
@@ -33,7 +33,7 @@ Install the Fermyon tap, which Homebrew tracks, updates, and installs Spin from:
 <!-- @selectiveCpy -->
 
 ```bash
-$ brew tap fermyon/tap
+$ brew tap spinframework/tap
 ```
 
 Install Spin:
@@ -41,7 +41,7 @@ Install Spin:
 <!-- @selectiveCpy -->
 
 ```bash
-$ brew install fermyon/tap/spin
+$ brew install spinframework/tap/spin
 ```
 
 > Note: `brew install spin` will **not** install Fermyon's Spin framework. Fermyon Spin is accessed from the `fermyon` tap, as shown above.
@@ -95,7 +95,7 @@ Install the Fermyon tap, which Homebrew tracks, updates, and installs Spin from:
 <!-- @selectiveCpy -->
 
 ```bash
-$ brew tap fermyon/tap
+$ brew tap spinframework/tap
 ```
 
 Install Spin:
@@ -103,7 +103,7 @@ Install Spin:
 <!-- @selectiveCpy -->
 
 ```bash
-$ brew install fermyon/tap/spin
+$ brew install spinframework/tap/spin
 ```
 
 > Note: `brew install spin` will **not** install Fermyon's Spin framework. Fermyon Spin is accessed from the `fermyon` tap, as shown above.

--- a/content/spin/v3/upgrade.md
+++ b/content/spin/v3/upgrade.md
@@ -87,7 +87,7 @@ If you installed Spin using [Homebrew](https://brew.sh/) please use the followin
 
 ```bash
 $ brew update
-$ brew upgrade fermyon/tap/spin
+$ brew upgrade spinframework/tap/spin
 ```
 
 ### Cargo


### PR DESCRIPTION
If you are using fermyon/tap, you can still continue to upgrade to latest Spin. Homebrew handles the migration for us, auto-fetching the spinframework tap. 
