### PR TITLE
docs(wasm-functions): show more of each changelog post

### DIFF
--- a/content/wasm-functions/changelog/changelog-aka-plugin-v04.md
+++ b/content/wasm-functions/changelog/changelog-aka-plugin-v04.md
@@ -10,8 +10,6 @@ type= "changelog_post"
 
 We're excited to announce the release of `spin aka` v0.4.0, the latest version of Fermyon Wasm Functions' plugin!
 
-<!-- break -->
-
 This release focuses on making your development experience smoother, especially when collaborating with teammates and deploying your applications. Here’s what’s new:
 
 ### ✨ What's New in `spin aka` v0.4.0
@@ -26,5 +24,7 @@ When things go wrong (or if you just need a reminder), you’ll now see clearer,
 
 * Improved Deployment Flow
 Deploying your app is now more interactive, guiding you through the process for a smoother experience.
+
+<!-- break -->
 
 Existing users can get started by upgrading your [`spin aka` plugin](https://spinframework.dev/v3/managing-plugins#upgrading-plugins) or [request access](https://fibsu0jcu2g.typeform.com/fwf-preview) to Fermyon Wasm Functions today.

--- a/content/wasm-functions/changelog/changelog-aka-plugin-v041.md
+++ b/content/wasm-functions/changelog/changelog-aka-plugin-v041.md
@@ -10,10 +10,10 @@ type= "changelog_post"
 
 We're excited to announce the release of `spin aka` v0.4.1, the latest version of Fermyon Wasm Functions' plugin!
 
-<!-- break -->
-
 ### ✨ What's New in `spin aka` v0.4.1
 
 - Introduce a `--usage-since` flag to the `spin aka app status` command to control the time range over which app usage will be shown.
+
+<!-- break -->
 
 Existing users can get started by upgrading your [`spin aka` plugin](https://spinframework.dev/v3/managing-plugins#upgrading-plugins) or [request access](https://fibsu0jcu2g.typeform.com/fwf-preview) to Fermyon Wasm Functions today.

--- a/content/wasm-functions/changelog/changelog-aka-plugin-v042.md
+++ b/content/wasm-functions/changelog/changelog-aka-plugin-v042.md
@@ -10,8 +10,6 @@ type= "changelog_post"
 
 We're excited to announce the release of `spin aka` v0.4.2, the latest version of Fermyon Wasm Functions' plugin!
 
-<!-- break -->
-
 ### ✨ What's New in `spin aka` v0.4.2
 
 - A new `spin aka app history` command has been added that enables you to view things like the deployments you've made to your app.
@@ -30,5 +28,7 @@ We're excited to announce the release of `spin aka` v0.4.2, the latest version o
   ```
 
 - `spin aka login` no longer fails if you are trying to log in with a user that is associated with multiple accounts.
+
+<!-- break -->
 
 Existing users can get started by upgrading your [`spin aka` plugin](https://spinframework.dev/v3/managing-plugins#upgrading-plugins) or [request access](https://fibsu0jcu2g.typeform.com/fwf-preview) to Fermyon Wasm Functions today.


### PR DESCRIPTION
Move the breaks so that more (basically all) of each changelog post is shown.  Otherwise, the view looks fairly undifferentiated.

Currently the page looks like:

<img width="1300" height="585" alt="Screenshot 2025-08-18 at 5 34 09 PM" src="https://github.com/user-attachments/assets/9bdca436-6c86-4095-9f66-7ca5ff32df13" />

With this change, it would look like:

<img width="1051" height="931" alt="Screenshot 2025-08-18 at 5 33 50 PM" src="https://github.com/user-attachments/assets/a17c645c-69ca-481c-b361-8fa10fe67f9b" />
