### PR TITLE
fix(github-actions.md): fix 'broken link'

### DIFF
--- a/content/wasm-functions/github-actions.md
+++ b/content/wasm-functions/github-actions.md
@@ -22,7 +22,7 @@ window, such as in the middle of a Continuous Integration (CI) or Continuous Dep
 workflow.
 
 To generate a Personal Access Token for use in a GitHub Actions workflow, [install the Spin
-CLI](/deploy#install-the-spin-cli) and follow these steps:
+CLI](/wasm-functions/deploy#install-the-spin-cli) and follow these steps:
 
 <!-- @selectiveCpy -->
 


### PR DESCRIPTION
- For some reason, the relative `/deploy` link was considered broken by the link checker.  Perhaps because there are multiple `deploy.md` files?  In any case, updating to point to the version under `wasm-functions` appears to fix it...