### PR TITLE
fix: fermyon/spin -> spinframework/spin

### DIFF
--- a/content/api/hub/contributing.md
+++ b/content/api/hub/contributing.md
@@ -140,7 +140,7 @@ The following is a list of the types of content that a user can submit to the Sp
     - Spin Application examples
     - Code snippets
 - **(Spin) Templates**
-    - Complete components such as the [Spin static-fileserver](https://github.com/fermyon/spin-fileserver)
+    - Complete components such as the [Spin static-fileserver](https://github.com/spinframework/spin-fileserver)
 - **(Spin) Plugins**
     - Triggers and tools
     - See Lee-Orr’s Message trigger: [https://github.com/lee-orr/spin-message-trigger](https://github.com/lee-orr/spin-message-trigger)
@@ -237,7 +237,7 @@ $ git push -u origin my_new_branch
 
 If you return to your GitHub repository in your browser, you will notice that a PR has automatically been generated for you.
 
-Clicking on the green “Compare and pull request” button will allow you to add a title and description as part of the PR. 
+Clicking on the green “Compare and pull request” button will allow you to add a title and description as part of the PR.
 
 ![Compare and pull request](/static/image/compare_and_pull_request.png)
 

--- a/content/api/hub/sample_hugo.md
+++ b/content/api/hub/sample_hugo.md
@@ -20,7 +20,6 @@ keywords = "Hugo, spin-fileserver, SSG, template, Fermyon Cloud"
 
 ### Getting started
 
-The [hugo-spin](https://github.com/ThorstenHans/hugo-spin) comes with all batteries included to serve your next [Hugo](https://gohugo.io) site leveraging the [`spin-fileserver`](https://github.com/fermyon/spin-fileserver). 
+The [hugo-spin](https://github.com/ThorstenHans/hugo-spin) comes with all batteries included to serve your next [Hugo](https://gohugo.io) site leveraging the [`spin-fileserver`](https://github.com/spinframework/spin-fileserver).
 
 To get started, open the [hugo-spin](https://github.com/ThorstenHans/hugo-spin) repository and click the "Use this template" button. Once you've created your own repository from the template, you can use the `make start` and `make deploy` to either build and the site locally, or to deploy it to Fermyon Cloud.
-

--- a/content/api/hub/template_http_empty copy.md
+++ b/content/api/hub/template_http_empty copy.md
@@ -12,9 +12,9 @@ created_at = "2022-10-15T00:22:56Z"
 last_updated = "2022-10-15T00:22:56Z"
 spin_version = ">v0.7"
 summary =  "A template to create an HTTP application with no components"
-url = "https://github.com/fermyon/spin/tree/main/templates/http-empty"
+url = "https://github.com/spinframework/spin/tree/main/templates/http-empty"
 template_id = "http-empty"
-repo_url = "https://github.com/fermyon/spin"
+repo_url = "https://github.com/spinframework/spin"
 keywords = "web app, http, api, starter"
 
 ---

--- a/content/api/hub/template_http_go copy.md
+++ b/content/api/hub/template_http_go copy.md
@@ -13,9 +13,9 @@ created_at = "2022-10-15T00:22:56Z"
 last_updated = "2022-10-15T00:22:56Z"
 spin_version = ">v0.2"
 summary =  "A template to create an HTTP handler in Go"
-url = "https://github.com/fermyon/spin/tree/main/templates/http-go"
+url = "https://github.com/spinframework/spin/tree/main/templates/http-go"
 template_id = "http-go"
-repo_url = "https://github.com/fermyon/spin"
+repo_url = "https://github.com/spinframework/spin"
 keywords = "web app, http, api"
 
 ---

--- a/content/api/hub/template_http_js copy.md
+++ b/content/api/hub/template_http_js copy.md
@@ -13,9 +13,9 @@ created_at = "2022-10-15T00:22:56Z"
 last_updated = "2022-10-15T00:22:56Z"
 spin_version = ">v0.8"
 summary =  "A template to create an HTTP handler in JavaScript"
-url = "https://github.com/fermyon/spin-js-sdk/tree/main/templates/http-js"
+url = "https://github.com/spinframework/spin-js-sdk/tree/main/templates/http-js"
 template_id = "http-js"
-repo_url = "https://github.com/fermyon/spin-js-sdk"
+repo_url = "https://github.com/spinframework/spin-js-sdk"
 keywords = "web app, http, api"
 
 ---

--- a/content/api/hub/template_http_python copy.md
+++ b/content/api/hub/template_http_python copy.md
@@ -13,9 +13,9 @@ created_at = "2022-10-15T00:22:56Z"
 last_updated = "2022-10-15T00:22:56Z"
 spin_version = ">v2.2"
 summary =  "A template to create an HTTP handler in Python"
-url = "https://github.com/fermyon/spin-python-sdk/tree/main/templates/http-py"
+url = "https://github.com/spinframework/spin-python-sdk/tree/main/templates/http-py"
 template_id = "http-py"
-repo_url = "https://github.com/fermyon/spin-python-sdk"
+repo_url = "https://github.com/spinframework/spin-python-sdk"
 keywords = "web app, http, api"
 
 ---

--- a/content/api/hub/template_http_rust copy.md
+++ b/content/api/hub/template_http_rust copy.md
@@ -13,9 +13,9 @@ created_at = "2022-10-15T00:22:56Z"
 last_updated = "2022-10-15T00:22:56Z"
 spin_version = ">v0.2"
 summary =  "A template to create an HTTP handler in Rust"
-url = "https://github.com/fermyon/spin/tree/main/templates/http-rust"
+url = "https://github.com/spinframework/spin/tree/main/templates/http-rust"
 template_id = "http-rust"
-repo_url = "https://github.com/fermyon/spin"
+repo_url = "https://github.com/spinframework/spin"
 keywords = "web app, http, api"
 
 ---

--- a/content/api/hub/template_http_ts copy.md
+++ b/content/api/hub/template_http_ts copy.md
@@ -13,9 +13,9 @@ created_at = "2022-10-15T00:22:56Z"
 last_updated = "2022-10-15T00:22:56Z"
 spin_version = ">v0.8"
 summary =  "A template to create an HTTP handler in TypeScript"
-url = "https://github.com/fermyon/spin-js-sdk/tree/main/templates/http-ts"
+url = "https://github.com/spinframework/spin-js-sdk/tree/main/templates/http-ts"
 template_id = "http-ts"
-repo_url = "https://github.com/fermyon/spin-js-sdk"
+repo_url = "https://github.com/spinframework/spin-js-sdk"
 keywords = "web app, http, api"
 
 ---

--- a/content/api/hub/template_spin_fileserver.md
+++ b/content/api/hub/template_spin_fileserver.md
@@ -13,9 +13,9 @@ created_at = "2022-10-15T00:22:56Z"
 last_updated = "2023-03-14T00:22:56Z"
 spin_version = ">v0.1"
 summary =  "A Spin template to serve static assets."
-url = "https://github.com/fermyon/spin-fileserver"
+url = "https://github.com/spinframework/spin-fileserver"
 template_id = "static-fileserver"
-repo_url = "https://github.com/fermyon/spin"
+repo_url = "https://github.com/spinframework/spin"
 keywords = "static websites, fileserver"
 
 ---

--- a/content/bartholomew/contributing-bartholomew.md
+++ b/content/bartholomew/contributing-bartholomew.md
@@ -205,14 +205,14 @@ $ cd ~/bartholomew
 $ make bart
 ```
 
-Once built, you will find the very useful `bart` CLI executable in the `~/bartholomew/target/release` directory. 
+Once built, you will find the very useful `bart` CLI executable in the `~/bartholomew/target/release` directory.
 
 For more information about how to use the CLI, please type `~/bartholomew/target/release/bart --help`, as shown below:
 
 <!-- @selectiveCpy -->
 
 ```bash
-$ ~/bartholomew/target/release/bart --help    
+$ ~/bartholomew/target/release/bart --help
 bart 0.6.0
 The Bartholomew CLI
 
@@ -269,7 +269,7 @@ The output from the above command will be similar to the following (depending on
 
 ## The Relationship Between Bartholomew and Spin
 
-To run Bartholomew, you will need a Spin-capable runtime. 
+To run Bartholomew, you will need a Spin-capable runtime.
 
 For Spin, follow [the Spin quickstart guide](https://spinframework.dev/quickstart) which details how to either:
 - download the latest Spin binary release,
@@ -456,7 +456,7 @@ The final stage of a successful contribution will be a notification that the PR 
 
 ## Thank You
 
-At this point, you have performed a significant amount of work which is greatly appreciated. 
+At this point, you have performed a significant amount of work which is greatly appreciated.
 
 Thank you for contributing!
 

--- a/content/bartholomew/quickstart.md
+++ b/content/bartholomew/quickstart.md
@@ -42,7 +42,7 @@ Here are some additional details about [creating a repository from a template](h
 
 ## Fetch Your Site
 
-Clone the repository which you created in the previous step: 
+Clone the repository which you created in the previous step:
 
 <!-- @nocpy -->
 

--- a/content/spin/v1/ai-sentiment-analysis-api-tutorial.md
+++ b/content/spin/v1/ai-sentiment-analysis-api-tutorial.md
@@ -46,9 +46,9 @@ In this tutorial we will:
 
 ## Tutorial Prerequisites
 
-### Spin 
+### Spin
 
-You will need to [install the latest version of Spin](install#installing-spin). Serverless AI is supported on Spin versions 1.5 and above. 
+You will need to [install the latest version of Spin](install#installing-spin). Serverless AI is supported on Spin versions 1.5 and above.
 
 If you already have Spin installed, [check what version you are on and upgrade](upgrade#are-you-on-the-latest-version) if required.
 
@@ -78,7 +78,7 @@ $ spin templates install --git https://github.com/spinframework/spin-python-sdk 
 
 > This tutorial uses [Meta AI](https://ai.meta.com/)'s Llama 2, Llama Chat and Code Llama models you will need to visit [Meta's Llama webpage](https://ai.meta.com/resources/models-and-libraries/llama-downloads/) and agree to Meta's License, Acceptable Use Policy, and to Meta’s privacy policy before fetching and using Llama models.
 
-## Serverless AI Inferencing With Spin Applications 
+## Serverless AI Inferencing With Spin Applications
 
 Now, let's dive deep into a comprehensive tutorial and unlock your potential to use Fermyon Serverless AI.
 **Note:** The full source code with other examples can be found in our [Github repo](https://github.com/fermyon/ai-examples/tree/main)
@@ -640,9 +640,9 @@ We create an `assets` directory where we can store files to serve statically (se
 $ mkdir assets
 ```
 
-### Add the Front-End 
+### Add the Front-End
 
-We can add a webpage that asks the user for some text and does the sentiment analysis on it. In your assets folder, create two files `dynamic.js` and `index.html`. 
+We can add a webpage that asks the user for some text and does the sentiment analysis on it. In your assets folder, create two files `dynamic.js` and `index.html`.
 
 Here's the code snippet for `index.html`
 
@@ -716,7 +716,7 @@ Here's the code snippet for `index.html`
 </html>
 ```
 
-Here's the code snippet for `dynamic.js` 
+Here's the code snippet for `dynamic.js`
 
 ```javascript
 // Listen for the Enter key being pressed
@@ -870,7 +870,7 @@ route = "/api/..."
 command = "npm run build"
 
 [[component]]
-source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.0.3/spin_static_fs.wasm", digest = "sha256:38bf971900228222f7f6b2ccee5051f399adca58d71692cdfdea98997965fd0d" }
+source = { url = "https://github.com/spinframework/spin-fileserver/releases/download/v0.0.3/spin_static_fs.wasm", digest = "sha256:38bf971900228222f7f6b2ccee5051f399adca58d71692cdfdea98997965fd0d" }
 id = "ui"
 files = [ { source = "assets", destination = "/" } ]
 [component.trigger]
@@ -913,7 +913,7 @@ $ curl -vXPOST 'localhost:3000/api/sentiment-analysis' -H'Content-Type: applicat
 
 ### Deploy to Fermyon Cloud
 
-Deploying to the Fermyon Cloud is one simple command. If you have not logged into your Fermyon Cloud account already, the CLI will prompt you to login. Follow the instructions to complete the authorization process.  
+Deploying to the Fermyon Cloud is one simple command. If you have not logged into your Fermyon Cloud account already, the CLI will prompt you to login. Follow the instructions to complete the authorization process.
 
 <!-- @selectiveCpy -->
 

--- a/content/spin/v1/contributing-spin.md
+++ b/content/spin/v1/contributing-spin.md
@@ -50,7 +50,7 @@ to make to Spin, make sure you can correctly build the project:
 
 ```bash
 # clone the repository
-$ git clone https://github.com/fermyon/spin && cd spin
+$ git clone https://github.com/spinframework/spin && cd spin
 # add a new remote pointing to your fork of the project
 $ git remote add fork https://github.com/<your-username>/spin
 # create a new branch for your work

--- a/content/spin/v1/go-components.md
+++ b/content/spin/v1/go-components.md
@@ -52,7 +52,7 @@ import (
  "fmt"
  "net/http"
 
- spinhttp "github.com/fermyon/spin/sdk/go/http"
+ spinhttp "github.com/spinframework/spin/sdk/go/http"
 )
 
 func init() {
@@ -95,7 +95,7 @@ import (
  "net/http"
  "os"
 
- spinhttp "github.com/fermyon/spin/sdk/go/http"
+ spinhttp "github.com/spinframework/spin/sdk/go/http"
 )
 
 func init() {
@@ -191,7 +191,7 @@ package main
 import (
  "fmt"
 
- "github.com/fermyon/spin/sdk/go/redis"
+ "github.com/spinframework/spin/sdk/go/redis"
 )
 
 func init() {
@@ -276,8 +276,8 @@ import (
  "net/http"
  "os"
 
- spin_http "github.com/fermyon/spin/sdk/go/http"
- "github.com/fermyon/spin/sdk/go/redis"
+ spin_http "github.com/spinframework/spin/sdk/go/http"
+ "github.com/spinframework/spin/sdk/go/redis"
 )
 
 func init() {

--- a/content/spin/v1/http-outbound.md
+++ b/content/spin/v1/http-outbound.md
@@ -111,11 +111,11 @@ You can find a complete example for using outbound HTTP in the [Python SDK repos
 
 {{ startTab "TinyGo"}}
 
-HTTP functions are available in the `github.com/fermyon/spin/sdk/go/http` package. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/http). The general function is named `Send`, but the Go SDK also surfaces individual functions, with request-specific parameters, for the `Get` and `Post` operations. For example:
+HTTP functions are available in the `github.com/spinframework/spin/sdk/go/http` package. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/http). The general function is named `Send`, but the Go SDK also surfaces individual functions, with request-specific parameters, for the `Get` and `Post` operations. For example:
 
 ```go
 import (
-	spinhttp "github.com/fermyon/spin/sdk/go/http"
+	spinhttp "github.com/spinframework/spin/sdk/go/http"
 )
 
 res1, err1 := spinhttp.Get("https://random-data-api.fermyon.app/animals/json")

--- a/content/spin/v1/http-trigger.md
+++ b/content/spin/v1/http-trigger.md
@@ -105,7 +105,7 @@ For example, suppose the application `base` path is `base = "/shop"`.  Then a co
 ### Resolving Overlapping Routes
 
 If multiple components could potentially handle the same request based on their
-defined routes, the component whose route has the longest matching prefix 
+defined routes, the component whose route has the longest matching prefix
 takes precedence.  This also means that exact matches take precedence over wildcard matches.
 
 In the following example, requests starting with the  `/users/` prefix (e.g. `/users/1`)
@@ -235,7 +235,7 @@ import (
         "fmt"
         "net/http"
 
-        spinhttp "github.com/fermyon/spin/sdk/go/http"
+        spinhttp "github.com/spinframework/spin/sdk/go/http"
 )
 
 func init() {
@@ -474,7 +474,7 @@ When exposing HTTP triggers using HTTPS you must provide `spin up` with a TLS ce
 
 The `spin up` command's `--tls-cert` and `--tls-key` trigger options provide a way for you to specify both a TLS certificate and a private key (whilst running the `spin up` command).
 
-The `--tls-cert` option specifies the path to the TLS certificate to use for HTTPS, if this is not set, normal HTTP will be used. The certificate should be in PEM format. 
+The `--tls-cert` option specifies the path to the TLS certificate to use for HTTPS, if this is not set, normal HTTP will be used. The certificate should be in PEM format.
 
 The `--tls-key` option specifies the path to the private key to use for HTTPS, if this is not set, normal HTTP will be used. The key should be in PKCS#8 format. For more information, please see the [Spin CLI Reference](./cli-reference#trigger-options).
 

--- a/content/spin/v1/key-value-store-tutorial.md
+++ b/content/spin/v1/key-value-store-tutorial.md
@@ -88,7 +88,7 @@ $ spin new http-go spin-key-value
 
 ## Configuration
 
-Good news - Spin will take care of setting up your key value store. However, in order to make sure your Spin application has permission to access the key value store, you must add the `key_value_stores = ["default"]` line in the `[[component]]` area of the `spin.toml` file. This line is necessary to communicate to Spin that a given component has access to the default key value store. A newly scaffolded Spin application will not have this line; you will need to add it. 
+Good news - Spin will take care of setting up your key value store. However, in order to make sure your Spin application has permission to access the key value store, you must add the `key_value_stores = ["default"]` line in the `[[component]]` area of the `spin.toml` file. This line is necessary to communicate to Spin that a given component has access to the default key value store. A newly scaffolded Spin application will not have this line; you will need to add it.
 
 >> Tip: You can choose between various store implementations by modifying [the runtime configuration](dynamic-configuration.md#key-value-store-runtime-configuration). The default implementation uses [SQLite](https://www.sqlite.org/index.html) within the Spin framework.
 
@@ -175,7 +175,7 @@ command = "tinygo build -target=wasi -gc=leaking -no-debug -o main.wasm main.go"
 
 ## Write Code to Save and Load Data
 
-In this section, we use the Spin SDK to open and persist our application's data inside our default key/value store. This is a special store that every environment running Spin applications will make available for their application. 
+In this section, we use the Spin SDK to open and persist our application's data inside our default key/value store. This is a special store that every environment running Spin applications will make available for their application.
 
 > Please note: Spin applications written in Rust can [store and retrieve Rust data structures](./rust-components#storing-data-in-the-spin-key-value-store) in the application's data store.
 
@@ -338,8 +338,8 @@ import (
 	"io"
 	"net/http"
 
-	spin_http "github.com/fermyon/spin/sdk/go/http"
-	"github.com/fermyon/spin/sdk/go/key_value"
+	spin_http "github.com/spinframework/spin/sdk/go/http"
+	"github.com/spinframework/spin/sdk/go/key_value"
 )
 
 func init() {
@@ -412,7 +412,7 @@ func main() {}
 
 ## Building and Deploying Your Spin Application
 
-Now let's build and deploy our Spin Application locally. Run the following command to build your application: 
+Now let's build and deploy our Spin Application locally. Run the following command to build your application:
 
 <!-- @selectiveCpy -->
 
@@ -443,7 +443,7 @@ We can now use a `HEAD` request to confirm that our component is holding data fo
 <!-- @selectiveCpy -->
 
 ```bash
-$ curl -I HEAD localhost:3000/test -v                                                     
+$ curl -I HEAD localhost:3000/test -v
 
 Trying 127.0.0.1:3000...
 * Connected to localhost (127.0.0.1) port 3000

--- a/content/spin/v1/kv-store-api-guide.md
+++ b/content/spin/v1/kv-store-api-guide.md
@@ -59,7 +59,7 @@ fn handle_request(_req: Request) -> Result<Response> {
 }
 ```
 
-**General Notes** 
+**General Notes**
 
 `set` **Operation**
 - For set, the value argument can be of any type that implements AsRef<[u8]>
@@ -95,7 +95,7 @@ export const handleRequest: HandleRequest = async function (request: HttpRequest
 ```
 
 **General Notes**
-- The spinSdk object is always available at runtime. Code checking and completion are available in TypeScript at design time if the module imports anything from the @fermyon/spin-sdk package. For example: 
+- The spinSdk object is always available at runtime. Code checking and completion are available in TypeScript at design time if the module imports anything from the @fermyon/spin-sdk package. For example:
 
 `get` **Operation**
 - The result is of the type `ArrayBuffer | null`
@@ -124,7 +124,7 @@ def handle_request(request):
     store.set("mykey", "myvalue")
     value = store.get()
     //
-    return Response(status, [("content-type", "text/plain")], value)   
+    return Response(status, [("content-type", "text/plain")], value)
 
 ```
 
@@ -137,10 +137,10 @@ def handle_request(request):
 
 {{ startTab "TinyGo"}}
 
-Key value functions are provided by the `github.com/fermyon/spin/sdk/go/key_value` module. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/key_value). For example: 
+Key value functions are provided by the `github.com/spinframework/spin/sdk/go/key_value` module. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/key_value). For example:
 
 ```go
-import "github.com/fermyon/spin/sdk/go/key_value"
+import "github.com/spinframework/spin/sdk/go/key_value"
 
 func example() error {
     store, err := key_value.Open("default")

--- a/content/spin/v1/quickstart.md
+++ b/content/spin/v1/quickstart.md
@@ -579,7 +579,7 @@ import (
         "fmt"
         "net/http"
 
-        spinhttp "github.com/fermyon/spin/sdk/go/http"
+        spinhttp "github.com/spinframework/spin/sdk/go/http"
 )
 
 func init() {
@@ -613,7 +613,7 @@ Executing the build command for component hello-rust: cargo build --target wasm3
    Compiling anyhow v1.0.69
    Compiling version_check v0.9.4
    # ...
-   Compiling spin-sdk v0.10.0 
+   Compiling spin-sdk v0.10.0
    Compiling hello-rust v0.1.0 (/home/ivan/testing/start/hello_rust)
     Finished release [optimized] target(s) in 11.94s
 Successfully ran the build command for the Spin components.
@@ -798,7 +798,7 @@ date: Thu, 02 Mar 2023 00:05:42 GMT
 Hello, Fermyon
 ```
 
-> The `curl` output may vary based on which language SDK you use. 
+> The `curl` output may vary based on which language SDK you use.
 
 Congratulations! You just created, built and ran your first Spin application!
 

--- a/content/spin/v1/redis-outbound.md
+++ b/content/spin/v1/redis-outbound.md
@@ -66,7 +66,7 @@ let value = redis::get(&address, &key)?;
 
 * The arguments and results are enums, representing integers, binary payloads, and (for results) status and nil values.
 
-You can find a complete Rust code example for using outbound Redis from an HTTP component in the [Spin repository on GitHub](https://github.com/spinframework/spin-rust-sdk/tree/main/examples/redis-outbound). Please also see this, related, [outbound Redis (using Rust) section](./rust-components#storing-data-in-redis-from-rust-components). 
+You can find a complete Rust code example for using outbound Redis from an HTTP component in the [Spin repository on GitHub](https://github.com/spinframework/spin-rust-sdk/tree/main/examples/redis-outbound). Please also see this, related, [outbound Redis (using Rust) section](./rust-components#storing-data-in-redis-from-rust-components).
 
 {{ blockEnd }}
 
@@ -120,11 +120,11 @@ You can find a complete Python code example for using outbound Redis from an HTT
 
 {{ startTab "TinyGo"}}
 
-Redis functions are available in the `github.com/fermyon/spin/sdk/go/redis` package. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/redis). The function names are TitleCased. For example:
+Redis functions are available in the `github.com/spinframework/spin/sdk/go/redis` package. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/redis). The function names are TitleCased. For example:
 
 ```go
 import (
-	"github.com/fermyon/spin/sdk/go/redis"
+	"github.com/spinframework/spin/sdk/go/redis"
 )
 
 payload, err := redis.Get(address, key)
@@ -142,7 +142,7 @@ payload, err := redis.Get(address, key)
 * The arguments are passed as `[]redis.RedisParameter`. You can construct `RedisParameter` instances around an `interface{}` but must provide a `Kind`. For example, `hello := redis.RedisParameter{Kind: redis.RedisParameterKindBinary, Val: []byte("hello")}`.
 * The results are returned as `[]redis.Result`. You can use the `Kind` member of `redis.Result` to interpret the `Val`.
 
-You can find a complete TinyGo example for using outbound Redis from an HTTP component in the [Spin repository on GitHub](https://github.com/spinframework/spin-go-sdk/tree/main/examples/redis-outbound). Please also see this, related, [outbound Redis (using TinyGo) section](./go-components#storing-data-in-redis-from-go-components). 
+You can find a complete TinyGo example for using outbound Redis from an HTTP component in the [Spin repository on GitHub](https://github.com/spinframework/spin-go-sdk/tree/main/examples/redis-outbound). Please also see this, related, [outbound Redis (using TinyGo) section](./go-components#storing-data-in-redis-from-go-components).
 
 {{ blockEnd }}
 

--- a/content/spin/v1/redis-trigger.md
+++ b/content/spin/v1/redis-trigger.md
@@ -112,7 +112,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/fermyon/spin/sdk/go/redis"
+	"github.com/spinframework/spin/sdk/go/redis"
 )
 
 func init() {

--- a/content/spin/v1/spin-application-structure.md
+++ b/content/spin/v1/spin-application-structure.md
@@ -161,7 +161,7 @@ workdir = "second-http-rust-component"
 watch = ["src/**/*.rs", "Cargo.toml"]
 
 [[component]]
-source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.0.2/spin_static_fs.wasm", digest = "sha256:65456bf4e84cf81b62075e761b2b0afaffaef2d0aeda521b245150f76b96421b" }
+source = { url = "https://github.com/spinframework/spin-fileserver/releases/download/v0.0.2/spin_static_fs.wasm", digest = "sha256:65456bf4e84cf81b62075e761b2b0afaffaef2d0aeda521b245150f76b96421b" }
 id = "assets"
 files = [ { source = "assets", destination = "/" } ]
 [component.trigger]

--- a/content/spin/v1/sqlite-api-guide.md
+++ b/content/spin/v1/sqlite-api-guide.md
@@ -96,7 +96,7 @@ struct ToDo {
 }
 ```
 
-**General Notes** 
+**General Notes**
 * All functions are on the `spin_sdk::sqlite::Connection` type.
 * Parameters are instances of the `ValueParam` enum; you must wrap raw values in this type.
 * The `execute` function returns a `QueryResult`. To iterate over the rows use the `rows()` function. This returns an iterator; use `collect()` if you want to load it all into a collection.
@@ -162,8 +162,8 @@ import (
 	"encoding/json"
 	"net/http"
 
-	spinhttp "github.com/fermyon/spin/sdk/go/http"
-	"github.com/fermyon/spin/sdk/go/sqlite"
+	spinhttp "github.com/spinframework/spin/sdk/go/http"
+	"github.com/spinframework/spin/sdk/go/sqlite"
 )
 
 type Todo struct {

--- a/content/spin/v1/variables.md
+++ b/content/spin/v1/variables.md
@@ -10,7 +10,7 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/v1/variables.
 - [Adding Variables to Your Applications](#adding-variables-to-your-applications)
 - [Using Variables From Applications](#using-variables-from-applications)
 
-Spin supports dynamic application variables. Instead of being static, their values can be updated without modifying the application, creating a simpler experience for rotating secrets, updating API endpoints, and more. 
+Spin supports dynamic application variables. Instead of being static, their values can be updated without modifying the application, creating a simpler experience for rotating secrets, updating API endpoints, and more.
 
 These variables are defined in a Spin application manifest (in the `[variables]` section), and their values can be set or overridden at runtime by an [application variables provider](./dynamic-configuration.md#application-variables-runtime-configuration). When running Spin locally, the variables provider can be [Hashicorp Vault](./dynamic-configuration.md#vault-application-variable-provider) for secrets, or host environment variables.
 
@@ -77,7 +77,7 @@ The Spin SDK surfaces the Spin configuration interface to your language. The [in
 |------------|-------------------------------------|---------------------|----------|
 | `get-config`    | Variable name  | Variable value    | Gets the value of the variable from the configured provider |
 
-To illustrate the config API, each of the following examples receives a password via the HTTP request body, compares it to the value stored in the application variable, and returns a JSON response indicating whether the submitted password matched or not. The application manifest associated with the examples would look similar to the one described [in the previous section](#adding-variables-to-your-applications). 
+To illustrate the config API, each of the following examples receives a password via the HTTP request body, compares it to the value stored in the application variable, and returns a JSON response indicating whether the submitted password matched or not. The application manifest associated with the examples would look similar to the one described [in the previous section](#adding-variables-to-your-applications).
 
 The exact details of calling the config SDK from a Spin application depends on the language:
 
@@ -168,7 +168,7 @@ def handle_request(request):
 
 {{ startTab "TinyGo"}}
 
-The config function is available in the `github.com/fermyon/spin/sdk/go/config` package and is named `Get`. See [Go package](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/config) for reference documentation.
+The config function is available in the `github.com/spinframework/spin/sdk/go/config` package and is named `Get`. See [Go package](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/config) for reference documentation.
 
 ```go
 import (
@@ -176,8 +176,8 @@ import (
 	"io"
 	"net/http"
 
-	spinconfig "github.com/fermyon/spin/sdk/go/config"
-	spinhttp "github.com/fermyon/spin/sdk/go/http"
+	spinconfig "github.com/spinframework/spin/sdk/go/config"
+	spinhttp "github.com/spinframework/spin/sdk/go/http"
 )
 
 spinhttp.Handle(func(w http.ResponseWriter, r *http.Request) {

--- a/content/spin/v1/writing-apps.md
+++ b/content/spin/v1/writing-apps.md
@@ -108,7 +108,7 @@ For components that are published on the Web, provide a `url` field containing t
 
 ```toml
 [[component]]
-source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.0.1/spin_static_fs.wasm", digest = "sha256:650376c33a0756b1a52cad7ca670f1126391b79050df0321407da9c741d32375" }
+source = { url = "https://github.com/spinframework/spin-fileserver/releases/download/v0.0.1/spin_static_fs.wasm", digest = "sha256:650376c33a0756b1a52cad7ca670f1126391b79050df0321407da9c741d32375" }
 ```
 
 Multiple components can have the same source.  An example is a document archive, where one component might serve user interface assets (CSS, images, etc.) on one route, while another serves the documents themselves on another route - both using the same file server module, but with different settings.
@@ -357,7 +357,7 @@ This is similar to the file server component above, but gets the Wasm module fro
 
 ```toml
 [[component]]
-source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.0.1/spin_static_fs.wasm", digest = "sha256:650376c33a0756b1a52cad7ca670f1126391b79050df0321407da9c741d32375" }
+source = { url = "https://github.com/spinframework/spin-fileserver/releases/download/v0.0.1/spin_static_fs.wasm", digest = "sha256:650376c33a0756b1a52cad7ca670f1126391b79050df0321407da9c741d32375" }
 id = "fileserver"
 files = [ { source = "static/", destination = "/" } ]
 [component.trigger]

--- a/content/spin/v2/ai-sentiment-analysis-api-tutorial.md
+++ b/content/spin/v2/ai-sentiment-analysis-api-tutorial.md
@@ -45,9 +45,9 @@ In this tutorial we will:
 
 ## Tutorial Prerequisites
 
-### Spin 
+### Spin
 
-You will need to [install the latest version of Spin](install#installing-spin). Serverless AI is supported on Spin versions 1.5 and above. 
+You will need to [install the latest version of Spin](install#installing-spin). Serverless AI is supported on Spin versions 1.5 and above.
 
 If you already have Spin installed, [check what version you are on and upgrade](upgrade#are-you-on-the-latest-version) if required.
 
@@ -88,14 +88,14 @@ Some of the Serverless AI examples are written using TinyGo. To enable Serverles
 <!-- @selectiveCpy -->
 
 ```bash
-$ spin templates install --git https://github.com/fermyon/spin --upgrade
+$ spin templates install --git https://github.com/spinframework/spin --upgrade
 ```
 
 ## Licenses
 
 > This tutorial uses [Meta AI](https://ai.meta.com/)'s Llama 2, Llama Chat and Code Llama models you will need to visit [Meta's Llama webpage](https://ai.meta.com/resources/models-and-libraries/llama-downloads/) and agree to Meta's License, Acceptable Use Policy, and to Meta’s privacy policy before fetching and using Llama models.
 
-## Serverless AI Inferencing With Spin Applications 
+## Serverless AI Inferencing With Spin Applications
 
 Now, let's dive deep into a comprehensive tutorial and unlock your potential to use Fermyon Serverless AI.
 **Note:** The full source code with other examples can be found in our [Github repo](https://github.com/fermyon/ai-examples/tree/main)
@@ -664,9 +664,9 @@ import (
 	"net/http"
 	"strings"
 
-	spinhttp "github.com/fermyon/spin/sdk/go/v2/http"
-	"github.com/fermyon/spin/sdk/go/v2/kv"
-	"github.com/fermyon/spin/sdk/go/v2/llm"
+	spinhttp "github.com/spinframework/spin/sdk/go/v2/http"
+	"github.com/spinframework/spin/sdk/go/v2/kv"
+	"github.com/spinframework/spin/sdk/go/v2/llm"
 )
 
 type sentimentAnalysisRequest struct {
@@ -804,9 +804,9 @@ We create an `assets` directory where we can store files to serve statically (se
 $ mkdir assets
 ```
 
-### Add the Front-End 
+### Add the Front-End
 
-We can add a webpage that asks the user for some text and does the sentiment analysis on it. In your assets folder, create two files `dynamic.js` and `index.html`. 
+We can add a webpage that asks the user for some text and does the sentiment analysis on it. In your assets folder, create two files `dynamic.js` and `index.html`.
 
 Here's the code snippet for `index.html`
 
@@ -880,7 +880,7 @@ Here's the code snippet for `index.html`
 </html>
 ```
 
-Here's the code snippet for `dynamic.js` 
+Here's the code snippet for `dynamic.js`
 
 ```javascript
 // Listen for the Enter key being pressed
@@ -1033,7 +1033,7 @@ route = "/..."
 component = "ui"
 
 [component.ui]
-source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.1.0/spin_static_fs.wasm", digest = "sha256:96c76d9af86420b39eb6cd7be5550e3cb5d4cc4de572ce0fd1f6a29471536cb4" }
+source = { url = "https://github.com/spinframework/spin-fileserver/releases/download/v0.1.0/spin_static_fs.wasm", digest = "sha256:96c76d9af86420b39eb6cd7be5550e3cb5d4cc4de572ce0fd1f6a29471536cb4" }
 files = [{ source = "assets", destination = "/" }]
 
 [[trigger.http]]
@@ -1074,7 +1074,7 @@ $ curl -vXPOST 'localhost:3000/api/sentiment-analysis' -H'Content-Type: applicat
 
 ### Deploy to Fermyon Cloud
 
-Deploying to the Fermyon Cloud is one simple command. If you have not logged into your Fermyon Cloud account already, the CLI will prompt you to login. Follow the instructions to complete the authorization process.  
+Deploying to the Fermyon Cloud is one simple command. If you have not logged into your Fermyon Cloud account already, the CLI will prompt you to login. Follow the instructions to complete the authorization process.
 
 <!-- @selectiveCpy -->
 

--- a/content/spin/v2/build.md
+++ b/content/spin/v2/build.md
@@ -153,7 +153,7 @@ Once the build commands are set up, running `spin build` will execute, sequentia
 $ spin build
 Building component hello with `cargo build --target wasm32-wasi --release`
     Updating crates.io index
-    Updating git repository `https://github.com/fermyon/spin`
+    Updating git repository `https://github.com/spinframework/spin`
 
     //--snip--
 

--- a/content/spin/v2/contributing-spin.md
+++ b/content/spin/v2/contributing-spin.md
@@ -20,7 +20,7 @@ typos, adding examples, one-liner code fixes, tests, or complete features.
 
 <div style="display: block" align="left">
   <source media="(prefers-color-scheme: dark)" srcset="https://next.ossinsight.io/widgets/official/compose-recent-active-contributors/thumbnail.png?repo_id=423679664&limit=30&image_size=auto&color_scheme=dark" width="655" height="auto">
-  <img alt="Active Contributors of fermyon/spin - Last 28 days" src="https://next.ossinsight.io/widgets/official/compose-recent-active-contributors/thumbnail.png?repo_id=423679664&limit=30&image_size=auto&color_scheme=light" width="655" height="auto">
+  <img alt="Active Contributors of spinframework/spin - Last 28 days" src="https://next.ossinsight.io/widgets/official/compose-recent-active-contributors/thumbnail.png?repo_id=423679664&limit=30&image_size=auto&color_scheme=light" width="655" height="auto">
 </div>
 
 >> _Recent contributors to Spin, past 30 days. Widget courtesy of <a href="https://next.ossinsight.io/widgets/official/compose-recent-active-contributors?repo_id=423679664&limit=30">OSSinsight.io</a>._
@@ -49,7 +49,7 @@ soon as possible. First, make sure you have Rust installed.
 
 After [installing Rust](https://www.rust-lang.org/tools/install) please ensure the `wasm32-wasi` and
   `wasm32-unknown-unknown` targets are configured. For example:
-  
+
 ```bash
 rustup target add wasm32-wasi && rustup target add wasm32-unknown-unknown
 ```
@@ -57,7 +57,7 @@ rustup target add wasm32-wasi && rustup target add wasm32-unknown-unknown
 In addition, make sure you have the following prerequisites configured:
 
 - [`rustfmt`](https://github.com/rust-lang/rustfmt)
-- [`clippy`](https://github.com/rust-lang/rust-clippy) 
+- [`clippy`](https://github.com/rust-lang/rust-clippy)
 - `make`
 - [`rust-analyzer`](https://rust-analyzer.github.io/) extension (for Visual Studio Code users)
 - [GPG signature verification for your GitHub commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) and remember to use a sign-off message (`git commit -S -s`) on each of your commits
@@ -68,7 +68,7 @@ Once you have set up the prerequisites and identified the contribution you want 
 
 ```bash
 # clone the repository
-$ git clone https://github.com/fermyon/spin && cd spin
+$ git clone https://github.com/spinframework/spin && cd spin
 # add a new remote pointing to your fork of the project
 $ git remote add fork https://github.com/<your-username>/spin
 # create a new branch for your work

--- a/content/spin/v2/go-components.md
+++ b/content/spin/v2/go-components.md
@@ -26,7 +26,7 @@ Using TinyGo to compile components for Spin is currently required, as the
 
 > All examples from this page can be found in [the Spin Go SDK repository on GitHub](https://github.com/spinframework/spin-go-sdk/tree/main/examples).
 
-[**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2)
+[**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/v2)
 
 ## Versions
 
@@ -52,7 +52,7 @@ import (
  "fmt"
  "net/http"
 
- spinhttp "github.com/fermyon/spin/sdk/go/v2/http"
+ spinhttp "github.com/spinframework/spin/sdk/go/v2/http"
 )
 
 func init() {
@@ -124,7 +124,7 @@ import (
  "net/http"
  "os"
 
- spinhttp "github.com/fermyon/spin/sdk/go/v2/http"
+ spinhttp "github.com/spinframework/spin/sdk/go/v2/http"
 )
 
 func init() {
@@ -217,7 +217,7 @@ package main
 import (
  "fmt"
 
- "github.com/fermyon/spin/sdk/go/v2/redis"
+ "github.com/spinframework/spin/sdk/go/v2/redis"
 )
 
 func init() {
@@ -309,8 +309,8 @@ import (
  "net/http"
  "os"
 
- spin_http "github.com/fermyon/spin/sdk/go/v2/http"
- "github.com/fermyon/spin/sdk/go/v2/redis"
+ spin_http "github.com/spinframework/spin/sdk/go/v2/http"
+ "github.com/spinframework/spin/sdk/go/v2/redis"
 )
 
 func init() {

--- a/content/spin/v2/http-outbound.md
+++ b/content/spin/v2/http-outbound.md
@@ -104,7 +104,7 @@ const response = await fetch("https://example.com/users");
 
 You can find a complete example of using outbound HTTP in the JavaScript SDK repository on [GitHub](https://github.com/spinframework/spin-js-sdk/tree/sdk-v2/examples/common-patterns/outbound-http)
 
-**Note**: `fetch` currently only works when building for the HTTP trigger.  
+**Note**: `fetch` currently only works when building for the HTTP trigger.
 
 {{ blockEnd }}
 
@@ -132,13 +132,13 @@ You can find a complete example for using outbound HTTP in the [Python SDK repos
 
 {{ startTab "TinyGo"}}
 
-> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/http)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/v2@v2.0.0/http)
 
-HTTP functions are available in the `github.com/fermyon/spin/sdk/go/v2/http` package. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2/http) The general function is named `Send`, but the Go SDK also surfaces individual functions, with request-specific parameters, for the `Get` and `Post` operations. For example:
+HTTP functions are available in the `github.com/spinframework/spin/sdk/go/v2/http` package. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/v2/http) The general function is named `Send`, but the Go SDK also surfaces individual functions, with request-specific parameters, for the `Get` and `Post` operations. For example:
 
 ```go
 import (
-	spinhttp "github.com/fermyon/spin/sdk/go/v2/http"
+	spinhttp "github.com/spinframework/spin/sdk/go/v2/http"
 )
 
 res1, err1 := spinhttp.Get("https://random-data-api.fermyon.app/animals/json")

--- a/content/spin/v2/http-trigger.md
+++ b/content/spin/v2/http-trigger.md
@@ -104,7 +104,7 @@ For example, suppose the application `base` path is `base = "/shop"`.  Then a tr
 ### Resolving Overlapping Routes
 
 If multiple triggers could potentially handle the same request based on their
-defined routes, the trigger whose route has the longest matching prefix 
+defined routes, the trigger whose route has the longest matching prefix
 takes precedence.  This also means that exact matches take precedence over wildcard matches.
 
 In the following example, requests starting with the  `/users/` prefix (e.g. `/users/1`)
@@ -305,7 +305,7 @@ class IncomingHandler(http.IncomingHandler):
 
 {{ startTab "TinyGo"}}
 
-> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/http)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/v2@v2.0.0/http)
 
 In Go, you register the handler as a callback in your program's `init` function.  Call `spinhttp.Handle`, passing your handler as the sole argument.  Your handler takes a `http.Request` record, from the standard `net/http` package, and a `ResponseWriter` to construct the response.
 
@@ -318,7 +318,7 @@ import (
         "fmt"
         "net/http"
 
-        spinhttp "github.com/fermyon/spin/sdk/go/v2/http"
+        spinhttp "github.com/spinframework/spin/sdk/go/v2/http"
 )
 
 func init() {
@@ -507,7 +507,7 @@ When exposing HTTP triggers using HTTPS you must provide `spin up` with a TLS ce
 
 The `spin up` command's `--tls-cert` and `--tls-key` trigger options provide a way for you to specify both a TLS certificate and a private key (whilst running the `spin up` command).
 
-The `--tls-cert` option specifies the path to the TLS certificate to use for HTTPS, if this is not set, normal HTTP will be used. The certificate should be in PEM format. 
+The `--tls-cert` option specifies the path to the TLS certificate to use for HTTPS, if this is not set, normal HTTP will be used. The certificate should be in PEM format.
 
 The `--tls-key` option specifies the path to the private key to use for HTTPS, if this is not set, normal HTTP will be used. The key should be in PKCS#8 format. For more information, please see the [Spin CLI Reference](./cli-reference#trigger-options).
 

--- a/content/spin/v2/key-value-store-tutorial.md
+++ b/content/spin/v2/key-value-store-tutorial.md
@@ -109,7 +109,7 @@ $ spin new -t http-go spin-key-value
 
 ## Configuration
 
-Good news - Spin will take care of setting up your Key Value store. However, in order to make sure your Spin application has permission to access the Key Value store, you must add the `key_value_stores = ["default"]` line in the `[component.<component-name>]` section of the `spin.toml` file, for each component which needs access to the Key Value store. This line is necessary to communicate to Spin that a given component has access to the default Key Value store. A newly scaffolded Spin application will not have this line; you will need to add it. 
+Good news - Spin will take care of setting up your Key Value store. However, in order to make sure your Spin application has permission to access the Key Value store, you must add the `key_value_stores = ["default"]` line in the `[component.<component-name>]` section of the `spin.toml` file, for each component which needs access to the Key Value store. This line is necessary to communicate to Spin that a given component has access to the default Key Value store. A newly scaffolded Spin application will not have this line; you will need to add it.
 
 > Note: `[component.spin_key_value]` contains the name of the component. If you used a different name, when creating the application, this sections name would be different.
 
@@ -150,7 +150,7 @@ key_value_stores = ["default"]
 
 ## Write Code to Save and Load Data
 
-In this section, we use the Spin SDK to open and persist our application's data inside our default key/value store. This is a special store that every environment running Spin applications will make available for their application. 
+In this section, we use the Spin SDK to open and persist our application's data inside our default key/value store. This is a special store that every environment running Spin applications will make available for their application.
 
 ### The Spin SDK Version
 
@@ -330,8 +330,8 @@ import (
 	"net/http"
 	"fmt"
 
-	spin_http "github.com/fermyon/spin/sdk/go/v2/http"
-	"github.com/fermyon/spin/sdk/go/v2/kv"
+	spin_http "github.com/spinframework/spin/sdk/go/v2/http"
+	"github.com/spinframework/spin/sdk/go/v2/kv"
 )
 
 func init() {
@@ -408,7 +408,7 @@ func main() {}
 
 ## Building and Running Your Spin Application
 
-Now, let's build and run our Spin Application locally. Run the following command to build your application: 
+Now, let's build and run our Spin Application locally. Run the following command to build your application:
 
 <!-- @selectiveCpy -->
 
@@ -477,9 +477,9 @@ As we can see above, there is currently no data found at the `/test` endpoint of
 
 ## (Optional) Deploy Your App To Fermyon Cloud
 
-Optionally, if you'd like to deploy your application and key value store to Fermyon Cloud here are the required steps. 
+Optionally, if you'd like to deploy your application and key value store to Fermyon Cloud here are the required steps.
 
-First, login to your Fermyon Cloud account. If you do not have one already, this will take you through the signup process for a free account. 
+First, login to your Fermyon Cloud account. If you do not have one already, this will take you through the signup process for a free account.
 
 <!-- @selectiveCpy -->
 
@@ -513,12 +513,11 @@ Would you like to link an existing key value store or create a new key value sto
   Create a new key value store and link the app to it
 ```
 
->> If you're interested in learning more about how to link your Spin app to different key value store instances on Fermyon Cloud, check out our [Key Value Links and Labels tutorial](../../cloud/linking-applications-to-resources-using-labels.md). 
+>> If you're interested in learning more about how to link your Spin app to different key value store instances on Fermyon Cloud, check out our [Key Value Links and Labels tutorial](../../cloud/linking-applications-to-resources-using-labels.md).
 
-Congratulations, you have a Spin application and associated Key Value store running up in Fermyon Cloud! You can visit it by clicking on the Spin application's domain name generated in the CLI output, which has the following pattern: `spin-key-value-<RANDOM>.fermyon.app`. 
+Congratulations, you have a Spin application and associated Key Value store running up in Fermyon Cloud! You can visit it by clicking on the Spin application's domain name generated in the CLI output, which has the following pattern: `spin-key-value-<RANDOM>.fermyon.app`.
 
 ## Next Steps
 
 * Explore the contents of your Key Value store with the [Key Value Store Explorer template](../../hub/preview/template_kv_explorer)
-* Learn about linking your applications to different [Key Value Stores on Fermyon Cloud](../../cloud/kv-cloud-tutorial.md) 
-
+* Learn about linking your applications to different [Key Value Stores on Fermyon Cloud](../../cloud/kv-cloud-tutorial.md)

--- a/content/spin/v2/kv-store-api-guide.md
+++ b/content/spin/v2/kv-store-api-guide.md
@@ -65,7 +65,7 @@ fn handle_request(_req: Request) -> Result<impl IntoResponse> {
 }
 ```
 
-**General Notes** 
+**General Notes**
 
 `set` **Operation**
 - For set, the value argument can be of any type that implements `AsRef<[u8]>`
@@ -129,7 +129,7 @@ class IncomingHandler(http.IncomingHandler):
         with key_value.open_default() as store:
             store.set("test", bytes("hello world!", "utf-8"))
             val = store.get("test")
-            
+
         return Response(
             200,
             {"content-type": "text/plain"},
@@ -148,12 +148,12 @@ class IncomingHandler(http.IncomingHandler):
 
 {{ startTab "TinyGo"}}
 
-> [**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/kv)
+> [**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/v2@v2.0.0/kv)
 
-Key value functions are provided by the `github.com/fermyon/spin/sdk/go/v2/kv` module. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2/kv) For example:
+Key value functions are provided by the `github.com/spinframework/spin/sdk/go/v2/kv` module. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/v2/kv) For example:
 
 ```go
-import "github.com/fermyon/spin/sdk/go/v2/kv"
+import "github.com/spinframework/spin/sdk/go/v2/kv"
 
 func example() error {
     store, err := kv.OpenStore("default")

--- a/content/spin/v2/language-support-overview.md
+++ b/content/spin/v2/language-support-overview.md
@@ -85,7 +85,7 @@ This page contains information about language support for Spin features:
 
 {{ startTab "TinyGo"}}
 
-**[📄 Visit the TinyGo Spin SDK reference documentation](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2) to see specific modules, functions, variables and syntax relating to the following TinyGo SDK.**
+**[📄 Visit the TinyGo Spin SDK reference documentation](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/v2) to see specific modules, functions, variables and syntax relating to the following TinyGo SDK.**
 
 | Feature | SDK Supported? |
 |-----|-----|

--- a/content/spin/v2/observing-apps.md
+++ b/content/spin/v2/observing-apps.md
@@ -45,7 +45,7 @@ In order to view the telemetry data you need to run an OTel compliant [collector
 
 ```sh
 cd  ~
-git clone git@github.com:fermyon/spin.git
+git clone git@github.com:spinframework/spin.git
 cd spin/hack/o11y-stack
 docker compose up -d
 ```

--- a/content/spin/v2/quickstart.md
+++ b/content/spin/v2/quickstart.md
@@ -509,7 +509,7 @@ The `requirements.txt`, by default, contains the references to the `spin-sdk` an
 <!-- @selectiveCpy -->
 
 ```bash
-$ pip3 install -r requirements.txt 
+$ pip3 install -r requirements.txt
 Collecting spin-sdk==3.1.0 (from -r requirements.txt (line 1))
   Using cached spin_sdk-3.1.0-py3-none-any.whl.metadata (16 kB)
 Collecting componentize-py==0.13.3 (from -r requirements.txt (line 2))
@@ -529,7 +529,7 @@ The `hello-python` directory structure created by the Spin `http-py` template is
 ```text
 ├── app.py
 ├── spin.toml
-└── requirements.txt 
+└── requirements.txt
 ```
 
 The additional `spin.toml` file is the manifest file, which tells Spin what events should trigger what components.  In this case our trigger is HTTP, for a Web application, and we have only one component, at the route `/...`.  This is a wildcard that matches any route.
@@ -661,7 +661,7 @@ import (
         "fmt"
         "net/http"
 
-        spinhttp "github.com/fermyon/spin/sdk/go/v2/http"
+        spinhttp "github.com/spinframework/spin/sdk/go/v2/http"
 )
 
 func init() {
@@ -695,7 +695,7 @@ Executing the build command for component hello-rust: cargo build --target wasm3
    Compiling anyhow v1.0.69
    Compiling version_check v0.9.4
    # ...
-   Compiling spin-sdk v0.10.0 
+   Compiling spin-sdk v0.10.0
    Compiling hello-rust v0.1.0 (/home/ivan/testing/start/hello_rust)
     Finished release [optimized] target(s) in 11.94s
 Finished building all Spin components
@@ -835,7 +835,7 @@ You can always run this command manually; `spin build` is a shortcut.
 ```bash
 $ spin build
 Executing the build command for component hello-go: tinygo build -target=wasi -gc=leaking -no-debug -o main.wasm main.go
-go: downloading github.com/fermyon/spin/sdk/go v0.10.0
+go: downloading github.com/spinframework/spin/sdk/go v0.10.0
 Finished building all Spin components
 ```
 
@@ -906,7 +906,7 @@ date = "2023-11-04T00:00:01Z"
 Hello, Fermyon
 ```
 
-> The `curl` output may vary based on which language SDK you use. 
+> The `curl` output may vary based on which language SDK you use.
 
 Congratulations! You just created, built and ran your first Spin application!
 

--- a/content/spin/v2/rdbms-storage.md
+++ b/content/spin/v2/rdbms-storage.md
@@ -78,7 +78,7 @@ The code below is an [Outbound MySQL example](https://github.com/spinframework/s
 ```ts
 import { ResponseBuilder, Mysql } from '@fermyon/spin-sdk';
 
-// Connects as the root user without a password 
+// Connects as the root user without a password
 const DB_URL = "mysql://root:@127.0.0.1/spin_dev"
 
 /*
@@ -94,7 +94,7 @@ export async function handler(_req: Request, res: ResponseBuilder) {
   conn.execute('delete from test where id=?', [4]);
   conn.execute('insert into test values (4,5)', []);
   let ret = conn.query('select * from test', []);
-  // return a object that looks like 
+  // return a object that looks like
   // { "columns": [{name: "id", dataType: "int32"}], "rows": [{ "id": 4, "val": 5 }] }
   res.send(JSON.stringify(ret, null, 2));
 }
@@ -117,7 +117,7 @@ class IncomingHandler(http.IncomingHandler):
     def handle_request(self, request: Request) -> Response:
         with mysql.open("mysql://root:@127.0.0.1/spin_dev") as db:
             print(db.query("select * from test", []))
-        
+
         return Response(
             200,
             {"content-type": "text/plain"},
@@ -129,9 +129,9 @@ class IncomingHandler(http.IncomingHandler):
 
 {{ startTab "TinyGo"}}
 
-> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/v2)
 
-MySQL functions are available in the `github.com/fermyon/spin/sdk/go/v2/mysql` package, and PostgreSQL in `github.com/fermyon/spin/sdk/go/v2/pg`. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2)
+MySQL functions are available in the `github.com/spinframework/spin/sdk/go/v2/mysql` package, and PostgreSQL in `github.com/spinframework/spin/sdk/go/v2/pg`. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/v2)
 
 The package follows the usual Go database API. Use `Open` to return a connection to the database of type `*sql.DB` - see the [Go standard library documentation](https://pkg.go.dev/database/sql#DB) for usage information.  For example:
 
@@ -144,8 +144,8 @@ import (
 	"net/http"
 	"os"
 
-	spinhttp "github.com/fermyon/spin/sdk/go/v2/http"
-	"github.com/fermyon/spin/sdk/go/v2/pg"
+	spinhttp "github.com/spinframework/spin/sdk/go/v2/http"
+	"github.com/spinframework/spin/sdk/go/v2/pg"
 )
 
 type Pet struct {

--- a/content/spin/v2/redis-outbound.md
+++ b/content/spin/v2/redis-outbound.md
@@ -83,7 +83,7 @@ For full details of the Redis API, see the [Spin SDK reference documentation](ht
 
 * The arguments and results are enums, representing integers, binary payloads, and (for results) status and nil values.
 
-You can find a complete Rust code example for using outbound Redis from an HTTP component in the [Spin repository on GitHub](https://github.com/spinframework/spin-rust-sdk/tree/main/examples/redis-outbound). Please also see this, related, [outbound Redis (using Rust) section](./rust-components#storing-data-in-redis-from-rust-components). 
+You can find a complete Rust code example for using outbound Redis from an HTTP component in the [Spin repository on GitHub](https://github.com/spinframework/spin-rust-sdk/tree/main/examples/redis-outbound). Please also see this, related, [outbound Redis (using Rust) section](./rust-components#storing-data-in-redis-from-rust-components).
 
 {{ blockEnd }}
 
@@ -139,13 +139,13 @@ You can find a complete Python code example for using outbound Redis from an HTT
 
 {{ startTab "TinyGo"}}
 
-> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/redis)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/v2@v2.0.0/redis)
 
-Redis functions are available in the `github.com/fermyon/spin/sdk/go/v2/redis` package. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2/redis) The function names are TitleCased. For example:
+Redis functions are available in the `github.com/spinframework/spin/sdk/go/v2/redis` package. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/v2/redis) The function names are TitleCased. For example:
 
 ```go
 import (
-	"github.com/fermyon/spin/sdk/go/v2/redis"
+	"github.com/spinframework/spin/sdk/go/v2/redis"
 )
 
 rdb := redis.NewClient(addr)
@@ -164,7 +164,7 @@ payload, err := rdb.Get(key)
 * The arguments are passed as `[]redis.RedisParameter`. You can construct `RedisParameter` instances around an `interface{}` but must provide a `Kind`. For example, `hello := redis.RedisParameter{Kind: redis.RedisParameterKindBinary, Val: []byte("hello")}`.
 * The results are returned as `[]redis.Result`. You can use the `Kind` member of `redis.Result` to interpret the `Val`.
 
-You can find a complete TinyGo example for using outbound Redis from an HTTP component in the [Spin repository on GitHub](https://github.com/spinframework/spin-go-sdk/tree/main/examples/redis-outbound). Please also see this, related, [outbound Redis (using TinyGo) section](./go-components#storing-data-in-redis-from-go-components). 
+You can find a complete TinyGo example for using outbound Redis from an HTTP component in the [Spin repository on GitHub](https://github.com/spinframework/spin-go-sdk/tree/main/examples/redis-outbound). Please also see this, related, [outbound Redis (using TinyGo) section](./go-components#storing-data-in-redis-from-go-components).
 
 {{ blockEnd }}
 

--- a/content/spin/v2/redis-trigger.md
+++ b/content/spin/v2/redis-trigger.md
@@ -114,7 +114,7 @@ class InboundRedis(exports.InboundRedis):
 
 {{ startTab "TinyGo"}}
 
-> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/redis)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/v2@v2.0.0/redis)
 
 In Go, you register the handler as a callback in your program's `init` function.  Call `redis.Handle` (from the Spin SDK `redis` package), passing your handler as the sole argument.  Your handler takes a single byte slice (`[]byte`) argument, and may return an error or `nil`.
 
@@ -128,7 +128,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/fermyon/spin/sdk/go/v2/redis"
+	"github.com/spinframework/spin/sdk/go/v2/redis"
 )
 
 func init() {

--- a/content/spin/v2/serverless-ai-api-guide.md
+++ b/content/spin/v2/serverless-ai-api-guide.md
@@ -13,9 +13,9 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/v2/serverless
 - [Troubleshooting](#troubleshooting)
   - [Error "Local LLM operations are not supported in this version of Spin"](#error-local-llm-operations-are-not-supported-in-this-version-of-spin)
 
-The nature of AI and LLM workloads on already trained models lends itself very naturally to a serverless-style architecture. As a framework for building and deploying serverless applications, Spin provides an interface for you to perform AI inference within Spin applications. 
+The nature of AI and LLM workloads on already trained models lends itself very naturally to a serverless-style architecture. As a framework for building and deploying serverless applications, Spin provides an interface for you to perform AI inference within Spin applications.
 
-## Using Serverless AI From Applications 
+## Using Serverless AI From Applications
 
 ### Configuration
 
@@ -94,7 +94,7 @@ fn handle_code(req: Request) -> anyhow::Result<impl IntoResponse> {
         },
     )?;
 
-    // -- snip --	
+    // -- snip --
 }
 
 ```
@@ -105,7 +105,7 @@ The `infer_with_options` examples, operation:
 
 - The above example takes the model name `llm::InferencingModel::CodellamaInstruct` as input. From an interface point of view, the model name is technically an alias for a string (to maximize future compatibility as users want to support more and different types of models).
 - The second parameter is a prompt (string) from whoever/whatever is making the request to the `handle_code()` function.
-- A third, optional, parameter which is an interface allows you to specify parameters such as `max_tokens`, `repeat_penalty`, `repeat_penalty_last_n_token_count`, `temperature`, `top_k` and `top_p`.  
+- A third, optional, parameter which is an interface allows you to specify parameters such as `max_tokens`, `repeat_penalty`, `repeat_penalty_last_n_token_count`, `temperature`, `top_k` and `top_p`.
 - The return value (the `inferencing-result` record) contains a text field of type `string`. Ideally, this would be a `stream` that would allow streaming inferencing results back to the user, but alas streaming support is not yet ready for use so we leave that as a possible future backward incompatible change.
 
 {{ blockEnd }}
@@ -114,7 +114,7 @@ The `infer_with_options` examples, operation:
 
 > [**Want to go straight to the reference documentation?**  Find it here.](https://spinframework.github.io/spin-js-sdk/v2.3/modules/Llm.html)
 
-To use Serverless AI functions, [the `Llm` module](https://spinframework.github.io/spin-js-sdk/v2.3/modules/Llm.html) from the Spin SDK provides two methods: `infer` and `generateEmbeddings`. For example: 
+To use Serverless AI functions, [the `Llm` module](https://spinframework.github.io/spin-js-sdk/v2.3/modules/Llm.html) from the Spin SDK provides two methods: `infer` and `generateEmbeddings`. For example:
 
 ```javascript
 import { ResponseBuilder, Llm} from "@fermyon/spin-sdk"
@@ -133,14 +133,14 @@ export async function handler(req: Request, res: ResponseBuilder) {
 
 `infer` operation:
 
-- It takes in the following arguments - model name, prompt and a optional third parameter for inferencing options. 
+- It takes in the following arguments - model name, prompt and a optional third parameter for inferencing options.
 - The model name is a string. There are enums for the inbuilt models (llama2-chat and codellama) in [`InferencingModels`](https://spinframework.github.io/spin-js-sdk/v2.3/enums/Llm.InferencingModels.html).
-- The optional third parameter which is an [InferencingOptions](https://spinframework.github.io/spin-js-sdk/v2.3/interfaces/Llm.InferencingOptions.html) interface allows you to specify parameters such as `maxTokens`, `repeatPenalty`, `repeatPenaltyLastNTokenCount`, `temperature`, `topK`, `topP`.  
+- The optional third parameter which is an [InferencingOptions](https://spinframework.github.io/spin-js-sdk/v2.3/interfaces/Llm.InferencingOptions.html) interface allows you to specify parameters such as `maxTokens`, `repeatPenalty`, `repeatPenaltyLastNTokenCount`, `temperature`, `topK`, `topP`.
 - The return value is an [`InferenceResult`](https://spinframework.github.io/spin-js-sdk/v2.3/interfaces/Llm.EmbeddingResult.html).
 
 `generateEmbeddings` operation:
 
-- It takes two arguments - model name and list of strings to generate the embeddings for. 
+- It takes two arguments - model name and list of strings to generate the embeddings for.
 - The model name is a string. There are enums for the inbuilt models (AllMiniLmL6V2) in [`EmbeddingModels`](https://spinframework.github.io/spin-js-sdk/v2.3/enums/Llm.EmbeddingModels.html).
 - The return value is an [`EmbeddingResult`](https://spinframework.github.io/spin-js-sdk/v2.3/interfaces/Llm.EmbeddingResult.html)
 
@@ -171,15 +171,15 @@ class IncomingHandler(http.IncomingHandler):
 - The model name is passed in as a string (as shown above; `"llama2-chat"`).
 [`infer_with_options` operation](https://spinframework.github.io/spin-python-sdk/llm.html#spin_sdk.llm.infer_with_options):
 
-- It takes in a model name, prompt text, and optionally a [parameter object](https://spinframework.github.io/spin-python-sdk/llm.html#spin_sdk.llm.InferencingParams) to control the inferencing. 
+- It takes in a model name, prompt text, and optionally a [parameter object](https://spinframework.github.io/spin-python-sdk/llm.html#spin_sdk.llm.InferencingParams) to control the inferencing.
 
 {{ blockEnd }}
 
 {{ startTab "TinyGo"}}
 
-> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/llm)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/v2@v2.0.0/llm)
 
-Serverless AI functions are available in the `github.com/fermyon/spin/sdk/go/v2/llm` package. See [Go Packages](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2/llm) for reference documentation. For example:
+Serverless AI functions are available in the `github.com/spinframework/spin/sdk/go/v2/llm` package. See [Go Packages](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/v2/llm) for reference documentation. For example:
 
 ```go
 package main
@@ -188,8 +188,8 @@ import (
 	"fmt"
 	"net/http"
 
-	spinhttp "github.com/fermyon/spin/sdk/go/v2/http"
-	"github.com/fermyon/spin/sdk/go/v2/llm"
+	spinhttp "github.com/spinframework/spin/sdk/go/v2/http"
+	"github.com/spinframework/spin/sdk/go/v2/llm"
 )
 
 func init() {
@@ -245,5 +245,5 @@ Most Spin builds support local LLMs as described above. However, the models buil
 
 In such cases, you can:
 
-* See if there is another Spin build available for your platform. All current builds from the [Spin GitHub repository](https://github.com/fermyon/spin) or [Spin installer support](./install.md) support local LLMs.
+* See if there is another Spin build available for your platform. All current builds from the [Spin GitHub repository](https://github.com/spinframework/spin) or [Spin installer support](./install.md) support local LLMs.
 * Use the [`cloud-gpu` plugin and runtime config option](./serverless-ai-hello-world.md#building-and-deploying-your-spin-application) to have LLM inferencing serviced in Fermyon Cloud instead of locally.

--- a/content/spin/v2/spin-application-structure.md
+++ b/content/spin/v2/spin-application-structure.md
@@ -174,7 +174,7 @@ route = "/static/..."
 component = "assets"
 
 [component.assets]
-source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.1.0/spin_static_fs.wasm", digest = "sha256:96c76d9af86420b39eb6cd7be5550e3cb5d4cc4de572ce0fd1f6a29471536cb4" }
+source = { url = "https://github.com/spinframework/spin-fileserver/releases/download/v0.1.0/spin_static_fs.wasm", digest = "sha256:96c76d9af86420b39eb6cd7be5550e3cb5d4cc4de572ce0fd1f6a29471536cb4" }
 files = [ { source = "assets", destination = "/" } ]
 
 [[trigger.http]]

--- a/content/spin/v2/sqlite-api-guide.md
+++ b/content/spin/v2/sqlite-api-guide.md
@@ -109,7 +109,7 @@ struct ToDo {
 }
 ```
 
-**General Notes** 
+**General Notes**
 * All functions are on the `spin_sdk::sqlite::Connection` type.
 * Parameters are instances of the `Value` enum; you must wrap raw values in this type.
 * The `execute` function returns a `QueryResult`. To iterate over the rows use the `rows()` function. This returns an iterator; use `collect()` if you want to load it all into a collection.
@@ -157,7 +157,7 @@ class IncomingHandler(http.IncomingHandler):
         with sqlite.open_default() as db:
             result = db.execute("SELECT * FROM todos WHERE id > (?);", [ValueInteger(1)])
             rows = result.rows
-        
+
         return Response(
             200,
             {"content-type": "text/plain"},
@@ -174,7 +174,7 @@ class IncomingHandler(http.IncomingHandler):
 
 {{ startTab "TinyGo"}}
 
-> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/sqlite)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/v2@v2.0.0/sqlite)
 
 The Go SDK is implemented as a driver for the standard library's [database/sql](https://pkg.go.dev/database/sql) interface.
 
@@ -185,8 +185,8 @@ import (
 	"encoding/json"
 	"net/http"
 
-	spinhttp "github.com/fermyon/spin/sdk/go/v2/http"
-	"github.com/fermyon/spin/sdk/go/v2/sqlite"
+	spinhttp "github.com/spinframework/spin/sdk/go/v2/http"
+	"github.com/spinframework/spin/sdk/go/v2/sqlite"
 )
 
 type Todo struct {

--- a/content/spin/v2/troubleshooting-application-dev.md
+++ b/content/spin/v2/troubleshooting-application-dev.md
@@ -39,7 +39,7 @@ $ spin doctor
 
 If `spin doctor` detects a problem it can fix, you can choose to accept the fix, skip it to fix manually later, or see more details before choosing.  If `spin doctor` can't fix the problem, it displays the problem so you can make your own decision about how to fix it.
 
-> `spin doctor` is in an early stage of development, and there are many potential problems it doesn't yet check for. Please [raise an issue](https://github.com/fermyon/spin/issues/new?template=suggestion.md) if you have a problem you think `spin doctor` should check for.
+> `spin doctor` is in an early stage of development, and there are many potential problems it doesn't yet check for. Please [raise an issue](https://github.com/spinframework/spin/issues/new?template=suggestion.md) if you have a problem you think `spin doctor` should check for.
 
 ## Spin Test
 

--- a/content/spin/v2/upgrade.md
+++ b/content/spin/v2/upgrade.md
@@ -27,7 +27,7 @@ $ spin --version
 
 You can compare the output from the above command with the [latest release release](https://github.com/spinframework/spin/releases/latest) listed in the Spin GitHub repository (which is also shown in the image below):
 
-![spin version image](https://img.shields.io/github/v/release/fermyon/spin)
+![spin version image](https://img.shields.io/github/v/release/spinframework/spin)
 
 ## Upgrade Spin
 
@@ -67,7 +67,7 @@ $ where spin
 
 {{ blockEnd }}
 
-### Installer 
+### Installer
 
 If you originally followed the documentation's [installer script method](./install#installing-spin), please revisit to reinstall.
 
@@ -118,7 +118,7 @@ If you have upgraded Spin and don't see the newer version, please consider the f
 
 ### Not Seeing the Latest Version?
 
-It may be possible that you have installed Spin **using more than one** of the above methods. In this case, the Spin executable that runs is the one that is listed first in your `PATH` system variable. 
+It may be possible that you have installed Spin **using more than one** of the above methods. In this case, the Spin executable that runs is the one that is listed first in your `PATH` system variable.
 
 If you have upgraded Spin yet still see the old version using `spin --version` this can be due to the order of precedence in your `PATH`. Try echoing your path to the screen and checking to see whether the location of your intended Spin executable is listed before or after other pre-existing installation paths:
 
@@ -129,6 +129,6 @@ echo $PATH
 
 > Paths are separated by the `:` (colon)
 
-In the above case, the [Cargo install method](./install#using-cargo-to-install-spin)'s installation will take precedence over the [installer script method](./install#installing-spin)'s installation. 
+In the above case, the [Cargo install method](./install#using-cargo-to-install-spin)'s installation will take precedence over the [installer script method](./install#installing-spin)'s installation.
 
 In this case, you can either remove the Cargo installation of Spin using `cargo uninstall spin-cli` or update your system path to prioritize the Spin binary path that you prefer.

--- a/content/spin/v2/url-shortener-tutorial.md
+++ b/content/spin/v2/url-shortener-tutorial.md
@@ -47,7 +47,7 @@ using Spin.
 First, we start with [a new Spin component written in Rust](./rust-components.md):
 
 ```rust
-/// A Spin HTTP component that redirects requests 
+/// A Spin HTTP component that redirects requests
 /// based on the router configuration.
 #[http_component]
 fn redirect(req: Request) -> Result<Response> {
@@ -119,7 +119,7 @@ And the component can now handle incoming requests:
 # to /spin should be redirected
 $ curl -i localhost:3000/spin
 HTTP/1.1 308 Permanent Redirect
-location: https://github.com/fermyon/spin
+location: https://github.com/spinframework/spin
 content-length: 0
 # based on the configuration file, a request
 # to /hype should be redirected

--- a/content/spin/v2/variables.md
+++ b/content/spin/v2/variables.md
@@ -9,7 +9,7 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/v2/variables.
 - [Adding Variables to Your Applications](#adding-variables-to-your-applications)
 - [Using Variables From Applications](#using-variables-from-applications)
 
-Spin supports dynamic application variables. Instead of being static, their values can be updated without modifying the application, creating a simpler experience for rotating secrets, updating API endpoints, and more. 
+Spin supports dynamic application variables. Instead of being static, their values can be updated without modifying the application, creating a simpler experience for rotating secrets, updating API endpoints, and more.
 
 These variables are defined in a Spin application manifest (in the `[variables]` section), and their values can be set or overridden at runtime by an [application variables provider](./dynamic-configuration.md#application-variables-runtime-configuration). When running Spin locally, the variables provider can be [Hashicorp Vault](./dynamic-configuration.md#vault-application-variable-provider) for secrets, [Azure Key Vault](https://azure.microsoft.com/en-us/products/key-vault), or host environment variables.
 
@@ -92,7 +92,7 @@ The Spin SDK surfaces the Spin configuration interface to your language. The [in
 |------------|--------------------|---------------------|----------|
 | `get`      | Variable name      | Variable value      | Gets the value of the variable from the configured provider |
 
-To illustrate the variables API, each of the following examples makes a request to some API with a bearer token. The API URI, version, and token are all passed as application variables. The application manifest associated with the examples would look similar to the one described [in the previous section](#adding-variables-to-your-applications). 
+To illustrate the variables API, each of the following examples makes a request to some API with a bearer token. The API URI, version, and token are all passed as application variables. The application manifest associated with the examples would look similar to the one described [in the previous section](#adding-variables-to-your-applications).
 
 The exact details of calling the config SDK from a Spin application depends on the language:
 
@@ -191,9 +191,9 @@ class IncomingHandler(IncomingHandler):
 
 {{ startTab "TinyGo"}}
 
-> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/variables)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/v2@v2.0.0/variables)
 
-The function is available in the `github.com/fermyon/spin/sdk/go/v2/variables` package and is named `Get`. See [Go package](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2/variables) for reference documentation.
+The function is available in the `github.com/spinframework/spin/sdk/go/v2/variables` package and is named `Get`. See [Go package](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/v2/variables) for reference documentation.
 
 ```go
 import (
@@ -201,8 +201,8 @@ import (
 	"fmt"
 	"net/http"
 
-	spinhttp "github.com/fermyon/spin/sdk/go/v2/http"
-	"github.com/fermyon/spin/sdk/go/v2/variables"
+	spinhttp "github.com/spinframework/spin/sdk/go/v2/http"
+	"github.com/spinframework/spin/sdk/go/v2/variables"
 )
 
 func init() {

--- a/content/spin/v2/writing-apps.md
+++ b/content/spin/v2/writing-apps.md
@@ -128,7 +128,7 @@ For components that are published on the Web, provide a `url` field containing t
 
 ```toml
 [component.asset-server]
-source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.0.1/spin_static_fs.wasm", digest = "sha256:650376c33a0756b1a52cad7ca670f1126391b79050df0321407da9c741d32375" }
+source = { url = "https://github.com/spinframework/spin-fileserver/releases/download/v0.0.1/spin_static_fs.wasm", digest = "sha256:650376c33a0756b1a52cad7ca670f1126391b79050df0321407da9c741d32375" }
 ```
 
 Multiple components can have the same source.  An example is a document archive, where one component might serve user interface assets (CSS, images, etc.) on one route, while another serves the documents themselves on another route - both using the same file server module, but with different settings.
@@ -387,7 +387,7 @@ route = "/static/..."
 component = "fileserver"
 
 [component.fileserver]
-source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.0.1/spin_static_fs.wasm", digest = "sha256:650376c33a0756b1a52cad7ca670f1126391b79050df0321407da9c741d32375" }
+source = { url = "https://github.com/spinframework/spin-fileserver/releases/download/v0.0.1/spin_static_fs.wasm", digest = "sha256:650376c33a0756b1a52cad7ca670f1126391b79050df0321407da9c741d32375" }
 files = [ { source = "static/", destination = "/" } ]
 ```
 

--- a/content/spin/v3/ai-sentiment-analysis-api-tutorial.md
+++ b/content/spin/v3/ai-sentiment-analysis-api-tutorial.md
@@ -631,9 +631,9 @@ import (
 	"net/http"
 	"strings"
 
-	spinhttp "github.com/fermyon/spin/sdk/go/v2/http"
-	"github.com/fermyon/spin/sdk/go/v2/kv"
-	"github.com/fermyon/spin/sdk/go/v2/llm"
+	spinhttp "github.com/spinframework/spin/sdk/go/v2/http"
+	"github.com/spinframework/spin/sdk/go/v2/kv"
+	"github.com/spinframework/spin/sdk/go/v2/llm"
 )
 
 type sentimentAnalysisRequest struct {
@@ -993,7 +993,7 @@ route = "/..."
 component = "ui"
 
 [component.ui]
-source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.3.0/spin_static_fs.wasm", digest = "sha256:ef88708817e107bf49985c7cefe4dd1f199bf26f6727819183d5c996baa3d148" }
+source = { url = "https://github.com/spinframework/spin-fileserver/releases/download/v0.3.0/spin_static_fs.wasm", digest = "sha256:ef88708817e107bf49985c7cefe4dd1f199bf26f6727819183d5c996baa3d148" }
 files = [{ source = "assets", destination = "/" }]
 
 [[trigger.http]]
@@ -1056,7 +1056,7 @@ route = "/..."
 component = "ui"
 
 [component.ui]
-source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.3.0/spin_static_fs.wasm", digest = "sha256:ef88708817e107bf49985c7cefe4dd1f199bf26f6727819183d5c996baa3d148" }
+source = { url = "https://github.com/spinframework/spin-fileserver/releases/download/v0.3.0/spin_static_fs.wasm", digest = "sha256:ef88708817e107bf49985c7cefe4dd1f199bf26f6727819183d5c996baa3d148" }
 files = [{ source = "assets", destination = "/" }]
 ```
 

--- a/content/spin/v3/go-components.md
+++ b/content/spin/v3/go-components.md
@@ -26,7 +26,7 @@ Using TinyGo to compile components for Spin is currently required, as the
 
 > All examples from this page can be found in [the Spin Go SDK repository on GitHub](https://github.com/spinframework/spin-go-sdk/tree/main/examples).
 
-[**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2)
+[**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/v2)
 
 ## Versions
 
@@ -52,7 +52,7 @@ import (
  "fmt"
  "net/http"
 
- spinhttp "github.com/fermyon/spin/sdk/go/v2/http"
+ spinhttp "github.com/spinframework/spin/sdk/go/v2/http"
 )
 
 func init() {
@@ -122,7 +122,7 @@ import (
  "net/http"
  "os"
 
- spinhttp "github.com/fermyon/spin/sdk/go/v2/http"
+ spinhttp "github.com/spinframework/spin/sdk/go/v2/http"
 )
 
 func init() {
@@ -213,7 +213,7 @@ package main
 import (
  "fmt"
 
- "github.com/fermyon/spin/sdk/go/v2/redis"
+ "github.com/spinframework/spin/sdk/go/v2/redis"
 )
 
 func init() {
@@ -302,8 +302,8 @@ import (
  "net/http"
  "os"
 
- spin_http "github.com/fermyon/spin/sdk/go/v2/http"
- "github.com/fermyon/spin/sdk/go/v2/redis"
+ spin_http "github.com/spinframework/spin/sdk/go/v2/http"
+ "github.com/spinframework/spin/sdk/go/v2/redis"
 )
 
 func init() {

--- a/content/spin/v3/http-outbound.md
+++ b/content/spin/v3/http-outbound.md
@@ -103,7 +103,7 @@ const response = await fetch("https://example.com/users");
 
 You can find a complete example of using outbound HTTP in the JavaScript SDK repository on [GitHub](https://github.com/spinframework/spin-js-sdk/tree/main/examples/common-patterns/outbound-http)
 
-**Note**: `fetch` currently only works when building for the HTTP trigger.  
+**Note**: `fetch` currently only works when building for the HTTP trigger.
 
 {{ blockEnd }}
 
@@ -131,13 +131,13 @@ You can find a complete example for using outbound HTTP in the [Python SDK repos
 
 {{ startTab "TinyGo"}}
 
-> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/http)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/v2@v2.0.0/http)
 
-HTTP functions are available in the `github.com/fermyon/spin/sdk/go/v2/http` package. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2/http) The general function is named `Send`, but the Go SDK also surfaces individual functions, with request-specific parameters, for the `Get` and `Post` operations. For example:
+HTTP functions are available in the `github.com/spinframework/spin/sdk/go/v2/http` package. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/v2/http) The general function is named `Send`, but the Go SDK also surfaces individual functions, with request-specific parameters, for the `Get` and `Post` operations. For example:
 
 ```go
 import (
-	spinhttp "github.com/fermyon/spin/sdk/go/v2/http"
+	spinhttp "github.com/spinframework/spin/sdk/go/v2/http"
 )
 
 res1, err1 := spinhttp.Get("https://random-data-api.fermyon.app/animals/json")

--- a/content/spin/v3/http-trigger.md
+++ b/content/spin/v3/http-trigger.md
@@ -89,7 +89,7 @@ component = "user-manager"
 ### Resolving Overlapping Routes
 
 If multiple triggers could potentially handle the same request based on their
-defined routes, the trigger whose route has the longest matching prefix 
+defined routes, the trigger whose route has the longest matching prefix
 takes precedence.  This also means that exact matches take precedence over wildcard matches.
 
 In the following example, requests starting with the  `/users/` prefix (e.g. `/users/1`)
@@ -302,7 +302,7 @@ class IncomingHandler(http.IncomingHandler):
 
 {{ startTab "TinyGo"}}
 
-> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/http)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/v2@v2.0.0/http)
 
 In Go, you register the handler as a callback in your program's `init` function.  Call `spinhttp.Handle`, passing your handler as the sole argument.  Your handler takes a `http.Request` record, from the standard `net/http` package, and a `ResponseWriter` to construct the response.
 
@@ -313,7 +313,7 @@ import (
         "fmt"
         "net/http"
 
-        spinhttp "github.com/fermyon/spin/sdk/go/v2/http"
+        spinhttp "github.com/spinframework/spin/sdk/go/v2/http"
 )
 
 func init() {

--- a/content/spin/v3/key-value-store-tutorial.md
+++ b/content/spin/v3/key-value-store-tutorial.md
@@ -109,7 +109,7 @@ $ spin new -t http-go spin-key-value
 
 ## Configuration
 
-Good news - Spin will take care of setting up your Key Value store. However, in order to make sure your Spin application has permission to access the Key Value store, you must add the `key_value_stores = ["default"]` line in the `[component.<component-name>]` section of the `spin.toml` file, for each component which needs access to the Key Value store. This line is necessary to communicate to Spin that a given component has access to the default Key Value store. A newly scaffolded Spin application will not have this line; you will need to add it. 
+Good news - Spin will take care of setting up your Key Value store. However, in order to make sure your Spin application has permission to access the Key Value store, you must add the `key_value_stores = ["default"]` line in the `[component.<component-name>]` section of the `spin.toml` file, for each component which needs access to the Key Value store. This line is necessary to communicate to Spin that a given component has access to the default Key Value store. A newly scaffolded Spin application will not have this line; you will need to add it.
 
 > Note: `[component.spin_key_value]` contains the name of the component. If you used a different name, when creating the application, this sections name would be different.
 
@@ -150,7 +150,7 @@ key_value_stores = ["default"]
 
 ## Write Code to Save and Load Data
 
-In this section, we use the Spin SDK to open and persist our application's data inside our default key/value store. This is a special store that every environment running Spin applications will make available for their application. 
+In this section, we use the Spin SDK to open and persist our application's data inside our default key/value store. This is a special store that every environment running Spin applications will make available for their application.
 
 ### The Spin SDK Version
 
@@ -332,8 +332,8 @@ import (
 	"net/http"
 	"fmt"
 
-	spin_http "github.com/fermyon/spin/sdk/go/v2/http"
-	"github.com/fermyon/spin/sdk/go/v2/kv"
+	spin_http "github.com/spinframework/spin/sdk/go/v2/http"
+	"github.com/spinframework/spin/sdk/go/v2/kv"
 )
 
 func init() {
@@ -407,7 +407,7 @@ func init() {
 
 ## Building and Running Your Spin Application
 
-Now, let's build and run our Spin Application locally. Run the following command to build your application: 
+Now, let's build and run our Spin Application locally. Run the following command to build your application:
 
 <!-- @selectiveCpy -->
 
@@ -476,9 +476,9 @@ As we can see above, there is currently no data found at the `/test` endpoint of
 
 ## (Optional) Deploy Your App To Fermyon Cloud
 
-Optionally, if you'd like to deploy your application and key value store to Fermyon Cloud here are the required steps. 
+Optionally, if you'd like to deploy your application and key value store to Fermyon Cloud here are the required steps.
 
-First, login to your Fermyon Cloud account. If you do not have one already, this will take you through the signup process for a free account. 
+First, login to your Fermyon Cloud account. If you do not have one already, this will take you through the signup process for a free account.
 
 <!-- @selectiveCpy -->
 
@@ -512,12 +512,11 @@ Would you like to link an existing key value store or create a new key value sto
   Create a new key value store and link the app to it
 ```
 
->> If you're interested in learning more about how to link your Spin app to different key value store instances on Fermyon Cloud, check out our [Key Value Links and Labels tutorial](../../cloud/linking-applications-to-resources-using-labels.md). 
+>> If you're interested in learning more about how to link your Spin app to different key value store instances on Fermyon Cloud, check out our [Key Value Links and Labels tutorial](../../cloud/linking-applications-to-resources-using-labels.md).
 
-Congratulations, you have a Spin application and associated Key Value store running up in Fermyon Cloud! You can visit it by clicking on the Spin application's domain name generated in the CLI output, which has the following pattern: `spin-key-value-<RANDOM>.fermyon.app`. 
+Congratulations, you have a Spin application and associated Key Value store running up in Fermyon Cloud! You can visit it by clicking on the Spin application's domain name generated in the CLI output, which has the following pattern: `spin-key-value-<RANDOM>.fermyon.app`.
 
 ## Next Steps
 
 * Explore the contents of your Key Value store with the [Key Value Store Explorer template](../../hub/preview/template_kv_explorer)
-* Learn about linking your applications to different [Key Value Stores on Fermyon Cloud](../../cloud/kv-cloud-tutorial.md) 
-
+* Learn about linking your applications to different [Key Value Stores on Fermyon Cloud](../../cloud/kv-cloud-tutorial.md)

--- a/content/spin/v3/kv-store-api-guide.md
+++ b/content/spin/v3/kv-store-api-guide.md
@@ -65,7 +65,7 @@ fn handle_request(_req: Request) -> Result<impl IntoResponse> {
 }
 ```
 
-**General Notes** 
+**General Notes**
 
 `set` **Operation**
 - For set, the value argument can be of any type that implements `AsRef<[u8]>`
@@ -96,7 +96,7 @@ let router = AutoRouter();
 router
     .get("/", () => {
         let store = Kv.openDefault()
-        store.set("mykey", "myvalue") 
+        store.set("mykey", "myvalue")
         return new Response(store.get("mykey") ?? "Key not found");
     })
 
@@ -136,7 +136,7 @@ class IncomingHandler(http.IncomingHandler):
         with key_value.open_default() as store:
             store.set("test", bytes("hello world!", "utf-8"))
             val = store.get("test")
-            
+
         return Response(
             200,
             {"content-type": "text/plain"},
@@ -155,12 +155,12 @@ class IncomingHandler(http.IncomingHandler):
 
 {{ startTab "TinyGo"}}
 
-> [**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/kv)
+> [**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/v2@v2.0.0/kv)
 
-Key value functions are provided by the `github.com/fermyon/spin/sdk/go/v2/kv` module. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2/kv) For example:
+Key value functions are provided by the `github.com/spinframework/spin/sdk/go/v2/kv` module. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/v2/kv) For example:
 
 ```go
-import "github.com/fermyon/spin/sdk/go/v2/kv"
+import "github.com/spinframework/spin/sdk/go/v2/kv"
 
 func example() error {
     store, err := kv.OpenStore("default")

--- a/content/spin/v3/language-support-overview.md
+++ b/content/spin/v3/language-support-overview.md
@@ -85,7 +85,7 @@ This page contains information about language support for Spin features:
 
 {{ startTab "TinyGo"}}
 
-**[📄 Visit the TinyGo Spin SDK reference documentation](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2) to see specific modules, functions, variables and syntax relating to the following TinyGo SDK.**
+**[📄 Visit the TinyGo Spin SDK reference documentation](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/v2) to see specific modules, functions, variables and syntax relating to the following TinyGo SDK.**
 
 | Feature | SDK Supported? |
 |-----|-----|

--- a/content/spin/v3/migration-v2-v3.md
+++ b/content/spin/v3/migration-v2-v3.md
@@ -26,7 +26,7 @@ Most applications will not require changes. The following changes may affect app
   If you relied on environment variables taking precedence over other sources, you will need to stop setting `--runtime-config-file`
   or tweak your workflow.
 * Some modules produced by languages with older WASI support may no longer run. This specifically affects WAGI applications
-  compiled with a WASI-SDK version 18 or earlier. See [https://github.com/fermyon/spin/issues/2552](https://github.com/fermyon/spin/issues/2552) for details
+  compiled with a WASI-SDK version 18 or earlier. See [https://github.com/spinframework/spin/issues/2552](https://github.com/spinframework/spin/issues/2552) for details
   of the issue and for possible workarounds.
 
 The following change will not affect most application authors, but may affect you if you work directly with the low-level WASI interfaces:

--- a/content/spin/v3/quickstart.md
+++ b/content/spin/v3/quickstart.md
@@ -402,7 +402,7 @@ Now let's have a look at the code. Below is the complete source
 code for a Spin HTTP component written in TypeScript — A function is attached to the fetch event listener which receives and responds to the HTTP request.
 
 ```javascript
-❯ cat hello-world/src/index.ts 
+❯ cat hello-world/src/index.ts
 import { AutoRouter } from 'itty-router';
 
 let router = AutoRouter();
@@ -501,7 +501,7 @@ The `requirements.txt`, by default, contains the references to the `spin-sdk` an
 <!-- @selectiveCpy -->
 
 ```bash
-$ pip3 install -r requirements.txt 
+$ pip3 install -r requirements.txt
 Collecting spin-sdk==3.1.0 (from -r requirements.txt (line 1))
   Using cached spin_sdk-3.1.0-py3-none-any.whl.metadata (16 kB)
 Collecting componentize-py==0.13.3 (from -r requirements.txt (line 2))
@@ -521,7 +521,7 @@ The `hello-python` directory structure created by the Spin `http-py` template is
 ```text
 ├── app.py
 ├── spin.toml
-└── requirements.txt 
+└── requirements.txt
 ```
 
 The additional `spin.toml` file is the manifest file, which tells Spin what events should trigger what components.  In this case our trigger is HTTP, for a Web application, and we have only one component, at the route `/...`.  This is a wildcard that matches any route.
@@ -652,7 +652,7 @@ import (
         "fmt"
         "net/http"
 
-        spinhttp "github.com/fermyon/spin/sdk/go/v2/http"
+        spinhttp "github.com/spinframework/spin/sdk/go/v2/http"
 )
 
 func init() {
@@ -684,7 +684,7 @@ Executing the build command for component hello-rust: cargo build --target wasm3
    Compiling anyhow v1.0.69
    Compiling version_check v0.9.4
    # ...
-   Compiling spin-sdk v0.10.0 
+   Compiling spin-sdk v0.10.0
    Compiling hello-rust v0.1.0 (/home/ivan/testing/start/hello_rust)
     Finished release [optimized] target(s) in 11.94s
 Finished building all Spin components
@@ -816,7 +816,7 @@ You can always run this command manually; `spin build` is a shortcut.
 ```bash
 $ spin build
 Executing the build command for component hello-go: tinygo build -target=wasip1 -gc=leaking -buildmode=c-shared -no-debug -o main.wasm .
-go: downloading github.com/fermyon/spin/sdk/go v0.10.0
+go: downloading github.com/spinframework/spin/sdk/go v0.10.0
 Finished building all Spin components
 ```
 
@@ -881,7 +881,7 @@ date = "2023-11-04T00:00:01Z"
 Hello, Fermyon
 ```
 
-> The `curl` output may vary based on which language SDK you use. 
+> The `curl` output may vary based on which language SDK you use.
 
 You'll also see any logging (stdout/stderr) from the generated code printed to the console where Spin is running. For more details, see the [page about running Spin applications](./running-apps.md).
 

--- a/content/spin/v3/rdbms-storage.md
+++ b/content/spin/v3/rdbms-storage.md
@@ -82,7 +82,7 @@ The code below is an [Outbound MySQL example](https://github.com/spinframework/s
 import { AutoRouter } from 'itty-router';
 import { Mysql } from '@fermyon/spin-sdk';
 
-// Connects as the root user without a password 
+// Connects as the root user without a password
 const DB_URL = "mysql://root:@127.0.0.1/spin_dev"
 
 /*
@@ -128,7 +128,7 @@ class IncomingHandler(http.IncomingHandler):
     def handle_request(self, request: Request) -> Response:
         with mysql.open("mysql://root:@127.0.0.1/spin_dev") as db:
             print(db.query("select * from test", []))
-        
+
         return Response(
             200,
             {"content-type": "text/plain"},
@@ -140,9 +140,9 @@ class IncomingHandler(http.IncomingHandler):
 
 {{ startTab "TinyGo"}}
 
-> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/v2)
 
-MySQL functions are available in the `github.com/fermyon/spin/sdk/go/v2/mysql` package, and PostgreSQL in `github.com/fermyon/spin/sdk/go/v2/pg`. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2)
+MySQL functions are available in the `github.com/spinframework/spin/sdk/go/v2/mysql` package, and PostgreSQL in `github.com/spinframework/spin/sdk/go/v2/pg`. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/v2)
 
 The package follows the usual Go database API. Use `Open` to return a connection to the database of type `*sql.DB` - see the [Go standard library documentation](https://pkg.go.dev/database/sql#DB) for usage information.  For example:
 
@@ -155,8 +155,8 @@ import (
 	"net/http"
 	"os"
 
-	spinhttp "github.com/fermyon/spin/sdk/go/v2/http"
-	"github.com/fermyon/spin/sdk/go/v2/pg"
+	spinhttp "github.com/spinframework/spin/sdk/go/v2/http"
+	"github.com/spinframework/spin/sdk/go/v2/pg"
 )
 
 type Pet struct {

--- a/content/spin/v3/redis-outbound.md
+++ b/content/spin/v3/redis-outbound.md
@@ -83,7 +83,7 @@ For full details of the Redis API, see the [Spin SDK reference documentation](ht
 
 * The arguments and results are enums, representing integers, binary payloads, and (for results) status and nil values.
 
-You can find a complete Rust code example for using outbound Redis from an HTTP component in the [Spin repository on GitHub](https://github.com/spinframework/spin-rust-sdk/tree/main/examples/redis-outbound). Please also see this, related, [outbound Redis (using Rust) section](./rust-components#storing-data-in-redis-from-rust-components). 
+You can find a complete Rust code example for using outbound Redis from an HTTP component in the [Spin repository on GitHub](https://github.com/spinframework/spin-rust-sdk/tree/main/examples/redis-outbound). Please also see this, related, [outbound Redis (using Rust) section](./rust-components#storing-data-in-redis-from-rust-components).
 
 {{ blockEnd }}
 
@@ -139,13 +139,13 @@ You can find a complete Python code example for using outbound Redis from an HTT
 
 {{ startTab "TinyGo"}}
 
-> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/redis)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/v2@v2.0.0/redis)
 
-Redis functions are available in the `github.com/fermyon/spin/sdk/go/v2/redis` package. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2/redis) The function names are TitleCased. For example:
+Redis functions are available in the `github.com/spinframework/spin/sdk/go/v2/redis` package. [See Go Packages for reference documentation.](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/v2/redis) The function names are TitleCased. For example:
 
 ```go
 import (
-	"github.com/fermyon/spin/sdk/go/v2/redis"
+	"github.com/spinframework/spin/sdk/go/v2/redis"
 )
 
 rdb := redis.NewClient(addr)
@@ -164,7 +164,7 @@ payload, err := rdb.Get(key)
 * The arguments are passed as `[]redis.RedisParameter`. You can construct `RedisParameter` instances around an `interface{}` but must provide a `Kind`. For example, `hello := redis.RedisParameter{Kind: redis.RedisParameterKindBinary, Val: []byte("hello")}`.
 * The results are returned as `[]redis.Result`. You can use the `Kind` member of `redis.Result` to interpret the `Val`.
 
-You can find a complete TinyGo example for using outbound Redis from an HTTP component in the [Spin repository on GitHub](https://github.com/spinframework/spin-go-sdk/tree/main/examples/redis-outbound). Please also see this, related, [outbound Redis (using TinyGo) section](./go-components#storing-data-in-redis-from-go-components). 
+You can find a complete TinyGo example for using outbound Redis from an HTTP component in the [Spin repository on GitHub](https://github.com/spinframework/spin-go-sdk/tree/main/examples/redis-outbound). Please also see this, related, [outbound Redis (using TinyGo) section](./go-components#storing-data-in-redis-from-go-components).
 
 {{ blockEnd }}
 

--- a/content/spin/v3/redis-trigger.md
+++ b/content/spin/v3/redis-trigger.md
@@ -114,7 +114,7 @@ class InboundRedis(exports.InboundRedis):
 
 {{ startTab "TinyGo"}}
 
-> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/redis)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/v2@v2.0.0/redis)
 
 In Go, you register the handler as a callback in your program's `init` function.  Call `redis.Handle` (from the Spin SDK `redis` package), passing your handler as the sole argument.  Your handler takes a single byte slice (`[]byte`) argument, and may return an error or `nil`.
 
@@ -128,7 +128,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/fermyon/spin/sdk/go/v2/redis"
+	"github.com/spinframework/spin/sdk/go/v2/redis"
 )
 
 func init() {

--- a/content/spin/v3/serverless-ai-api-guide.md
+++ b/content/spin/v3/serverless-ai-api-guide.md
@@ -13,9 +13,9 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/v3/serverless
 - [Troubleshooting](#troubleshooting)
   - [Error "Local LLM operations are not supported in this version of Spin"](#error-local-llm-operations-are-not-supported-in-this-version-of-spin)
 
-The nature of AI and LLM workloads on already trained models lends itself very naturally to a serverless-style architecture. As a framework for building and deploying serverless applications, Spin provides an interface for you to perform AI inference within Spin applications. 
+The nature of AI and LLM workloads on already trained models lends itself very naturally to a serverless-style architecture. As a framework for building and deploying serverless applications, Spin provides an interface for you to perform AI inference within Spin applications.
 
-## Using Serverless AI From Applications 
+## Using Serverless AI From Applications
 
 ### Configuration
 
@@ -98,7 +98,7 @@ fn handle_code(req: Request) -> anyhow::Result<impl IntoResponse> {
         },
     )?;
 
-    // -- snip --	
+    // -- snip --
 }
 
 ```
@@ -109,7 +109,7 @@ The `infer_with_options` examples, operation:
 
 - The above example takes the model name `llm::InferencingModel::CodellamaInstruct` as input. From an interface point of view, the model name is technically an alias for a string (to maximize future compatibility as users want to support more and different types of models).
 - The second parameter is a prompt (string) from whoever/whatever is making the request to the `handle_code()` function.
-- A third, optional, parameter which is an interface allows you to specify parameters such as `max_tokens`, `repeat_penalty`, `repeat_penalty_last_n_token_count`, `temperature`, `top_k` and `top_p`.  
+- A third, optional, parameter which is an interface allows you to specify parameters such as `max_tokens`, `repeat_penalty`, `repeat_penalty_last_n_token_count`, `temperature`, `top_k` and `top_p`.
 - The return value (the `inferencing-result` record) contains a text field of type `string`. Ideally, this would be a `stream` that would allow streaming inferencing results back to the user, but alas streaming support is not yet ready for use so we leave that as a possible future backward incompatible change.
 
 {{ blockEnd }}
@@ -118,7 +118,7 @@ The `infer_with_options` examples, operation:
 
 > [**Want to go straight to the reference documentation?**  Find it here.](https://spinframework.github.io/spin-js-sdk/stable/modules/Llm.html)
 
-To use Serverless AI functions, [the `Llm` module](https://spinframework.github.io/spin-js-sdk/stable/modules/Llm.html) from the Spin SDK provides two methods: `infer` and `generateEmbeddings`. For example: 
+To use Serverless AI functions, [the `Llm` module](https://spinframework.github.io/spin-js-sdk/stable/modules/Llm.html) from the Spin SDK provides two methods: `infer` and `generateEmbeddings`. For example:
 
 ```javascript
 import { AutoRouter } from 'itty-router';
@@ -145,14 +145,14 @@ addEventListener('fetch', async (event: FetchEvent) => {
 
 `infer` operation:
 
-- It takes in the following arguments - model name, prompt and a optional third parameter for inferencing options. 
+- It takes in the following arguments - model name, prompt and a optional third parameter for inferencing options.
 - The model name is a string. There are enums for the inbuilt models (llama2-chat and codellama) in [`InferencingModels`](https://spinframework.github.io/spin-js-sdk/stable/enums/Llm.InferencingModels.html).
-- The optional third parameter which is an [InferencingOptions](https://spinframework.github.io/spin-js-sdk/stable/interfaces/Llm.InferencingOptions.html) interface allows you to specify parameters such as `maxTokens`, `repeatPenalty`, `repeatPenaltyLastNTokenCount`, `temperature`, `topK`, `topP`.  
+- The optional third parameter which is an [InferencingOptions](https://spinframework.github.io/spin-js-sdk/stable/interfaces/Llm.InferencingOptions.html) interface allows you to specify parameters such as `maxTokens`, `repeatPenalty`, `repeatPenaltyLastNTokenCount`, `temperature`, `topK`, `topP`.
 - The return value is an [`InferenceResult`](https://spinframework.github.io/spin-js-sdk/stable/interfaces/Llm.EmbeddingResult.html).
 
 `generateEmbeddings` operation:
 
-- It takes two arguments - model name and list of strings to generate the embeddings for. 
+- It takes two arguments - model name and list of strings to generate the embeddings for.
 - The model name is a string. There are enums for the inbuilt models (AllMiniLmL6V2) in [`EmbeddingModels`](https://spinframework.github.io/spin-js-sdk/stable/enums/Llm.EmbeddingModels.html).
 - The return value is an [`EmbeddingResult`](https://spinframework.github.io/spin-js-sdk/stable/interfaces/Llm.EmbeddingResult.html)
 
@@ -183,15 +183,15 @@ class IncomingHandler(http.IncomingHandler):
 - The model name is passed in as a string (as shown above; `"llama2-chat"`).
 [`infer_with_options` operation](https://spinframework.github.io/spin-python-sdk/llm.html#spin_sdk.llm.infer_with_options):
 
-- It takes in a model name, prompt text, and optionally a [parameter object](https://spinframework.github.io/spin-python-sdk/llm.html#spin_sdk.llm.InferencingParams) to control the inferencing. 
+- It takes in a model name, prompt text, and optionally a [parameter object](https://spinframework.github.io/spin-python-sdk/llm.html#spin_sdk.llm.InferencingParams) to control the inferencing.
 
 {{ blockEnd }}
 
 {{ startTab "TinyGo"}}
 
-> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/llm)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/v2@v2.0.0/llm)
 
-Serverless AI functions are available in the `github.com/fermyon/spin/sdk/go/v2/llm` package. See [Go Packages](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2/llm) for reference documentation. For example:
+Serverless AI functions are available in the `github.com/spinframework/spin/sdk/go/v2/llm` package. See [Go Packages](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/v2/llm) for reference documentation. For example:
 
 ```go
 package main
@@ -200,8 +200,8 @@ import (
 	"fmt"
 	"net/http"
 
-	spinhttp "github.com/fermyon/spin/sdk/go/v2/http"
-	"github.com/fermyon/spin/sdk/go/v2/llm"
+	spinhttp "github.com/spinframework/spin/sdk/go/v2/http"
+	"github.com/spinframework/spin/sdk/go/v2/llm"
 )
 
 func init() {

--- a/content/spin/v3/spin-application-structure.md
+++ b/content/spin/v3/spin-application-structure.md
@@ -174,7 +174,7 @@ route = "/static/..."
 component = "assets"
 
 [component.assets]
-source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.1.0/spin_static_fs.wasm", digest = "sha256:96c76d9af86420b39eb6cd7be5550e3cb5d4cc4de572ce0fd1f6a29471536cb4" }
+source = { url = "https://github.com/spinframework/spin-fileserver/releases/download/v0.1.0/spin_static_fs.wasm", digest = "sha256:96c76d9af86420b39eb6cd7be5550e3cb5d4cc4de572ce0fd1f6a29471536cb4" }
 files = [ { source = "assets", destination = "/" } ]
 
 [[trigger.http]]

--- a/content/spin/v3/sqlite-api-guide.md
+++ b/content/spin/v3/sqlite-api-guide.md
@@ -109,7 +109,7 @@ struct ToDo {
 }
 ```
 
-**General Notes** 
+**General Notes**
 * All functions are on the `spin_sdk::sqlite::Connection` type.
 * Parameters are instances of the `Value` enum; you must wrap raw values in this type.
 * The `execute` function returns a `QueryResult`. To iterate over the rows use the `rows()` function. This returns an iterator; use `collect()` if you want to load it all into a collection.
@@ -166,7 +166,7 @@ class IncomingHandler(http.IncomingHandler):
         with sqlite.open_default() as db:
             result = db.execute("SELECT * FROM todos WHERE id > (?);", [ValueInteger(1)])
             rows = result.rows
-        
+
         return Response(
             200,
             {"content-type": "text/plain"},
@@ -183,7 +183,7 @@ class IncomingHandler(http.IncomingHandler):
 
 {{ startTab "TinyGo"}}
 
-> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/sqlite)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/v2@v2.0.0/sqlite)
 
 The Go SDK is implemented as a driver for the standard library's [database/sql](https://pkg.go.dev/database/sql) interface.
 
@@ -194,8 +194,8 @@ import (
 	"encoding/json"
 	"net/http"
 
-	spinhttp "github.com/fermyon/spin/sdk/go/v2/http"
-	"github.com/fermyon/spin/sdk/go/v2/sqlite"
+	spinhttp "github.com/spinframework/spin/sdk/go/v2/http"
+	"github.com/spinframework/spin/sdk/go/v2/sqlite"
 )
 
 type Todo struct {

--- a/content/spin/v3/variables.md
+++ b/content/spin/v3/variables.md
@@ -10,7 +10,7 @@ url = "https://github.com/fermyon/developer/blob/main/content/spin/v3/variables.
 - [Using Variables From Applications](#using-variables-from-applications)
 - [Troubleshooting](#troubleshooting)
 
-Spin supports dynamic application variables. Instead of being static, their values can be updated without modifying the application, creating a simpler experience for rotating secrets, updating API endpoints, and more. 
+Spin supports dynamic application variables. Instead of being static, their values can be updated without modifying the application, creating a simpler experience for rotating secrets, updating API endpoints, and more.
 
 These variables are defined in a Spin application manifest (in the `[variables]` section), and their values can be set or overridden at runtime by an [application variables provider](./dynamic-configuration.md#application-variables-runtime-configuration). When running Spin locally, the variables provider can be [Hashicorp Vault](./dynamic-configuration.md#vault-application-variable-provider) for secrets, [Azure Key Vault](https://azure.microsoft.com/en-us/products/key-vault), or host environment variables.
 
@@ -93,7 +93,7 @@ The Spin SDK surfaces the Spin configuration interface to your language. The [in
 |------------|--------------------|---------------------|----------|
 | `get`      | Variable name      | Variable value      | Gets the value of the variable from the configured provider |
 
-To illustrate the variables API, each of the following examples makes a request to some API with a bearer token. The API URI, version, and token are all passed as application variables. The application manifest associated with the examples would look similar to the one described [in the previous section](#adding-variables-to-your-applications). 
+To illustrate the variables API, each of the following examples makes a request to some API with a bearer token. The API URI, version, and token are all passed as application variables. The application manifest associated with the examples would look similar to the one described [in the previous section](#adding-variables-to-your-applications).
 
 The exact details of calling the config SDK from a Spin application depends on the language:
 
@@ -201,9 +201,9 @@ class IncomingHandler(IncomingHandler):
 
 {{ startTab "TinyGo"}}
 
-> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2@v2.0.0/variables)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/v2@v2.0.0/variables)
 
-The function is available in the `github.com/spinframework/spin/sdk/go/v2/variables` package and is named `Get`. See [Go package](https://pkg.go.dev/github.com/fermyon/spin/sdk/go/v2/variables) for reference documentation.
+The function is available in the `github.com/spinframework/spin/sdk/go/v2/variables` package and is named `Get`. See [Go package](https://pkg.go.dev/github.com/spinframework/spin/sdk/go/v2/variables) for reference documentation.
 
 ```go
 import (
@@ -211,8 +211,8 @@ import (
 	"fmt"
 	"net/http"
 
-	spinhttp "github.com/fermyon/spin/sdk/go/v2/http"
-	"github.com/fermyon/spin/sdk/go/v2/variables"
+	spinhttp "github.com/spinframework/spin/sdk/go/v2/http"
+	"github.com/spinframework/spin/sdk/go/v2/variables"
 )
 
 func init() {

--- a/content/spin/v3/writing-apps.md
+++ b/content/spin/v3/writing-apps.md
@@ -132,7 +132,7 @@ For components that are published on the Web, provide a `url` field containing t
 
 ```toml
 [component.asset-server]
-source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.0.1/spin_static_fs.wasm", digest = "sha256:650376c33a0756b1a52cad7ca670f1126391b79050df0321407da9c741d32375" }
+source = { url = "https://github.com/spinframework/spin-fileserver/releases/download/v0.0.1/spin_static_fs.wasm", digest = "sha256:650376c33a0756b1a52cad7ca670f1126391b79050df0321407da9c741d32375" }
 ```
 
 Multiple components can have the same source.  An example is a document archive, where one component might serve user interface assets (CSS, images, etc.) on one route, while another serves the documents themselves on another route - both using the same file server module, but with different settings.
@@ -391,7 +391,7 @@ route = "/static/..."
 component = "fileserver"
 
 [component.fileserver]
-source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.0.1/spin_static_fs.wasm", digest = "sha256:650376c33a0756b1a52cad7ca670f1126391b79050df0321407da9c741d32375" }
+source = { url = "https://github.com/spinframework/spin-fileserver/releases/download/v0.0.1/spin_static_fs.wasm", digest = "sha256:650376c33a0756b1a52cad7ca670f1126391b79050df0321407da9c741d32375" }
 files = [ { source = "static/", destination = "/" } ]
 ```
 

--- a/content/wasm-functions/old-data-redis.md
+++ b/content/wasm-functions/old-data-redis.md
@@ -32,7 +32,7 @@ The Spin CLI facilitates the creation of new Spin applications through the use o
 <!-- @selectiveCpy -->
 
 ```bash
-$ spin templates install --git https://github.com/fermyon/spin --update
+$ spin templates install --git https://github.com/spinframework/spin --update
 ```
 
 The output from the command above will be similar to the following:
@@ -79,12 +79,12 @@ HTTP path: /...
 
 > You can change these values later, in the project's `spin.toml` file.
 
-## Redis 
+## Redis
 
-To create your free database go to [app.redislabs.com](https://app.redislabs.com/). For this tutorial, we are signing up using GitHub authentication. 
+To create your free database go to [app.redislabs.com](https://app.redislabs.com/). For this tutorial, we are signing up using GitHub authentication.
 
-> Note: Programmatic access to the Redis cloud console (Redis Rest API) requires a Redislabs paid plan, so we will just be using the free tier for this tutorial. 
- 
+> Note: Programmatic access to the Redis cloud console (Redis Rest API) requires a Redislabs paid plan, so we will just be using the free tier for this tutorial.
+
 Once you have logged in to Redislabs click on the `Data Access Control` and `Databases` menus (in the left sidebar) to create roles/users and a new Redis database. Be sure to acknowledge the usernames, passwords and database URLs (provided during setup) as we will be using these to configure our Spin application. Please see the [Redis docs](https://developer.redis.com/howtos/quick-start/?s=redis%20cloud) for additional information.
 
 ## Configuration
@@ -111,7 +111,7 @@ allowed_outbound_hosts = ["redis://redis-1234.redislabs.com:15730"]
 
 In this tutorial we will create the code to store and retrieve data from a Redislabs database.
 
-## Rust 
+## Rust
 
 The following is the content which is required in the `src/lib.rs` file. Feel free to cut and paste the following, for convenience:
 
@@ -192,11 +192,11 @@ The above deploy command will produce similar output to the following:
 <!-- @nocpy -->
 
 ```text
-Waiting for application to be ready... 
+Waiting for application to be ready...
 Application deployed to https://redisrustapplication-8270f183.aka.fermyon.tech/
 
-View application:   
-https://redisrustapplication-8270f183.aka.fermyon.tech/  
+View application:
+https://redisrustapplication-8270f183.aka.fermyon.tech/
 ```
 
 Visiting the URL, which is provided by the spin deploy command's output will show the `Eureka Fermyon Wasm Functions!` value for the `spin-example` key which is stored in Redis.

--- a/content/wasm-functions/old-develop.md
+++ b/content/wasm-functions/old-develop.md
@@ -2,7 +2,7 @@ title = "Develop a Spin application"
 template = "functions_main"
 date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
-[extra] 
+[extra]
 url = "https://github.com/fermyon/developer/blob/main/content/cloud/develop.md"
 
 ---
@@ -65,7 +65,7 @@ $ sudo mv ./spin /usr/local/bin/spin
 
 {{ startTab "Windows"}}
 
-Download <a href="https://github.com/fermyon/spin/releases/latest" class="spin-install" id="spin-install-windows">the Windows binary release of Spin</a> from GitHub.
+Download <a href="https://github.com/spinframework/spin/releases/latest" class="spin-install" id="spin-install-windows">the Windows binary release of Spin</a> from GitHub.
 
 Unzip the binary release and place the `spin.exe` in your system path.
 
@@ -86,7 +86,7 @@ The quickest and most convenient way to start a new application is to use a Spin
 <!-- @selectiveCpy -->
 
 ```bash
-$ spin templates install --git https://github.com/fermyon/spin --update
+$ spin templates install --git https://github.com/spinframework/spin --update
 Copying remote template source
 Installing template redis-rust...
 Installing template http-rust...
@@ -110,7 +110,7 @@ Note: The Rust templates are in a repo that contains several other languages; th
 <!-- @selectiveCpy -->
 
 ```bash
-$ spin templates install --git https://github.com/fermyon/spin-js-sdk --update
+$ spin templates install --git https://github.com/spinframework/spin-js-sdk --update
 Copying remote template source
 Installing template http-js...
 Installing template http-ts...
@@ -137,7 +137,7 @@ If you do not have Python 3.10 or later, you can install it by following the ins
 <!-- @selectiveCpy -->
 
 ```bash
-$ spin templates install --git https://github.com/fermyon/spin-python-sdk --update
+$ spin templates install --git https://github.com/spinframework/spin-python-sdk --update
 Copying remote template source
 Installing template http-py...
 +---------------------------------------------+
@@ -154,7 +154,7 @@ Installing template http-py...
 <!-- @selectiveCpy -->
 
 ```bash
-$ spin templates install --git https://github.com/fermyon/spin --update
+$ spin templates install --git https://github.com/spinframework/spin --update
 Copying remote template source
 Installing template redis-go...
 Installing template http-go...
@@ -174,7 +174,7 @@ Note: The Go templates are in a repo that contains several other languages; they
 
 {{ blockEnd }}
 
-{{ details "Additional info" "If you already have templates installed, you can update them by running `spin templates install --git https://github.com/fermyon/spin --update`." }}
+{{ details "Additional info" "If you already have templates installed, you can update them by running `spin templates install --git https://github.com/spinframework/spin --update`." }}
 
 ### Install the Tools
 
@@ -213,7 +213,7 @@ $ spin plugins install js2wasm --yes
 
 {{ startTab "Python" }}
 
-> Historic: You may have seen a `py2wasm` plugin in your travels. Please note, `py2wasm` has since been replaced by `componentize-py`. 
+> Historic: You may have seen a `py2wasm` plugin in your travels. Please note, `py2wasm` has since been replaced by `componentize-py`.
 
 The process of getting your system ready to write Wasm-powered Python applications, using `componentize-py` is as follows:
 
@@ -221,7 +221,7 @@ The process of getting your system ready to write Wasm-powered Python applicatio
 
 ```bash
 # As shown above, we install the Python SDK (which provides us with Spin's http-py template)
-$ spin templates install --git https://github.com/fermyon/spin-python-sdk --update
+$ spin templates install --git https://github.com/spinframework/spin-python-sdk --update
 ```
 
 Once we have the Spin template(s) from the `spin-python-sdk` repository we can scaffold out a new app. For this example, we will be using the `http-py` template. The scaffolded app, that the `http-py` template creates, has a `requirements.txt` file that facilitates the installation of `spin-sdk` and `componentize-py`. While you could manually install these using Pip, the `requirements.txt` file has the appropriate version numbers set making the process quicker and also more robust. Let's create a new Spin app and install the contents of `requirements.txt`:
@@ -281,7 +281,7 @@ The `requirements.txt`, by default, contains the references to the `spin-sdk` an
 
 ```bash
 # Now we can install Componentize-Py and the Spin SDK via the requirements file
-$ pip3 install -r requirements.txt 
+$ pip3 install -r requirements.txt
 ```
 
 From here the app is ready to build and run:
@@ -507,7 +507,7 @@ Next, let’s build the app:
 $ spin build
 Building component hello-rust with `cargo build --target wasm32-wasi --release`
     Updating crates.io index
-    Updating git repository `https://github.com/fermyon/spin`
+    Updating git repository `https://github.com/spinframework/spin`
    # ...
     Finished release [optimized] target(s) in 27.81s
 Finished building all Spin components
@@ -588,7 +588,7 @@ If the build fails, check:
 <!-- @selectiveCpy -->
 
 ```bash
-$ spin build 
+$ spin build
 Building component hello-go with `tinygo build -target=wasi -gc=leaking -no-debug -o main.wasm main.go`
 Finished building all Spin components
 ```

--- a/content/wasm-functions/quickstart.md
+++ b/content/wasm-functions/quickstart.md
@@ -71,7 +71,7 @@ $ sudo mv ./spin /usr/local/bin/spin
 
 {{ startTab "Windows"}}
 
-Download <a href="https://github.com/fermyon/spin/releases/latest" class="spin-install" id="spin-install-windows">the Windows binary release of Spin</a> from GitHub.
+Download <a href="https://github.com/spinframework/spin/releases/latest" class="spin-install" id="spin-install-windows">the Windows binary release of Spin</a> from GitHub.
 
 Unzip the binary release and place the `spin.exe` in your system path.
 
@@ -323,7 +323,7 @@ import (
 	"fmt"
 	"net/http"
 
-	spinhttp "github.com/fermyon/spin/sdk/go/v2/http"
+	spinhttp "github.com/spinframework/spin/sdk/go/v2/http"
 )
 
 func init() {
@@ -429,7 +429,7 @@ Finished building all Spin components
 ```bash
 $ spin build
 Executing the build command for component hello-spin: tinygo build -target=wasi -gc=leaking -no-debug -o main.wasm main.go
-go: downloading github.com/fermyon/spin/sdk/go v0.10.0
+go: downloading github.com/spinframework/spin/sdk/go v0.10.0
 Finished building all Spin components
 ```
 
@@ -494,7 +494,7 @@ date: Tue, 14 Jan 2025 16:10:36 GMT
 Hello, Fermyon
 ```
 
-You can terminate `spin up` at anytime, by pressing `CTRL+C`. 
+You can terminate `spin up` at anytime, by pressing `CTRL+C`.
 
 ## Log in to the Fermyon Wasm Functions
 
@@ -509,13 +509,13 @@ $ spin aka login
 <!-- @nocpy -->
 
 ```console
-Go to https://login.neutrino.fermyon.computer/realms/neutrino/device?user_code=BB-AA 
+Go to https://login.neutrino.fermyon.computer/realms/neutrino/device?user_code=BB-AA
 and follow the prompts.
 
 Don't worry, we'll wait here for you. You got this.
 ```
 
-Click the link displayed as part of the output from the `spin aka login` command. Authenticate using your individual GitHub Account and authorize the `spin` CLI for interacting with your _Fermyon Wasm Functions_ account. 
+Click the link displayed as part of the output from the `spin aka login` command. Authenticate using your individual GitHub Account and authorize the `spin` CLI for interacting with your _Fermyon Wasm Functions_ account.
 
 ## Deploy the Application
 

--- a/content/wasm-languages/go-lang.md
+++ b/content/wasm-languages/go-lang.md
@@ -35,7 +35,7 @@ Things we like:
 
 We're neutral about:
 
-- The resulting binary sizes start at around 300k, but can rapidly climb 
+- The resulting binary sizes start at around 300k, but can rapidly climb
 
 Things we're not big fans of:
 
@@ -71,7 +71,7 @@ import (
 	"fmt"
 	"net/http"
 
-	spinhttp "github.com/fermyon/spin-go-sdk/http"
+	spinhttp "github.com/spinframework/spin-go-sdk/http"
 )
 
 func main() {

--- a/content/wasm-languages/rust.md
+++ b/content/wasm-languages/rust.md
@@ -34,7 +34,7 @@ $ cargo build --target wasm32-wasi --release
 ```
 
 While `--release` is not required, doing so will drastically reduce the size of the output `.wasm` module.
-WebAssembly binaries will be written to your project's `target/wasm32-wasi/release` directory. 
+WebAssembly binaries will be written to your project's `target/wasm32-wasi/release` directory.
 
 ## Pros and Cons
 

--- a/spin.toml
+++ b/spin.toml
@@ -288,7 +288,7 @@ source = "modules/redirect.wasm"
 environment = { DESTINATION = "https://spinframework.dev/kubernetes", STATUSCODE = "301" }
 
 [component.hub-fileserver-static]
-source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.0.2/spin_static_fs.wasm", digest = "sha256:65456bf4e84cf81b62075e761b2b0afaffaef2d0aeda521b245150f76b96421b" }
+source = { url = "https://github.com/spinframework/spin-fileserver/releases/download/v0.0.2/spin_static_fs.wasm", digest = "sha256:65456bf4e84cf81b62075e761b2b0afaffaef2d0aeda521b245150f76b96421b" }
 environment = { FALLBACK_PATH = "./index.html" }
 files = [{ source = "spin-up-hub/dist/", destination = "/" }]
 


### PR DESCRIPTION
All of the repositories changed in this commit have been migrated to the spinframework org.

This coincides with other changes like #1503.