### PR TITLE
feat(*): indicate Spin Hub links to an external site

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -6,7 +6,7 @@ enable_shortcodes = true
 
 ### Start Building
 
-<p class="subtitle mb-5">The <a href="/hub">Spin Hub</a> is an open library of templates, plugins and resources to help you create powerful apps, fast.</p>
+<p class="subtitle mb-5">The <a href="https://spinframework.dev/hub" target="_blank">Spin Hub</a> is an open library of templates, plugins and resources to help you create powerful apps, fast.</p>
 
 {{suh_cards}}
 {{card_element "sample" "Next.js React App" "An app template for running Next.js as a Wasm app with Spin." "https://spinframework.dev/hub/preview/template_nextjs" "JS,Next,http" true }}

--- a/templates/content_navbar.hbs
+++ b/templates/content_navbar.hbs
@@ -152,8 +152,8 @@
             <div class="overlay"></div>
             
             {{!-- quicklinks can be added to the topbar here --}}
-            <a class="navbar-item plausible-event-name=docs-nav-hub" href="/hub" title="Sample apps, plugins and templates in Spin Hub">
-                Spin Hub
+            <a class="navbar-item plausible-event-name=docs-nav-hub" href="https://spinframework.dev/hub" title="Sample apps, plugins and templates in Spin Hub" target="_blank">
+                Spin Hub <img src="/static/image/arrowexternal.svg" alt="external link" class="external"/>
             </a>
 
             {{#if (active_project request.spin-path-info "/cloud/" )}}


### PR DESCRIPTION
Closes https://github.com/fermyon/developer/issues/1493

Wanted to indicate that the Spin Hub now links to an [external site](https://spinframework.dev/hub).  Thus,

- Added the arrow img to appropriate links (~~is it overkill or distracting having it on the link in the text under 'Start Building'?~~ _edit: the external arrow didn't look quite right there so I removed it_) 
- Have link open new tab

I didn't update the cards to add the arrow, but we could.  The `card_element` shortcode is also used in the wasm-functions section which link to external fwf-examples, so it would apply there, too.