### PR TITLE
fix(wasm-lang/r-lang): update in-browser R console link

### DIFF
--- a/content/wasm-languages/r-lang.md
+++ b/content/wasm-languages/r-lang.md
@@ -20,5 +20,5 @@ Here are some great resources:
 
 - [webR](https://github.com/georgestagg/webR), an in-browser implementation of R
 - An excellent [blog post](https://blog.ouseful.info/2022/02/17/running-r-and-debian-linux-in-the-browser-via-wasm/) on webR.
-- An [in-browser R console](https://www.mas.ncl.ac.uk/~ngs54/webR/) built using webR
+- An [in-browser R console](https://webr.sh/) built using webR
 - A [Fortran-to-Wasm](https://github.com/StarGate01/Full-Stack-Fortran) compiler toolchain.


### PR DESCRIPTION
A recent (unrelated) PR [failed on account of this broken link](https://github.com/fermyon/developer/actions/runs/17045204813/job/48319078074?pr=1569)

I think I've updated it with an appropriate alternative.

