### PR TITLE
[wasm-languages] update the recommended languages

### DIFF
--- a/content/wasm-languages/webassembly-language-support.md
+++ b/content/wasm-languages/webassembly-language-support.md
@@ -93,7 +93,7 @@ For each environment, we use the following icons to indicate a level of support:
 
 Spin, Fermyon Platform and Fermyon Cloud require [WASI](https://wasi.dev) support. Any language that has a ✅ for WASI should be supported on the Fermyon Platform. The *Spin SDK* indicates that there is additional libraries available for Spin.
 
-We are often asked which languages are best supported for production-grade WebAssembly. We suggest [C][C]/[C++][CPLUSPLUS], [Rust][Rust], and [AssemblyScript][AssemblyScript].
+We are often asked which languages are best supported for production-grade WebAssembly. We suggest [Rust][Rust], [JavaScript/TypeScript][JavaScript], [Python][Python] and [Go][Go].
 
 ## Updates and Additions
 


### PR DESCRIPTION
Modify the language rec here:

> We are often asked which languages are best supported for production-grade WebAssembly. We suggest C/C++, Rust, and AssemblyScript.

_Changed to Rust, JavaScript/TypeScript, Python and Go._