### PR TITLE
docs(functions): add http trigger doc, request header info

### DIFF
--- a/content/wasm-functions/http-trigger-reference.md
+++ b/content/wasm-functions/http-trigger-reference.md
@@ -1,0 +1,30 @@
+title = "HTTP Trigger Reference"
+template = "functions_main"
+date = "2025-07-11T00:00:00Z"
+enable_shortcodes = true
+
+---
+- [HTTP Requests](#http-requests)
+  - [Request Headers](#request-headers)
+
+Fermyon Wasm Functions currently supports the [`http` trigger type](https://spinframework.dev/v3/http-trigger) for Spin applications.
+
+# HTTP Requests
+
+Here we'll cover details around the inbound HTTP request received by an application (or a specific component) when running on Fermyon Wasm Functions.
+
+## Request Headers
+
+In addition to any headers passed by the client making the request to an application, there are several Spin-related headers included in the request passed to your component.
+
+> Each of the headers below link to upstream Spin documentation, where more details and examples can be seen.
+
+- [`spin-full-url`](https://spinframework.dev/v3/http-trigger#additional-request-information-spin-full-url): The full URL of the request. This includes full host and scheme information.
+- [`spin-path-info`](https://spinframework.dev/v3/http-trigger#additional-request-information-spin-path-info): The request path relative to the component route
+- [`spin-path-match-n`](https://spinframework.dev/v3/http-trigger#additional-request-information-spin-path-match-n): (Conditionally included): Where n is the pattern for a single-segment wildcard value (e.g. spin-path-match-userid will access the value in a URL containing a route that includes :userid)
+- [`spin-matched-route`](https://spinframework.dev/v3/http-trigger#additional-request-information-spin-matched-route): The part of the trigger route that was matched by the route (including the wildcard indicator if present)
+- [`spin-raw-component-route`](https://spinframework.dev/v3/http-trigger#additional-request-information-spin-raw-component-route): The component route pattern matched, including the wildcard indicator if present
+
+Other headers of interest that can be utilized by the triggered component are seen below:
+
+- `true-client-ip`: The IP of the client sending the request (e.g. "151.49.93.60")

--- a/templates/functions_sidebar.hbs
+++ b/templates/functions_sidebar.hbs
@@ -53,6 +53,9 @@
         <a {{#if (active_content request.spin-path-info "/wasm-functions/aka-command-reference" )}} class="active"
             {{/if}} href="{{site.info.base_url}}/wasm-functions/aka-command-reference">The <code>aka</code> Command
             Reference</a>
+        <a {{#if (active_content request.spin-path-info "/wasm-functions/http-trigger-reference" )}} class="active"
+            {{/if}} href="{{site.info.base_url}}/wasm-functions/http-trigger-reference">HTTP Trigger
+            Reference</a>
         <a {{#if (active_content request.spin-path-info "/wasm-functions/changelog" )}} class="active" {{/if}}
             href="{{site.info.base_url}}/wasm-functions/changelog">Changelog</a>
         <a {{#if (active_project request.spin-full-url "/wasm-languages/webassembly-language-support" )}} class="active"


### PR DESCRIPTION
- Adds info around request headers that guest applications on FwF can expect, but starts a new, more generic doc to hold this information; 'HTTP Trigger Reference' seemed appropriate but feedback welcome.