### PR TITLE
Removing cron tutorial from functions_sidebar.hbs

### DIFF
--- a/templates/functions_sidebar.hbs
+++ b/templates/functions_sidebar.hbs
@@ -22,7 +22,6 @@
         
         <a {{#if (active_content request.spin-path-info "/wasm-functions/property-manager-integration" )}} class="active" {{/if}} href="{{site.info.base_url}}/wasm-functions/property-manager-integration">Integrating with Property Manager</a>
         <a {{#if (active_content request.spin-path-info "/wasm-functions/using-key-value-store" )}} class="active" {{/if}} href="{{site.info.base_url}}/wasm-functions/using-key-value-store">Using the Key Value Store</a>
-        <a {{#if (active_content request.spin-path-info "/wasm-functions/using-a-cron-trigger" )}} class="active" {{/if}} href="{{site.info.base_url}}/wasm-functions/using-cron-trigger">Using a Cron Trigger</a>
         <a {{#if (active_content request.spin-path-info "/wasm-functions/querying-postgresql" )}} class="active" {{/if}} href="{{site.info.base_url}}/wasm-functions/querying-postgresql">Querying PostgreSQL</a>
         <a {{#if (active_content request.spin-path-info "/wasm-functions/querying-linode-mysql" )}} class="active" {{/if}} href="{{site.info.base_url}}/wasm-functions/querying-linode-mysql">Querying MySQL (Linode)</a>
         <a {{#if (active_content request.spin-path-info "/wasm-functions/supabase-cache-proxy" )}} class="active" {{/if}} href="{{site.info.base_url}}/wasm-functions/supabase-cache-proxy">Building a Supabase Cache Proxy</a>


### PR DESCRIPTION
Temporarily removing incomplete tutorial until it is finished (see https://github.com/fermyon/a3000-docs/issues/228)

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title`, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep $'\r' | wc -l` and expect 0 as a result)
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
